### PR TITLE
fix: use border for focus style and add transition

### DIFF
--- a/apps/embed/src/app/globals.css
+++ b/apps/embed/src/app/globals.css
@@ -36,6 +36,7 @@ body {
       hsl(0 0% 98%)
     );
     --border: var(--light-theme-border, hsl(0 0% 89.8%));
+    --border-focus: var(--light-theme-border-focus, hsl(0 0% 3.9%));
     --input: var(--light-theme-border, hsl(0 0% 89.8%));
     --ring: var(--light-theme-ring, hsl(0 0% 3.9%));
     --radius: var(--theme-radius, 0.5rem);
@@ -65,6 +66,7 @@ body {
         hsl(0 0% 98%)
       );
       --border: var(--dark-theme-border, hsl(0 0% 14.9%));
+      --border-focus: var(--dark-theme-border-focus, hsl(0 0% 83.1%));
       --input: var(--dark-theme-border, hsl(0 0% 14.9%));
       --ring: var(--dark-theme-ring, hsl(0 0% 83.1%));
     }

--- a/apps/embed/src/components/comments/CommentForm.tsx
+++ b/apps/embed/src/components/comments/CommentForm.tsx
@@ -114,7 +114,7 @@ export function CommentForm({
           submitCommentMutation.error &&
             submitCommentMutation.error instanceof
               SubmitCommentMutationValidationError &&
-            "border-destructive focus-visible:ring-destructive"
+            "border-destructive focus-visible:border-destructive"
         )}
         disabled={isSubmitting}
         maxLength={MAX_COMMENT_LENGTH}

--- a/apps/embed/src/components/ui/textarea.tsx
+++ b/apps/embed/src/components/ui/textarea.tsx
@@ -9,7 +9,9 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        // border related classes
+        "transition-[border-color] border border-input focus-visible:outline-none focus-visible:border-border-focus",
         className
       )}
       ref={ref}

--- a/apps/embed/src/lib/theming.ts
+++ b/apps/embed/src/lib/theming.ts
@@ -1,42 +1,6 @@
 import type { EmbedConfigSchemaType } from "@ecp.eth/sdk/schemas";
 import { CSSProperties } from "react";
 
-export const defaultTheme: EmbedConfigSchemaType = {
-  theme: {
-    colors: {
-      light: {
-        "destructive-foreground": "hsl(0 0% 98%)",
-        "muted-foreground": "hsl(0 0% 45.1%)",
-        "primary-foreground": "hsl(0 0% 98%)",
-        "secondary-foreground": "hsl(0 0% 9%)",
-        background: "white",
-        border: "hsl(0 0% 89.8%)",
-        destructive: "hsl(0 84.2% 60.2%)",
-        foreground: "hsl(0 0% 3.9%)",
-        primary: "hsl(0 0% 9%)",
-        ring: "hsl(0 0% 3.9%)",
-        secondary: "hsl(0 0% 96.1%)",
-      },
-      dark: {
-        "destructive-foreground": "hsl(0 0% 98%)",
-        "muted-foreground": "hsl(0 0% 63.9%)",
-        "primary-foreground": "hsl(0 0% 9%)",
-        "secondary-foreground": "hsl(0 0% 98%)",
-        background: "hsl(0 0% 3.9%)",
-        border: "hsl(0 0% 14.9%)",
-        destructive: "hsl(0 84.2% 60.2%)",
-        foreground: "hsl(0 0% 98%)",
-        primary: "hsl(0 0% 98%)",
-        ring: "hsl(0 0% 83.1%)",
-        secondary: "hsl(0 0% 14.9%)",
-      },
-    },
-    other: {
-      radius: "0.5rem",
-    },
-  },
-};
-
 export function createThemeCSSVariables(
   config: EmbedConfigSchemaType | undefined
 ): CSSProperties {

--- a/apps/embed/tailwind.config.ts
+++ b/apps/embed/tailwind.config.ts
@@ -77,7 +77,10 @@ export default {
           DEFAULT: "var(--destructive)",
           foreground: "var(--destructive-foreground)",
         },
-        border: "var(--border)",
+        border: {
+          DEFAULT: "var(--border)",
+          focus: "var(--border-focus)",
+        },
         input: "var(--input)",
         ring: "var(--ring)",
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vocs dev -p 3003",
+    "dev": "vocs dev -p 3004",
     "build": "vocs build",
     "preview": "vocs preview",
     "ref:gen:demo:blog": "cp ../apps/embed-demo-blog/README.md pages/demos/blog/index.mdx",

--- a/packages/sdk/src/schemas.ts
+++ b/packages/sdk/src/schemas.ts
@@ -92,7 +92,10 @@ export const EmbedConfigThemePaletteSchema = z.object({
   ring: CSSColorSchema.optional().describe(
     "Color used by interactive elements like button when they are focused"
   ),
-  border: CSSColorSchema.optional().describe("Border color - used by sonner"),
+  border: CSSColorSchema.optional().describe("Border color"),
+  "border-focus": CSSColorSchema.optional().describe(
+    "Border color when focused"
+  ),
 });
 
 export type EmbedConfigThemePaletteSchemaType = z.infer<


### PR DESCRIPTION
fix https://linear.app/modprotocol/issue/FRA-998/border-of-textarea-in-commentsembed-cropped-off

the border was cut off a bit due to using shadow for focus style.
this PR change it to use border for focus style, this also allows us to add color transition between normal and focus style.

