### PR TITLE
fix(protocol): `calculateHookTransactionFee` no need to be payable

### DIFF
--- a/packages/protocol/src/ProtocolFees.sol
+++ b/packages/protocol/src/ProtocolFees.sol
@@ -84,15 +84,13 @@ abstract contract ProtocolFees is IProtocolFees, Ownable, ReentrancyGuard {
     /// @return hookValue The amount that should be passed to the hook
     function calculateHookTransactionFee(
         uint256 value
-    ) public payable returns (uint256 hookValue) {
-        if (value > 0 && hookTransactionFeeBasisPoints > 0) {
-            uint256 protocolFee = (value * hookTransactionFeeBasisPoints) /
-                10000;
-            hookValue = value - protocolFee;
-        } else {
-            hookValue = value;
+    ) public view returns (uint256 hookValue) {
+        if (value <= 0 || hookTransactionFeeBasisPoints <= 0) {
+            return value;
         }
-        return hookValue;
+
+        uint256 protocolFee = (value * hookTransactionFeeBasisPoints) / 10000;
+        return value - protocolFee;
     }
 
     /// @notice Internal function to handle fee collection and refunds

--- a/packages/sdk/src/channel-manager/hook.ts
+++ b/packages/sdk/src/channel-manager/hook.ts
@@ -272,7 +272,6 @@ export async function calculateHookTransactionFee(
     abi: ChannelManagerABI,
     functionName: "calculateHookTransactionFee",
     args: [value],
-    value,
   });
 
   return {


### PR DESCRIPTION
and also simplified a bit use early return