### PR TITLE
fix(protocol): use transfer instead of call for ETH refunds and payments

### DIFF
--- a/packages/protocol/src/ProtocolFees.sol
+++ b/packages/protocol/src/ProtocolFees.sol
@@ -100,11 +100,8 @@ abstract contract ProtocolFees is IProtocolFees, Ownable, ReentrancyGuard {
         if (msg.value < requiredFee) revert IChannelManager.InsufficientFee();
 
         if (msg.value > requiredFee) {
-            // Refund excess payment
-            (bool success, ) = msg.sender.call{value: msg.value - requiredFee}(
-                ""
-            );
-            require(success, "Refund failed");
+            // Refund excess payment using transfer for safety
+            payable(msg.sender).transfer(msg.value - requiredFee);
         }
 
         return requiredFee;

--- a/packages/protocol/test/FlatFeeHook.t.sol
+++ b/packages/protocol/test/FlatFeeHook.t.sol
@@ -6,6 +6,7 @@ import {ChannelManager} from "../src/ChannelManager.sol";
 import {CommentManager} from "../src/CommentManager.sol";
 import {IChannelManager} from "../src/interfaces/IChannelManager.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {TestUtils} from "./utils.sol";
 import {BaseHook} from "../src/hooks/BaseHook.sol";
 import {Hooks} from "../src/libraries/Hooks.sol";
@@ -67,8 +68,7 @@ contract FlatFeeHook is BaseHook {
         uint256 refundAmount = pendingRefunds[commentData.author];
         if (refundAmount > 0) {
             delete pendingRefunds[commentData.author];
-            (bool success, ) = commentData.author.call{value: refundAmount}("");
-            require(success, "Refund failed");
+            payable(commentData.author).transfer(refundAmount);
             emit RefundIssued(commentData.author, refundAmount);
         }
         return true;
@@ -81,8 +81,7 @@ contract FlatFeeHook is BaseHook {
         uint256 amount = totalFeesCollected;
         totalFeesCollected = 0;
 
-        (bool success, ) = feeCollector.call{value: amount}("");
-        require(success, "Fee withdrawal failed");
+        payable(feeCollector).transfer(amount);
         emit FeeWithdrawn(feeCollector, amount);
     }
 }

--- a/packages/protocol/test/ProtocolFees.t.sol
+++ b/packages/protocol/test/ProtocolFees.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/ProtocolFees.sol";
+import "../src/interfaces/IProtocolFees.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+
+// Concrete implementation of ProtocolFees for testing
+contract TestProtocolFees is ProtocolFees {
+    constructor(address initialOwner) ProtocolFees(initialOwner) {}
+}
+
+contract ProtocolFeesTest is Test {
+    TestProtocolFees public protocolFees;
+    address public owner;
+    address public nonOwner;
+    address public recipient;
+
+    event FeesWithdrawn(address indexed recipient, uint256 amount);
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        nonOwner = makeAddr("nonOwner");
+        recipient = makeAddr("recipient");
+        
+        vm.startPrank(owner);
+        protocolFees = new TestProtocolFees(owner);
+        vm.stopPrank();
+    }
+
+    function test_OnlyOwnerCanWithdrawFees() public {
+        // Send some ETH to the contract
+        vm.deal(address(protocolFees), 1 ether);
+
+        // Try to withdraw as non-owner (should fail)
+        vm.startPrank(nonOwner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, nonOwner));
+        protocolFees.withdrawFees(recipient);
+        vm.stopPrank();
+
+        // Withdraw as owner (should succeed)
+        vm.startPrank(owner);
+        vm.expectEmit(true, false, false, true);
+        emit FeesWithdrawn(recipient, 1 ether);
+        uint256 amount = protocolFees.withdrawFees(recipient);
+        vm.stopPrank();
+
+        // Verify the amount withdrawn
+        assertEq(amount, 1 ether);
+        assertEq(recipient.balance, 1 ether);
+        assertEq(address(protocolFees).balance, 0);
+    }
+
+    function test_CannotWithdrawToZeroAddress() public {
+        // Send some ETH to the contract
+        vm.deal(address(protocolFees), 1 ether);
+
+        // Try to withdraw to zero address (should fail)
+        vm.startPrank(owner);
+        vm.expectRevert(IChannelManager.ZeroAddress.selector);
+        protocolFees.withdrawFees(address(0));
+        vm.stopPrank();
+    }
+
+    function test_WithdrawFeesEmitsEvent() public {
+        // Send some ETH to the contract
+        vm.deal(address(protocolFees), 1 ether);
+
+        // Withdraw as owner and verify event
+        vm.startPrank(owner);
+        vm.expectEmit(true, false, false, true);
+        emit FeesWithdrawn(recipient, 1 ether);
+        protocolFees.withdrawFees(recipient);
+        vm.stopPrank();
+    }
+} 

--- a/packages/protocol/test/TipHook.t.sol
+++ b/packages/protocol/test/TipHook.t.sol
@@ -85,10 +85,7 @@ contract TipHook is BaseHook {
                 parentAuthor,
                 msg.value
             );
-            (bool success, ) = parentAuthor.call{value: msg.value}("");
-            if (!success) {
-                revert TipTransferFailed();
-            }
+            payable(parentAuthor).transfer(msg.value);
         } else if (msg.value > 0) {
             revert InvalidTipSyntax(
                 "ETH was sent but no valid tip mention was found"


### PR DESCRIPTION
## Summary
- Replace low-level `call` with `transfer` for ETH refunds in ProtocolFees, FlatFeeHook, and TipHook
- Added dedicated test file for ProtocolFees contract

## Test plan
- All tests pass with existing test coverage
- New test file for ProtocolFees verifies functionality

🤖 Generated with [Claude Code](https://claude.ai/code)