### PR TITLE
WIP: docs: trigger client rerender to avoid showing empty result

### DIFF
--- a/docs/components/IframeConfigurator.tsx
+++ b/docs/components/IframeConfigurator.tsx
@@ -303,8 +303,6 @@ export default function IframeConfigurator() {
     }));
   };
 
-  console.log("rendering", mode);
-
   return (
     <div className="space-y-8 border border-input-border rounded-iframe-configurator-section p-4">
       <div className="space-y-6">
@@ -313,7 +311,7 @@ export default function IframeConfigurator() {
             className="block text-sm font-medium mb-2"
             htmlFor="mode-select"
           >
-            Mode
+            Mode {mode}
           </label>
           <select
             id="mode-select"


### PR DESCRIPTION
production docs renders like this:

<img width="830" alt="image" src="https://github.com/user-attachments/assets/fa82c80b-378f-4eda-8f44-22e39077884a" />

it looks like it renders only once on server using SSR, and do not rerender on client.
this PR adds a hook that trigger rerender on client side
