### PR TITLE
fix: should not break-all

### DIFF
--- a/apps/demo/src/components/comments/CommentShared.tsx
+++ b/apps/demo/src/components/comments/CommentShared.tsx
@@ -192,7 +192,7 @@ export function CommentShared({
       </div>
       <div
         className={cn(
-          "mb-2 break-all text-foreground",
+          "mb-2 break-words hyphens-auto text-foreground",
           comment.deletedAt && "text-muted-foreground"
         )}
       >

--- a/apps/embed/src/components/comments/Comment.tsx
+++ b/apps/embed/src/components/comments/Comment.tsx
@@ -290,7 +290,7 @@ export function Comment({
       </div>
       <div
         className={cn(
-          "mb-2 text-foreground break-all",
+          "mb-2 text-foreground break-words hyphens-auto",
           comment.deletedAt && "text-muted-foreground"
         )}
       >


### PR DESCRIPTION
break-all makes English text unreadable as it break at the mid of the word:

<img width="791" alt="image" src="https://github.com/user-attachments/assets/01bdfdfa-932e-4439-85c2-70283eb425ec" />


with `break-works` and `hyphen-auto`. super long words still got broke into 2 lines with an hyphen while the shorter words are kept unbroken:

<img width="907" alt="image" src="https://github.com/user-attachments/assets/ad9a0e60-6855-4b3d-afff-79bd2e1a1cef" />
