### PR TITLE
fix: retry processing block in case of malformed rpc result

### DIFF
--- a/apps/indexer/src/lib/ponder-rpc-results-cache.ts
+++ b/apps/indexer/src/lib/ponder-rpc-results-cache.ts
@@ -2,6 +2,23 @@ import { createHash } from "node:crypto";
 import { getDb } from "../db";
 import { toHex } from "viem";
 
+export async function deleteCachedGetBlockRpcResponse(
+  blockNumber: bigint,
+  chainId: number
+) {
+  const db = getDb();
+
+  if (!db) {
+    throw new Error("Database not found");
+  }
+
+  await db
+    .deleteFrom("rpc_request_results")
+    .where("request_hash", "=", createRequestHash(blockNumber))
+    .where("chain_id", "=", chainId)
+    .execute();
+}
+
 /**
  * This function removes cached result from rpc response because we aren't interested in the result anymore
  */

--- a/apps/indexer/src/lib/try-async.ts
+++ b/apps/indexer/src/lib/try-async.ts
@@ -1,0 +1,30 @@
+export async function tryAsync<T>(
+  fn: () => Promise<T>,
+  {
+    onError,
+    retries = 10,
+  }: {
+    onError: (error: unknown) => void | Promise<void>;
+    /**
+     * @default 10
+     */
+    retries?: number;
+  }
+) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      console.error(`[tryAsync] error ${i + 1} of ${retries}`);
+      console.error(error);
+
+      await onError(error);
+
+      if (i === retries - 1) {
+        throw error;
+      } else {
+        console.log(`[tryAsync] retrying...`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://linear.app/modprotocol/issue/FRA-1110/we-need-to-handle-block-not-found-error-which-is-breaking-the-indexer

This PR fixes issue when RPC returns an invalid result `null` and ponder just caches it in DB and breaks the app. Now it will retry by removing the malformed row and trying the function again.