### PR TITLE
fix: (docs) text cropping

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@ecp.eth/sdk": "workspace:*",
-    "@theguild/remark-mermaid": "^0.2.0",
+    "@theguild/remark-mermaid": "^0.3.0",
     "acorn": "^8.14.0",
     "decimal.js": "^10.5.0",
     "hono": "^4.6.20",

--- a/docs/pages/architecture-overview.mdx
+++ b/docs/pages/architecture-overview.mdx
@@ -6,7 +6,7 @@ The Ethereum Comments Protocol enables decentralized commenting through a combin
 
 ```mermaid
 graph TD
-    A[fa:fa-window-maximize App server] --> B[fa:fa-code SDK]
+    A[fa:fa-window-maximize App server] --> B["fa:fa-file-code SDK"]
     B --> C["fa:fa-file-contract CommentV1\n(Smart Contract)"]
     B --> D[fa:fa-server Indexer]
     D --> E[fa:fa-database Database]
@@ -14,16 +14,19 @@ graph TD
 ```
 
 ### 1. CommentV1 (Smart Contract)
+
 - Manages comment storage and threading relationships
 - Emits events for comment additions, deletions and approvals
 - [Dual-signature system](/dual-signature-system) where both authors and app signers can authorize actions
 
 ### 2. Indexer
+
 - Listens for comment events on-chain
 - Processes and indexes comments for efficient querying
 - Maintains a synchronized database of all comments
 
 ### 3. SDK
+
 - Provides easy-to-use interfaces for developers
 - Handles interaction with smart contracts
 - Manages connection to indexer services

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -28,3 +28,15 @@
 :root.dark .ecp_Paragraph_secondary {
   @apply text-gray-400;
 }
+
+.vocs_Content svg[role="graphics-document document"] foreignObject {
+  overflow: visible;
+}
+
+.vocs_Content
+  svg[role="graphics-document document"]
+  foreignObject
+  .nodeLabel
+  .fa {
+  margin-left: -2px;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,8 +524,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/sdk
       '@theguild/remark-mermaid':
-        specifier: ^0.2.0
-        version: 0.2.0(react@19.0.0)
+        specifier: ^0.3.0
+        version: 0.3.0(react@19.0.0)
       acorn:
         specifier: ^8.14.0
         version: 8.14.1
@@ -4405,10 +4405,10 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@theguild/remark-mermaid@0.2.0':
-    resolution: {integrity: sha512-o8n57TJy0OI4PCrNw8z6S+vpHtrwoQZzTA5Y3fL0U1NDRIoMg/78duWgEBFsCZcWM1G6zjE91yg1aKCsDwgE2Q==}
+  '@theguild/remark-mermaid@0.3.0':
+    resolution: {integrity: sha512-Fy1J4FSj8totuHsHFpaeWyWRaRSIvpzGTRoEfnNJc1JmLV9uV70sYE3zcT+Jj5Yw20Xq4iCsiT+3Ho49BBZcBQ==}
     peerDependencies:
-      react: ^18.2.0
+      react: ^18.2.0 || ^19.0.0
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -16314,7 +16314,7 @@ snapshots:
       '@tanstack/query-core': 5.69.0
       react: 19.0.0
 
-  '@theguild/remark-mermaid@0.2.0(react@19.0.0)':
+  '@theguild/remark-mermaid@0.3.0(react@19.0.0)':
     dependencies:
       mermaid: 11.4.1
       react: 19.0.0


### PR DESCRIPTION
text in mermaid chart was cropped due to the use of font awesome, the speculation is mermaid assume consistent font used in the foreign object so in this case it couldn't calculate correctly.

this pr make foreignobject overflow:visible and move font awesome slightly to the left

before:
<img width="811" alt="image" src="https://github.com/user-attachments/assets/e3cd0d7c-9b46-4843-a930-657aabcf95c9" />

after:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/d083a04f-169e-4735-89ad-ca39e4b4125c" />
