### PR TITLE
feat: clear irrelevant rpc results cache items

### DIFF
--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -11,6 +11,7 @@ PONDER_START_BLOCK_8453="26203482"
 
 # (Optional) Postgres database URL. If not provided, SQLite will be used. 
 DATABASE_URL=
+# DATABASE_URL=postgres://ponder:ponder@localhost:5432/ponder
 
 # (Required) Neynar API key used to resolve farcaster user data by Ethereum address.
 NEYNAR_API_KEY=

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -23,13 +23,16 @@
     "@sentry/profiling-node": "^9.3.0",
     "dataloader": "^2.2.3",
     "hono": "^4.5.0",
+    "kysely": "^0.26.3",
     "lru-cache": "^11.0.2",
     "normalize-url": "^8.0.1",
+    "pg": "^8.11.3",
     "ponder": "^0.9.23",
     "viem": "^2.22.21",
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/node": "^22.13.1"
+    "@types/node": "^22.13.1",
+    "@types/pg": "^8.11.11"
   }
 }

--- a/apps/indexer/src/db.ts
+++ b/apps/indexer/src/db.ts
@@ -1,0 +1,60 @@
+import {
+  type ColumnType,
+  Kysely,
+  PostgresDialect,
+  WithSchemaPlugin,
+} from "kysely";
+import { Pool } from "pg";
+
+// taken from ponder/src/sync-store/encoding.ts
+export type RpcRequestResultsTable = {
+  request: string;
+  /**
+   * This is computed column using md5(request) as hash
+   */
+  request_hash: ColumnType<string, undefined>;
+  chain_id: number;
+  block_number: ColumnType<
+    string | undefined,
+    string | bigint | undefined,
+    string | bigint | undefined
+  >;
+  result: string;
+};
+
+let db:
+  | Kysely<{
+      rpc_request_results: RpcRequestResultsTable;
+    }>
+  | null
+  | undefined = undefined;
+
+export function getDb(): Kysely<{
+  rpc_request_results: RpcRequestResultsTable;
+}> | null {
+  if (db !== undefined) {
+    return db;
+  }
+
+  const connectionString =
+    process.env.PRIVATE_DATABASE_URL || process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    console.log("PGlite is not supported for rpc resuts cache clearing");
+    db = null;
+
+    return db;
+  }
+
+  db = new Kysely({
+    dialect: new PostgresDialect({
+      pool: new Pool({
+        connectionString,
+        max: 5,
+      }),
+    }),
+    plugins: [new WithSchemaPlugin("ponder_sync")],
+  });
+
+  return db;
+}

--- a/apps/indexer/src/lib/ponder-rpc-results-cache.ts
+++ b/apps/indexer/src/lib/ponder-rpc-results-cache.ts
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+import { getDb } from "../db";
+import { toHex } from "viem";
+
+/**
+ * This function removes cached result from rpc response because we aren't interested in the result anymore
+ */
+export async function markCachedGetBlockRpcResponseAsSkipped(
+  blockNumber: bigint,
+  chainId: number
+) {
+  const db = getDb();
+
+  if (!db) {
+    return;
+  }
+
+  await db
+    .updateTable("rpc_request_results")
+    .set({ result: "" })
+    .where("request_hash", "=", createRequestHash(blockNumber))
+    .where("chain_id", "=", chainId)
+    .execute();
+}
+
+/**
+ *
+ * @param blockNumber
+ * @param chainId
+ * @returns
+ */
+export async function getCachedGetBlockRpcResponseSkipStatus(
+  blockNumber: bigint,
+  chainId: number
+): Promise<"skipped" | "not_skipped" | "not_found"> {
+  const db = getDb();
+
+  if (!db) {
+    return "not_found";
+  }
+
+  const row = await db
+    .selectFrom("rpc_request_results")
+    .select("result")
+    .where("chain_id", "=", chainId)
+    .where("request_hash", "=", createRequestHash(blockNumber))
+    .limit(1)
+    .executeTakeFirst();
+
+  if (!row) {
+    return "not_found";
+  }
+
+  return row.result === "" ? "skipped" : "not_skipped";
+}
+
+function createRequestHash(blockNumber: bigint): string {
+  return createHash("md5")
+    .update(
+      JSON.stringify({
+        method: "eth_getblockbynumber",
+        params: [toHex(blockNumber), true],
+      })
+    )
+    .digest()
+    .toString("hex");
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: ponder
+      POSTGRES_USER: ponder
+      POSTGRES_PASSWORD: ponder
+    ports:
+      - "127.0.0.1:5432:5432"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,15 +284,21 @@ importers:
       hono:
         specifier: ^4.5.0
         version: 4.6.20
+      kysely:
+        specifier: ^0.26.3
+        version: 0.26.3
       lru-cache:
         specifier: ^11.0.2
         version: 11.0.2
       normalize-url:
         specifier: ^8.0.1
         version: 8.0.1
+      pg:
+        specifier: ^8.11.3
+        version: 8.13.1
       ponder:
         specifier: ^0.9.23
-        version: 0.9.24(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(@types/pg@8.6.1)(@types/react@19.0.8)(bufferutil@4.0.9)(hono@4.6.20)(lightningcss@1.29.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+        version: 0.9.24(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(@types/pg@8.11.11)(@types/react@19.0.8)(bufferutil@4.0.9)(hono@4.6.20)(lightningcss@1.29.1)(terser@5.39.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
       viem:
         specifier: ^2.22.21
         version: 2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
@@ -303,6 +309,9 @@ importers:
       '@types/node':
         specifier: ^22.13.1
         version: 22.13.1
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.11.11
 
   docs:
     dependencies:
@@ -338,7 +347,7 @@ importers:
         version: 1.3.1(typedoc@0.27.9(typescript@5.7.3))
       vocs:
         specifier: 1.0.0-alpha.62
-        version: 1.0.0-alpha.62(@types/node@22.13.1)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(acorn@8.14.0)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.2)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(typescript@5.7.3)
+        version: 1.0.0-alpha.62(@types/node@22.13.1)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(acorn@8.14.0)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.2)(terser@5.39.0)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(typescript@5.7.3)
     devDependencies:
       '@ecp.eth/indexer':
         specifier: workspace:*
@@ -3276,6 +3285,9 @@ packages:
 
   '@types/pg-pool@2.0.6':
     resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
+  '@types/pg@8.11.11':
+    resolution: {integrity: sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==}
 
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
@@ -7343,6 +7355,10 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
   pg-pool@3.7.0:
     resolution: {integrity: sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==}
     peerDependencies:
@@ -7357,6 +7373,10 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg-types@4.0.2:
+    resolution: {integrity: sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==}
+    engines: {node: '>=10'}
 
   pg@8.13.1:
     resolution: {integrity: sha512-OUir1A0rPNZlX//c7ksiu7crsGZTKSOXJPgtNiHGIlC9H0lO+NC6ZDYksSgBYY/thSWhnSRBv8w1lieNNGATNQ==}
@@ -7521,17 +7541,36 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
+  postgres-array@3.0.2:
+    resolution: {integrity: sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==}
+    engines: {node: '>=12'}
+
   postgres-bytea@1.0.0:
     resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
     engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
 
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   preact@10.25.4:
     resolution: {integrity: sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==}
@@ -13266,7 +13305,13 @@ snapshots:
 
   '@types/pg-pool@2.0.6':
     dependencies:
-      '@types/pg': 8.6.1
+      '@types/pg': 8.11.11
+
+  '@types/pg@8.11.11':
+    dependencies:
+      '@types/node': 20.11.17
+      pg-protocol: 1.7.0
+      pg-types: 4.0.2
 
   '@types/pg@8.6.1':
     dependencies:
@@ -13444,7 +13489,7 @@ snapshots:
     dependencies:
       '@vanilla-extract/private': 1.0.6
 
-  '@vanilla-extract/integration@6.5.0(@types/node@22.13.1)(lightningcss@1.29.1)':
+  '@vanilla-extract/integration@6.5.0(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.9)
@@ -13457,8 +13502,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.7.4
       outdent: 0.8.0
-      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)
-      vite-node: 1.6.1(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-node: 1.6.1(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13477,13 +13522,13 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.15.5
 
-  '@vanilla-extract/vite-plugin@3.9.5(@types/node@22.13.1)(lightningcss@1.29.1)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1))':
+  '@vanilla-extract/vite-plugin@3.9.5(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))':
     dependencies:
-      '@vanilla-extract/integration': 6.5.0(@types/node@22.13.1)(lightningcss@1.29.1)
+      '@vanilla-extract/integration': 6.5.0(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
       outdent: 0.8.0
       postcss: 8.5.1
       postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))
-      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13497,14 +13542,14 @@ snapshots:
       - terser
       - ts-node
 
-  '@vitejs/plugin-react@4.3.1(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1))':
+  '@vitejs/plugin-react@4.3.1(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15125,6 +15170,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -15243,11 +15292,11 @@ snapshots:
 
   drange@1.1.1: {}
 
-  drizzle-orm@0.39.3(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)(kysely@0.26.3)(pg@8.13.1):
+  drizzle-orm@0.39.3(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0)(@types/pg@8.11.11)(kysely@0.26.3)(pg@8.13.1):
     optionalDependencies:
       '@electric-sql/pglite': 0.2.13
       '@opentelemetry/api': 1.9.0
-      '@types/pg': 8.6.1
+      '@types/pg': 8.11.11
       kysely: 0.26.3
       pg: 8.13.1
 
@@ -16134,7 +16183,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16500,7 +16549,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16528,7 +16577,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18316,7 +18365,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -18456,6 +18505,8 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
+  pg-numeric@1.0.2: {}
+
   pg-pool@3.7.0(pg@8.13.1):
     dependencies:
       pg: 8.13.1
@@ -18471,6 +18522,16 @@ snapshots:
       postgres-bytea: 1.0.0
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg-types@4.0.2:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.2
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
 
   pg@8.13.1:
     dependencies:
@@ -18559,7 +18620,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  ponder@0.9.24(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(@types/pg@8.6.1)(@types/react@19.0.8)(bufferutil@4.0.9)(hono@4.6.20)(lightningcss@1.29.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1):
+  ponder@0.9.24(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(@types/pg@8.11.11)(@types/react@19.0.8)(bufferutil@4.0.9)(hono@4.6.20)(lightningcss@1.29.1)(terser@5.39.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1):
     dependencies:
       '@babel/code-frame': 7.26.2
       '@commander-js/extra-typings': 12.1.0(commander@12.1.0)
@@ -18575,7 +18636,7 @@ snapshots:
       dataloader: 2.2.3
       detect-package-manager: 3.0.2
       dotenv: 16.4.7
-      drizzle-orm: 0.39.3(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)(kysely@0.26.3)(pg@8.13.1)
+      drizzle-orm: 0.39.3(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0)(@types/pg@8.11.11)(kysely@0.26.3)(pg@8.13.1)
       glob: 10.4.5
       graphql: 16.10.0
       graphql-yoga: 5.10.11(graphql@16.10.0)
@@ -18595,9 +18656,9 @@ snapshots:
       stacktrace-parser: 0.1.10
       superjson: 2.2.2
       viem: 2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)
-      vite-node: 1.0.2(@types/node@22.13.1)(lightningcss@1.29.1)
-      vite-tsconfig-paths: 4.3.1(typescript@5.7.3)(vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1))
+      vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-node: 1.0.2(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-tsconfig-paths: 4.3.1(typescript@5.7.3)(vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -18707,13 +18768,25 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
+  postgres-array@3.0.2: {}
+
   postgres-bytea@1.0.0: {}
 
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
   postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   preact@10.25.4: {}
 
@@ -18774,7 +18847,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -19321,7 +19394,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       module-details-from-path: 1.0.3
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -19733,7 +19806,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -20881,13 +20954,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-node@1.0.2(@types/node@22.13.1)(lightningcss@1.29.1):
+  vite-node@1.0.2(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -20898,13 +20971,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.1(@types/node@22.13.1)(lightningcss@1.29.1):
+  vite-node@1.6.1(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -20916,18 +20989,18 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.1(typescript@5.7.3)(vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)):
+  vite-tsconfig-paths@4.3.1(typescript@5.7.3)(vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)):
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.7.3)
     optionalDependencies:
-      vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1):
+  vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.5.1
@@ -20936,8 +21009,9 @@ snapshots:
       '@types/node': 22.13.1
       fsevents: 2.3.3
       lightningcss: 1.29.1
+      terser: 5.39.0
 
-  vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1):
+  vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
@@ -20946,8 +21020,9 @@ snapshots:
       '@types/node': 22.13.1
       fsevents: 2.3.3
       lightningcss: 1.29.1
+      terser: 5.39.0
 
-  vocs@1.0.0-alpha.62(@types/node@22.13.1)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(acorn@8.14.0)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.2)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(typescript@5.7.3):
+  vocs@1.0.0-alpha.62(@types/node@22.13.1)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(acorn@8.14.0)(lightningcss@1.29.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.34.2)(terser@5.39.0)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@hono/node-server': 1.13.3(hono@3.12.12)
@@ -20967,8 +21042,8 @@ snapshots:
       '@shikijs/twoslash': 1.29.2(typescript@5.7.3)
       '@vanilla-extract/css': 1.17.1
       '@vanilla-extract/dynamic': 2.1.2
-      '@vanilla-extract/vite-plugin': 3.9.5(@types/node@22.13.1)(lightningcss@1.29.1)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1))
-      '@vitejs/plugin-react': 4.3.1(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1))
+      '@vanilla-extract/vite-plugin': 3.9.5(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)(ts-node@10.9.2(@types/node@22.13.1)(typescript@5.7.3))(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
+      '@vitejs/plugin-react': 4.3.1(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
       autoprefixer: 10.4.20(postcss@8.5.1)
       cac: 6.7.14
       chroma-js: 2.6.0
@@ -21011,7 +21086,7 @@ snapshots:
       ua-parser-js: 1.0.40
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)
+      vite: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@types/react'


### PR DESCRIPTION
This PR removes irrelevant rpc result cache items when processing transaction blocks.

This works locally only with postgres, for pg lite it is noop.