### PR TITLE
feat: add CommentsEmbed to docs

### DIFF
--- a/docs/footer.tsx
+++ b/docs/footer.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { CommentsEmbed } from "@ecp.eth/sdk/react";
+
+/**
+ * A custom footer component that renders a comments embed.
+ * @returns
+ */
+export default function Footer() {
+  // there is no way to retrieve pathname in Vita SSR, so we don't render the comments embed
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return (
+    <CommentsEmbed
+      uri={`${window.location.origin}/${window.location.pathname}`}
+      iframeProps={{
+        style: {
+          height: "300px",
+          width: "100%",
+        },
+      }}
+      containerProps={{
+        style: {
+          padding: "12px 8px",
+          backgroundColor: "black",
+          borderRadius: "var(--vocs-borderRadius_8)",
+          overflow: "hidden",
+        },
+      }}
+    />
+  );
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "ref:gen:protocol": "solidity-docgen -o pages/protocol-reference -i ../packages/protocol/src/ --solc-module solc -t templates/solidity-codegen"
   },
   "dependencies": {
+    "@ecp.eth/sdk": "workspace:*",
     "@theguild/remark-mermaid": "^0.2.0",
     "acorn": "^8.14.0",
     "hono": "^4.6.20",

--- a/packages/sdk/src/react.tsx
+++ b/packages/sdk/src/react.tsx
@@ -9,10 +9,12 @@ import { Hex, SignTypedDataParameters } from "viem";
 import { useSignTypedData } from "wagmi";
 import { COMMENTS_EMBED_DEFAULT_URL } from "./constants.js";
 import { EmbedConfigSchema, type EmbedConfigSchemaType } from "./schemas.js";
-import { compressToURI } from "lz-ts";
+import lz from "lz-ts";
 
 // also export the type for generating docs correctly
 export type { EmbedConfigSchemaType } from "./schemas.js";
+
+const { compressToURI } = lz;
 
 /**
  * A hook for repeat gasless transaction pattern

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
 
   docs:
     dependencies:
+      '@ecp.eth/sdk':
+        specifier: workspace:*
+        version: link:../packages/sdk
       '@theguild/remark-mermaid':
         specifier: ^0.2.0
         version: 0.2.0(react@18.3.1)


### PR DESCRIPTION
Added CommentsEmbed to docs, but because there is limited ability provided for customisation, we will restyle it later once those requested features implemented

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/f30786b0-dc4e-4e8b-85d2-6028304504e2" />
