### PR TITLE
fix: set min height only when modal shows up

### DIFF
--- a/apps/embed/src/app/globals.css
+++ b/apps/embed/src/app/globals.css
@@ -110,5 +110,11 @@ body {
     margin: 0;
     padding: 0;
     background: transparent;
+    /** 
+     * because the container on parent window always sync with the body content height,
+     * we can simply set overflow: hidden to prevent scrollbar showing up and mess up the 
+     * scrollHeight measurement.
+     */
+    overflow: hidden;
   }
 }

--- a/apps/embed/src/app/page.tsx
+++ b/apps/embed/src/app/page.tsx
@@ -65,7 +65,7 @@ export default async function EmbedPage({ searchParams }: EmbedPageProps) {
 
     return (
       <ApplyTheme config={config}>
-        <main className="min-h-screen p-0 bg-background text-foreground font-default px-root-padding-horizontal py-root-padding-vertical">
+        <main className="p-0 bg-background text-foreground font-default px-root-padding-horizontal py-root-padding-vertical">
           <div className="max-w-4xl mx-auto">
             <Providers>
               <EmbedConfigProvider value={{ targetUri }}>

--- a/apps/embed/src/components/WatchDocumentResize.tsx
+++ b/apps/embed/src/components/WatchDocumentResize.tsx
@@ -9,7 +9,10 @@ import { useEffect } from "react";
 export function WatchDocumentResize() {
   useEffect(() => {
     const notifyParent = () => {
-      const height = document.documentElement.scrollHeight;
+      // use body.scrollHeight instead of documentElement.scrollHeight
+      // because body.scrollHeight gives us the real height of __content__
+      // the container on parent window should always sync with the content height
+      const height = document.body.scrollHeight;
       window.parent.postMessage(
         EmbedResizedEventSchema.parse({
           type: "@ecp.eth/sdk/embed/resize",

--- a/apps/embed/src/components/comments/CommentSection.tsx
+++ b/apps/embed/src/components/comments/CommentSection.tsx
@@ -19,6 +19,7 @@ import { Button } from "../ui/button";
 import { COMMENTS_PER_PAGE } from "@/lib/constants";
 import { fetchComments } from "@ecp.eth/sdk";
 import { CommentPageSchema, type CommentPageSchemaType } from "@/lib/schemas";
+import { useAutoBodyMinHeight } from "@/hooks/useAutoBodyMinHeight";
 
 type CommentSectionProps = {
   initialData?: InfiniteData<
@@ -28,6 +29,7 @@ type CommentSectionProps = {
 };
 
 export function CommentSection({ initialData }: CommentSectionProps) {
+  useAutoBodyMinHeight();
   const { targetUri } = useEmbedConfig();
   const account = useAccount();
   const queryKey = useMemo(() => ["comments", targetUri], [targetUri]);

--- a/apps/embed/src/hooks/useAutoBodyMinHeight.ts
+++ b/apps/embed/src/hooks/useAutoBodyMinHeight.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useChainModal, useConnectModal, useAccountModal } from "@rainbow-me/rainbowkit";
+import { useEffect, useState } from "react";
+
+export function useAutoBodyMinHeight() {
+  const { connectModalOpen } = useConnectModal();
+  const { accountModalOpen } = useAccountModal();
+  const { chainModalOpen } = useChainModal();
+  const [hasMinHeight, setHasMinHeight] = useState(false);
+
+  useEffect(() => {
+    setHasMinHeight(connectModalOpen || accountModalOpen || chainModalOpen)
+  }, [connectModalOpen, accountModalOpen, chainModalOpen]);
+
+  useEffect(() => {
+    if (!hasMinHeight) {
+      return;
+    }
+
+    const body = document.body
+    const currentMinHeight = parseFloat(getComputedStyle(document.body).minHeight)
+
+    if (currentMinHeight >= 570) {
+      return
+    }
+
+    const originalMinHeight = body.style.minHeight
+
+    body.style.minHeight = '570px'
+
+    return () => {
+      body.style.minHeight = originalMinHeight
+    }
+  }, [hasMinHeight])
+}

--- a/packages/sdk/src/react.tsx
+++ b/packages/sdk/src/react.tsx
@@ -258,11 +258,6 @@ function CommentsEmbedInternal({
           border: "none",
           width: "100%",
           ...iframeProps?.style,
-          // because of wallet connect dialog
-          // also it will be updated if the height is higher
-          // also we don't want to allow user to override minHeight
-          // as it will break the layout
-          minHeight: "500px",
           ...dimensions,
         }}
         src={src}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13937,6 +13937,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -14935,7 +14939,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15295,7 +15299,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15316,7 +15320,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17069,7 +17073,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -17525,7 +17529,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -18453,7 +18457,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -19572,7 +19576,7 @@ snapshots:
   vite-node@1.0.2(@types/node@22.13.1)(lightningcss@1.29.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
       vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)
@@ -19606,7 +19610,7 @@ snapshots:
 
   vite-tsconfig-paths@4.3.1(typescript@5.7.3)(vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)):
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.7.3)
     optionalDependencies:


### PR DESCRIPTION
fix https://linear.app/modprotocol/issue/FRA-991/improve-commentsembedss-minheight500

also previously the content height synchronisation goes only one way, when content height __decreases__ the iframe height is not synced, this PR also make it sync.


https://github.com/user-attachments/assets/9c88a46d-3cc3-437d-8d1c-af1271f2ccb6

