### PR TITLE
docs: revert to typedoc `~0.27.0` to fix zod schema docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,14 +28,16 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "swagger-ui-react": "^5.20.5",
-    "typedoc-plugin-markdown": "^4.6.1",
+    "typedoc-plugin-markdown": "~4.4.2",
     "typedoc-plugin-zod": "^1.4.0",
+    "typescript": "^5.8.2",
     "use-debounce": "^10.0.4",
     "vocs": "^1.0.11",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@ecp.eth/indexer": "workspace:*",
+    "@ecp.eth/solidity-docgen": "~0.5.19",
     "@hono/zod-openapi": "^0.18.4",
     "@types/react": "^19.0.11",
     "@types/react-dom": "^19.0.4",
@@ -44,10 +46,9 @@
     "escape-string-regexp": "^5.0.0",
     "js-yaml": "^4.1.0",
     "solc": "^0.8.29",
-    "@ecp.eth/solidity-docgen": "~0.5.19",
     "tailwindcss": "^4.0.13",
     "tsx": "^4.19.3",
-    "typedoc": "^0.28.2",
+    "typedoc": "~0.27.9",
     "unist-util-visit": "^5.0.0",
     "vite": "^6.2.1"
   }

--- a/docs/pages/sdk-reference/react/type-aliases/CommentsEmbedProps.mdx
+++ b/docs/pages/sdk-reference/react/type-aliases/CommentsEmbedProps.mdx
@@ -79,7 +79,7 @@ Allows to customise the theme of the embed iframe.
 ### uri
 
 ```ts
-uri: string;
+uri: string | URL;
 ```
 
 URL of the page to embed comments for. Comments for this uri are rendered in iframe's page.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,11 +557,14 @@ importers:
         specifier: ^5.20.5
         version: 5.20.5(@types/react@19.0.11)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       typedoc-plugin-markdown:
-        specifier: ^4.6.1
-        version: 4.6.1(typedoc@0.28.2(typescript@5.8.2))
+        specifier: ~4.4.2
+        version: 4.4.2(typedoc@0.27.9(typescript@5.8.2))
       typedoc-plugin-zod:
         specifier: ^1.4.0
-        version: 1.4.0(typedoc@0.28.2(typescript@5.8.2))
+        version: 1.4.0(typedoc@0.27.9(typescript@5.8.2))
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
       use-debounce:
         specifier: ^10.0.4
         version: 10.0.4(react@19.0.0)
@@ -609,8 +612,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typedoc:
-        specifier: ^0.28.2
-        version: 0.28.2(typescript@5.8.2)
+        specifier: ~0.27.9
+        version: 0.27.9(typescript@5.8.2)
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2250,8 +2253,8 @@ packages:
   '@formatjs/intl-relativetimeformat@11.4.11':
     resolution: {integrity: sha512-EiknGq2z8ZcIDUhf3kkizrPmHHdD0lO6B3OXG6u0o0lAvusSc9gkr33F2S/vzOHM9iTh6oHmzTl21klGsLR9LA==}
 
-  '@gerrit0/mini-shiki@3.2.2':
-    resolution: {integrity: sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==}
+  '@gerrit0/mini-shiki@1.27.2':
+    resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
 
   '@graphql-tools/executor@1.3.12':
     resolution: {integrity: sha512-FzLXZQJOZHB75SecYFOIEEHw/qcxkRFViw0lVqHpaL07c+GqDxv6VOto0FZCIiV9RgGdyRj3O8lXDCp9Cw1MbA==}
@@ -4153,23 +4156,14 @@ packages:
   '@shikijs/engine-oniguruma@1.29.2':
     resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
 
-  '@shikijs/engine-oniguruma@3.2.1':
-    resolution: {integrity: sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==}
-
   '@shikijs/langs@1.29.2':
     resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
-
-  '@shikijs/langs@3.2.1':
-    resolution: {integrity: sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==}
 
   '@shikijs/rehype@1.29.2':
     resolution: {integrity: sha512-sxi53HZe5XDz0s2UqF+BVN/kgHPMS9l6dcacM4Ra3ZDzCJa5rDGJ+Ukpk4LxdD1+MITBM6hoLbPfGv9StV8a5Q==}
 
   '@shikijs/themes@1.29.2':
     resolution: {integrity: sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==}
-
-  '@shikijs/themes@3.2.1':
-    resolution: {integrity: sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==}
 
   '@shikijs/transformers@1.29.2':
     resolution: {integrity: sha512-NHQuA+gM7zGuxGWP9/Ub4vpbwrYCrho9nQCLcCPfOe3Yc7LOYwmSuhElI688oiqIXk9dlZwDiyAG9vPBTuPJMA==}
@@ -4179,9 +4173,6 @@ packages:
 
   '@shikijs/types@1.29.2':
     resolution: {integrity: sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==}
-
-  '@shikijs/types@3.2.1':
-    resolution: {integrity: sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -10647,20 +10638,20 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typedoc-plugin-markdown@4.6.1:
-    resolution: {integrity: sha512-SrJv9zkpCWdG1cvtWniFU6M7MkCZuheN2R3fuqDPF+O+PeZ8bzmfj1ju/BJwoPWIKyFJVPhK8Sg6tBrM1y+VoA==}
+  typedoc-plugin-markdown@4.4.2:
+    resolution: {integrity: sha512-kJVkU2Wd+AXQpyL6DlYXXRrfNrHrEIUgiABWH8Z+2Lz5Sq6an4dQ/hfvP75bbokjNDUskOdFlEEm/0fSVyC7eg==}
     engines: {node: '>= 18'}
     peerDependencies:
-      typedoc: 0.28.x
+      typedoc: 0.27.x
 
   typedoc-plugin-zod@1.4.0:
     resolution: {integrity: sha512-Mr4hoEfjIR1xjp0RqtEyfba03NDUE4jLvgErg0VQz9L60eCVLcUrV0x+71+B7rykDMexrTx0I9Yk6SS0PuSbKw==}
     peerDependencies:
       typedoc: 0.23.x || 0.24.x || 0.25.x || 0.26.x || 0.27.x || 0.28.x
 
-  typedoc@0.28.2:
-    resolution: {integrity: sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==}
-    engines: {node: '>= 18', pnpm: '>= 10'}
+  typedoc@0.27.9:
+    resolution: {integrity: sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==}
+    engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
@@ -13204,12 +13195,10 @@ snapshots:
       '@formatjs/intl-localematcher': 0.6.1
       tslib: 2.8.1
 
-  '@gerrit0/mini-shiki@3.2.2':
+  '@gerrit0/mini-shiki@1.27.2':
     dependencies:
-      '@shikijs/engine-oniguruma': 3.2.1
-      '@shikijs/langs': 3.2.1
-      '@shikijs/themes': 3.2.1
-      '@shikijs/types': 3.2.1
+      '@shikijs/engine-oniguruma': 1.29.2
+      '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
   '@graphql-tools/executor@1.3.12(graphql@16.10.0)':
@@ -15695,18 +15684,9 @@ snapshots:
       '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/engine-oniguruma@3.2.1':
-    dependencies:
-      '@shikijs/types': 3.2.1
-      '@shikijs/vscode-textmate': 10.0.2
-
   '@shikijs/langs@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
-
-  '@shikijs/langs@3.2.1':
-    dependencies:
-      '@shikijs/types': 3.2.1
 
   '@shikijs/rehype@1.29.2':
     dependencies:
@@ -15720,10 +15700,6 @@ snapshots:
   '@shikijs/themes@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
-
-  '@shikijs/themes@3.2.1':
-    dependencies:
-      '@shikijs/types': 3.2.1
 
   '@shikijs/transformers@1.29.2':
     dependencies:
@@ -15740,11 +15716,6 @@ snapshots:
       - typescript
 
   '@shikijs/types@1.29.2':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-
-  '@shikijs/types@3.2.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -21854,7 +21825,7 @@ snapshots:
 
   openapi3-ts@4.4.0:
     dependencies:
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   optionator@0.9.4:
     dependencies:
@@ -23062,7 +23033,7 @@ snapshots:
       estree-util-value-to-estree: 3.3.2
       toml: 3.0.0
       unified: 11.0.5
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   remark-mdx@3.1.0:
     dependencies:
@@ -24204,17 +24175,17 @@ snapshots:
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc-plugin-markdown@4.6.1(typedoc@0.28.2(typescript@5.8.2)):
+  typedoc-plugin-markdown@4.4.2(typedoc@0.27.9(typescript@5.8.2)):
     dependencies:
-      typedoc: 0.28.2(typescript@5.8.2)
+      typedoc: 0.27.9(typescript@5.8.2)
 
-  typedoc-plugin-zod@1.4.0(typedoc@0.28.2(typescript@5.8.2)):
+  typedoc-plugin-zod@1.4.0(typedoc@0.27.9(typescript@5.8.2)):
     dependencies:
-      typedoc: 0.28.2(typescript@5.8.2)
+      typedoc: 0.27.9(typescript@5.8.2)
 
-  typedoc@0.28.2(typescript@5.8.2):
+  typedoc@0.27.9(typescript@5.8.2):
     dependencies:
-      '@gerrit0/mini-shiki': 3.2.2
+      '@gerrit0/mini-shiki': 1.27.2
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
@@ -24454,7 +24425,7 @@ snapshots:
   vfile-matter@5.0.0:
     dependencies:
       vfile: 6.0.3
-      yaml: 2.7.0
+      yaml: 2.7.1
 
   vfile-message@4.0.2:
     dependencies:


### PR DESCRIPTION
tried to hack the issue but it seems the problem was deep down inside typedoc reflection.
so bug reported: https://github.com/Gerrit0/typedoc-plugin-zod/issues/9

meanwhile lets use older version of typedoc and plugins