### PR TITLE
[BLOCKED] feat: indexer sentry

### DIFF
--- a/apps/indexer/src/index.ts
+++ b/apps/indexer/src/index.ts
@@ -1,3 +1,5 @@
+// must be first import
+import "./sentry";
 import { ponder } from "ponder:registry";
 import schema from "ponder:schema";
 import { getAddress } from "viem";

--- a/apps/indexer/src/sentry.ts
+++ b/apps/indexer/src/sentry.ts
@@ -1,0 +1,27 @@
+// must be the first import
+import * as Sentry from "@sentry/node";
+import "dotenv/config";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+import "./env";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const dsn = process.env.SENTRY_DSN;
+
+Sentry.init({
+  dsn,
+  integrations: [
+    Sentry.captureConsoleIntegration({
+      levels: ["error"],
+    }),
+    Sentry.rewriteFramesIntegration({
+      root: resolve(dirname(fileURLToPath(import.meta.url)), "../"),
+    }),
+    nodeProfilingIntegration(),
+  ],
+  tracesSampleRate: 1.0,
+  profilesSampleRate: 1.0,
+  environment: process.env.NODE_ENV,
+  debug: !dsn,
+  enabled: !!dsn,
+});


### PR DESCRIPTION
This PR reenables sentry in indexer.

This doesn't work since the indexer still fails, probably because of `pnpm`.

I tried `node-linker=hoisted` but that didn't help at all since it removed `node_modules` from `packages/protocol` completely breaking our dev/build system.


This really looks like issue with https://github.com/open-telemetry/opentelemetry-js/issues/4898.