### PR TITLE
fix: node ver is not specified

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -2,6 +2,9 @@
   "name": "@ecp.eth/indexer",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22 <23"
+  },
   "scripts": {
     "dev": "ponder dev",
     "start": "ponder start",


### PR DESCRIPTION
app crashed due to one of the new dep added requires higher version of node engine
so this pr add `engine` field to package.json to force it

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/509974a5-0cfb-486b-a90d-84f6f69016f9" />
