### PR TITLE
fix: consolidate contract deployments to root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ A protocol for commenting built on Ethereum.
 
 ## Deployments
 
-| Network | Block Number | Address                                    |
-| ------- | ------------ | ------------------------------------------ |
-| Base    | 26637776     | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
+| Network          | Contract Address                           |
+| ---------------- | ------------------------------------------ |
+| Ethereum Mainnet | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
+| Ethereum Sepolia | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
+| Base             | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
+| Base Sepolia     | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
 
 ## Packages
 

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -52,12 +52,3 @@ Ensure that etherscan API key is set in the `.env` file.
 ```
 pnpm run deploy --rpc-url $RPC_URL
 ```
-
-## Deployed Contracts
-
-| Network | Contract Address |
-| --- | --- |
-| Ethereum Mainnet | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
-| Ethereum Sepolia | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
-| Base | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |
-| Base Sepolia | 0xabD9cE1952992211dEe051Df6ed337fa6efC995d |


### PR DESCRIPTION
for people who wants to see the contract deployment, they are more likely to visit the root readme instead of protocol readme.

people who checks the protocol readme is more likely for redeployment of the contract or checking source code for reference.