### PR TITLE
fix(protocol): add author validation in deleteComment

### DIFF
--- a/packages/protocol/src/CommentManager.sol
+++ b/packages/protocol/src/CommentManager.sol
@@ -232,7 +232,7 @@ contract CommentManager is ICommentManager, ReentrancyGuard, Pausable, Ownable {
 
         Comments.CommentData storage comment = comments[commentId];
         require(comment.author != address(0), "Comment does not exist");
-
+        require(comment.author == author, "Author does not match comment author");
         nonces[author][app]++;
 
         bytes32 deleteHash = getDeleteCommentHash(


### PR DESCRIPTION
## Summary
- Adds validation to ensure the author parameter in deleteComment matches the actual comment author for the CommentManager contract

## Test plan
- Verify functionality with existing tests
- Confirm that attempting to delete a comment with an incorrect author parameter will fail properly

🤖 Generated with [Claude Code](https://claude.ai/code)