### PR TITLE
fix: move submit buttons to the right if account is not connected

### DIFF
--- a/apps/demo/src/components/comments/CommentBox.tsx
+++ b/apps/demo/src/components/comments/CommentBox.tsx
@@ -142,7 +142,7 @@ export function CommentBox({
       />
       <div className="flex gap-2 justify-between">
         {address && <CommentBoxAuthor address={address} />}
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-2 items-center ml-auto">
           <Button
             name="action"
             value="post"

--- a/apps/demo/src/components/comments/gasless/CommentBoxGasless.tsx
+++ b/apps/demo/src/components/comments/gasless/CommentBoxGasless.tsx
@@ -85,7 +85,7 @@ export function CommentBoxGasless({
         {address && <CommentBoxAuthor address={address} />}
         <Button
           type="submit"
-          className="px-4 py-2 rounded"
+          className="px-4 py-2 rounded ml-auto"
           disabled={isSubmitting || !isContentValid}
         >
           {isSubmitting ? "Posting..." : "Comment"}

--- a/apps/embed/src/components/comments/CommentForm.tsx
+++ b/apps/embed/src/components/comments/CommentForm.tsx
@@ -133,6 +133,7 @@ export function CommentForm({
       <div className="flex gap-2 justify-between">
         {address && <CommentFormAuthor address={address} />}
         <Button
+          className="ml-auto"
           type="submit"
           disabled={isSubmitting || !isContentValid}
           size="sm"


### PR DESCRIPTION
https://linear.app/modprotocol/issue/FRA-1100/put-submit-buttons-to-right-even-when-user-doesnt-have-wallet