### PR TITLE
refactor: (demo) reuse same get approval func on server and client

### DIFF
--- a/apps/demo/src/lib/contract.ts
+++ b/apps/demo/src/lib/contract.ts
@@ -1,7 +1,9 @@
 import { COMMENTS_V1_ADDRESS, CommentsV1Abi } from "@ecp.eth/sdk";
 import { CommentData } from "@ecp.eth/sdk/schemas";
-import { Hex } from "viem";
+import { Address, Chain, Hex, PublicClient, Transport } from "viem";
 import { UseWriteContractReturnType } from "wagmi";
+import { chain } from "@/lib/wagmi";
+import { publicEnv } from "@/publicEnv";
 
 type PostCommentViaContractParams = {
   commentData: CommentData;
@@ -18,4 +20,64 @@ export const postCommentAsAuthorViaCommentsV1 = async (
     functionName: "postCommentAsAuthor",
     args: [commentData, appSignature],
   });
+};
+
+export const getApprovalStatusAndNonce = async <
+  TTransport extends Transport,
+  TChain extends Chain,
+  TPublicClient extends PublicClient<TTransport, TChain> = PublicClient<
+    TTransport,
+    TChain
+  >,
+>(
+  publicClient: TPublicClient,
+  connectedAddress: Address
+): Promise<[{ result: boolean }, { result: bigint }]> => {
+  return (
+    chain.contracts?.multicall3
+      ? await publicClient.multicall({
+          contracts: [
+            {
+              address: COMMENTS_V1_ADDRESS,
+              abi: CommentsV1Abi,
+              functionName: "isApproved",
+              args: [
+                connectedAddress,
+                publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+              ],
+            },
+            {
+              address: COMMENTS_V1_ADDRESS,
+              abi: CommentsV1Abi,
+              functionName: "nonces",
+              args: [
+                connectedAddress,
+                publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+              ],
+            },
+          ],
+        })
+      : (
+          await Promise.all([
+            publicClient.readContract({
+              address: COMMENTS_V1_ADDRESS,
+              abi: CommentsV1Abi,
+              functionName: "isApproved",
+              args: [
+                connectedAddress,
+                publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+              ],
+            }),
+            publicClient.readContract({
+              address: COMMENTS_V1_ADDRESS,
+              abi: CommentsV1Abi,
+              functionName: "nonces",
+              args: [
+                connectedAddress,
+                publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+              ],
+            }),
+          ])
+        ).map((result) => ({ result }))
+  ) as [{ result: boolean }, { result: bigint }];
 };


### PR DESCRIPTION
use to reuse the same function to retrieve approval and nonce