### PR TITLE
feat: mute deleted comment content

### DIFF
--- a/apps/demo/src/components/comments/Comment.tsx
+++ b/apps/demo/src/components/comments/Comment.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import { COMMENTS_V1_ADDRESS } from "@ecp.eth/sdk";
 import { CommentsV1Abi } from "@ecp.eth/sdk/abis";
 import { MoreVertical } from "lucide-react";
@@ -102,7 +103,9 @@ export function Comment({
           </DropdownMenu>
         )}
       </div>
-      <div className="mb-2">{renderCommentContent(comment.content)}</div>
+      <div className={cn("mb-2", comment.deletedAt && "text-muted-foreground")}>
+        {renderCommentContent(comment.content)}
+      </div>
       {connectedAddress && (
         <div className="text-xs text-gray-500 mb-2">
           <button

--- a/apps/demo/src/components/comments/gasless/CommentGasless.tsx
+++ b/apps/demo/src/components/comments/gasless/CommentGasless.tsx
@@ -4,7 +4,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { bigintReplacer } from "@/lib/utils";
+import { bigintReplacer, cn } from "@/lib/utils";
 import { useGaslessTransaction } from "@ecp.eth/sdk/react";
 import { MoreVertical } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -28,6 +28,7 @@ import useEnrichedAuthor from "@/hooks/useEnrichedAuthor";
 import { Hex } from "@ecp.eth/sdk/schemas";
 import { publicEnv } from "@/publicEnv";
 import { CommentAuthor } from "../CommentAuthor";
+import { renderCommentContent } from "@/lib/renderer";
 
 async function gaslessDeleteComment(
   params: PrepareGaslessCommentDeletionRequestBodySchemaType
@@ -210,7 +211,9 @@ export function CommentGasless({
           </DropdownMenu>
         )}
       </div>
-      <div className="mb-2">{comment.content}</div>
+      <div className={cn("mb-2", comment.deletedAt && "text-muted-foreground")}>
+        {renderCommentContent(comment.content)}
+      </div>
       {connectedAddress && (
         <div className="text-xs text-gray-500 mb-2">
           <button


### PR DESCRIPTION
https://linear.app/modprotocol/issue/FRA-1056/deleted-comments-should-be-a-slightly-lighter-gray-color-maybe-555

This PR adds text muting on deleted comments and also add missing `renderCommentContent` to gasless comment

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/c8b274f6-e415-442a-a937-411eea18a8b7" />
