### PR TITLE
build: generate build id from indexer code

### DIFF
--- a/apps/indexer/bin/build-id.js
+++ b/apps/indexer/bin/build-id.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import {
+  createProgram,
+  ModuleKind,
+  ModuleResolutionKind,
+  ScriptTarget,
+  createPrinter,
+  NewLineKind,
+} from "typescript";
+import { resolve } from "node:path";
+import { createHash } from "node:crypto";
+import process from "node:process";
+
+/**
+ * This script is prone to changes in packages/sdk/schemas.d.ts, abis.d.ts, index.d.ts
+ */
+
+const printer = createPrinter({
+  newLine: NewLineKind.LineFeed,
+  // remove comments to avoid changing the hash when the comments are changed
+  removeComments: true,
+});
+
+const program = createProgram({
+  options: {
+    removeComments: true,
+    noUncheckedIndexedAccess: true,
+
+    // Interop constraints
+    verbatimModuleSyntax: false,
+    esModuleInterop: true,
+    isolatedModules: true,
+    allowSyntheticDefaultImports: true,
+    resolveJsonModule: true,
+    declaration: false,
+
+    // Language and environment
+    moduleResolution: ModuleResolutionKind.Bundler,
+    module: ModuleKind.ESNext,
+    noEmit: true,
+    lib: ["ES2022"],
+    target: ScriptTarget.ES2022,
+
+    // Skip type checking for node modules
+    skipLibCheck: true,
+    allowJs: true,
+  },
+  rootNames: [
+    resolve(import.meta.dirname, "../src/index.ts"),
+    resolve(import.meta.dirname, "../ponder.config.ts"),
+    resolve(import.meta.dirname, "../ponder.schema.ts"),
+  ],
+});
+
+const files = program
+  .getSourceFiles()
+  .filter((file) => !file.fileName.includes("node_modules"));
+
+const hash = createHash("sha256");
+
+for (const file of files) {
+  hash.update(printer.printFile(file));
+}
+
+process.stdout.write(hash.digest("hex"));

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -13,7 +13,8 @@
     "codegen": "ponder codegen",
     "serve": "ponder serve",
     "lint": "eslint \"./src/**/*.ts\"",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "build-id": "node bin/build-id.js"
   },
   "dependencies": {
     "@ecp.eth/sdk": "^0.0.11",
@@ -33,6 +34,7 @@
     "obscenity": "^0.4.3",
     "pg": "^8.11.3",
     "ponder": "^0.9.23",
+    "typescript": "5.7.3",
     "viem": "^2.22.21",
     "xxhash-wasm": "^1.1.0",
     "zod": "^3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       ponder:
         specifier: ^0.9.23
         version: 0.9.24(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(@types/pg@8.11.11)(@types/react@19.0.11)(bufferutil@4.0.9)(hono@4.6.20)(lightningcss@1.29.1)(terser@5.39.0)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
       viem:
         specifier: ^2.22.21
         version: 2.22.21(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
@@ -19326,7 +19329,7 @@ snapshots:
   vite@5.0.7(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0):
     dependencies:
       esbuild: 0.19.12
-      postcss: 8.5.1
+      postcss: 8.5.3
       rollup: 4.34.2
     optionalDependencies:
       '@types/node': 22.13.1


### PR DESCRIPTION
This code generates a hash from files relevant to indexer. It works mostly fine only issue can happen when you update `sdk` code, for example changing the comment or something unrelated, then it also triggers new build id since there is no tree shaking.