### PR TITLE
refactor(protocol): reduce get channel sload/store to improve gas consumption

### DIFF
--- a/packages/protocol/script/debug.s.sol
+++ b/packages/protocol/script/debug.s.sol
@@ -38,6 +38,9 @@ contract DebugGasUsage is Test, IERC721Receiver {
         debugSetHookGloballyEnabledTrue();
         debugSetHookGloballyEnabledFalse();
         debugExecuteHooks();
+        debugConstructChannelManager();
+        debugCreateChannel();
+        debugUpdateChannel();
     }
 
     function debugRegisterHook() public {
@@ -118,6 +121,40 @@ contract DebugGasUsage is Test, IERC721Receiver {
             user1,
             bytes32(0),
             IChannelManager.HookPhase.Before
+        );
+    }
+
+    function debugConstructChannelManager() public {
+        measureGas("constructChannelManager", runConstructChannelManager);
+    }
+
+    function runConstructChannelManager() internal {
+        new ChannelManager(address(this));
+    }
+
+    function debugCreateChannel() public {
+        measureGas("createChannel", runCreateChannel);
+    }
+
+    function runCreateChannel() internal {
+        channelManager.createChannel{value: 0.02 ether}(
+            "Test Channel 2",
+            "Description",
+            "{}",
+            address(0)
+        );
+    }
+
+    function debugUpdateChannel() public {
+        measureGas("updateChannel", runUpdateChannel);
+    }
+
+    function runUpdateChannel() internal {
+        channelManager.updateChannel(
+            channelId,
+            "Test Channel 3",
+            "Description",
+            "{}"
         );
     }
 

--- a/packages/protocol/src/ChannelManager.sol
+++ b/packages/protocol/src/ChannelManager.sol
@@ -63,9 +63,11 @@ contract ChannelManager is IChannelManager, ProtocolFees, ERC721Enumerable {
         // Create default channel with ID 0
         _safeMint(initialOwner, 0);
 
-        channels[0].name = "Home";
-        channels[0].description = "Any kind of content";
-        channels[0].metadata = "{}";
+        ChannelConfig storage channelZero = channels[0];
+
+        channelZero.name = "Home";
+        channelZero.description = "Any kind of content";
+        channelZero.metadata = "{}";
     }
 
     modifier onlyCommentsContract() {
@@ -159,9 +161,11 @@ contract ChannelManager is IChannelManager, ProtocolFees, ERC721Enumerable {
 
         _safeMint(msg.sender, channelId);
 
-        channels[channelId].name = name;
-        channels[channelId].description = description;
-        channels[channelId].metadata = metadata;
+        ChannelConfig storage channel = channels[channelId];
+
+        channel.name = name;
+        channel.description = description;
+        channel.metadata = metadata;
 
         // Add hook if provided
         if (hook != address(0)) {
@@ -186,9 +190,11 @@ contract ChannelManager is IChannelManager, ProtocolFees, ERC721Enumerable {
         if (!_channelExists(channelId)) revert ChannelDoesNotExist();
         if (ownerOf(channelId) != msg.sender) revert UnauthorizedCaller();
 
-        channels[channelId].name = name;
-        channels[channelId].description = description;
-        channels[channelId].metadata = metadata;
+        ChannelConfig storage channel = channels[channelId];
+
+        channel.name = name;
+        channel.description = description;
+        channel.metadata = metadata;
 
         emit ChannelUpdated(channelId, name, description, metadata);
     }


### PR DESCRIPTION
### Before

  Gas used for registerHook : 46972
  Gas used for setHookGloballyEnabledTrue : 6076
  Gas used for setHookGloballyEnabledFalse : 4075
  Gas used for executeHooks : 33649
  **Gas used for constructChannelManager : 4794137**
  **Gas used for createChannel : 202239**
  **Gas used for updateChannel : 10451**


### After

  Gas used for registerHook : 46972
  Gas used for setHookGloballyEnabledTrue : 6076
  Gas used for setHookGloballyEnabledFalse : 4075
  Gas used for executeHooks : 33649
  **Gas used for constructChannelManager : 4783151**
  **Gas used for createChannel : 202099**
  **Gas used for updateChannel : 10311**