### PR TITLE
chore: lower rate limit on embed sign comment

### DIFF
--- a/apps/embed/src/services/rate-limiter.ts
+++ b/apps/embed/src/services/rate-limiter.ts
@@ -24,10 +24,10 @@ export class RateLimiter {
       token: redisToken,
     });
 
-    // Create a new ratelimiter that allows 1 request per minute
+    // Create a new ratelimiter that allows 1 request per 15 seconds
     this.limiter = new Ratelimit({
       redis: this.redis,
-      limiter: Ratelimit.slidingWindow(1, "1 m"),
+      limiter: Ratelimit.slidingWindow(1, "15 s"),
       prefix: namespace,
     });
   }


### PR DESCRIPTION
This PR lowers the embed sign comment rate limit from 1 min to 15 seconds.

https://linear.app/modprotocol/issue/FRA-1169/rate-limit-on-docs-page-is-imposed-even-if-signing-failed-which-is