### PR TITLE
refactor(sdk): avoid deploy contract module level execution

### DIFF
--- a/packages/sdk/src/channel-manager/test/channel.ts
+++ b/packages/sdk/src/channel-manager/test/channel.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from "node:test";
+import { describe, it, beforeEach, before } from "node:test";
 import assert from "node:assert";
 import {
   createWalletClient,
@@ -24,390 +24,397 @@ import {
 } from "../channel.js";
 import { ChannelManagerABI } from "../../abis.js";
 import { deployContracts } from "../../../scripts/test-helpers.js";
+import type { Hex } from "../../core/schemas.js";
 
-const { channelManagerAddress } = deployContracts();
+describe("channel", () => {
+  let channelManagerAddress: Hex;
 
-// Test account setup
-const testPrivateKey =
-  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"; // Anvil's first private key
-const account = privateKeyToAccount(testPrivateKey);
-
-const testPrivateKey2 =
-  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"; // Anvil's second private key
-const account2 = privateKeyToAccount(testPrivateKey2);
-
-// Create wallet client
-const client = createWalletClient({
-  chain: anvil,
-  transport: http("http://localhost:8545"),
-  account,
-}).extend(publicActions);
-
-const client2 = createWalletClient({
-  chain: anvil,
-  transport: http("http://localhost:8545"),
-  account: account2,
-}).extend(publicActions);
-
-async function resetFees() {
-  const creationFee = await setChannelCreationFee({
-    fee: parseEther("0.02"),
-    writeContract: client.writeContract,
-    channelManagerAddress,
+  before(async () => {
+    channelManagerAddress = deployContracts().channelManagerAddress;
   });
 
-  const receipt = await client.waitForTransactionReceipt({
-    hash: creationFee.txHash,
-  });
+  // Test account setup
+  const testPrivateKey =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"; // Anvil's first private key
+  const account = privateKeyToAccount(testPrivateKey);
 
-  assert.equal(receipt.status, "success");
-}
+  const testPrivateKey2 =
+    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"; // Anvil's second private key
+  const account2 = privateKeyToAccount(testPrivateKey2);
 
-beforeEach(async () => {
-  await resetFees();
-});
+  // Create wallet client
+  const client = createWalletClient({
+    chain: anvil,
+    transport: http("http://localhost:8545"),
+    account,
+  }).extend(publicActions);
 
-describe("createChannel()", () => {
-  it("fails on insufficient fee", async () => {
-    await assert.rejects(
-      () =>
-        createChannel({
-          name: "Test channel",
-          writeContract: client.writeContract,
-          channelManagerAddress,
-        }),
-      (err) => {
-        assert.ok(
-          err instanceof ContractFunctionExecutionError,
-          "should be a ContractFunctionExecutionError",
-        );
-        assert.ok(
-          err.message.includes("Error: InsufficientFee()"),
-          "should include InsufficientFee",
-        );
+  const client2 = createWalletClient({
+    chain: anvil,
+    transport: http("http://localhost:8545"),
+    account: account2,
+  }).extend(publicActions);
 
-        return true;
-      },
-    );
-  });
-
-  it("creates channel", async () => {
-    const channel = await createChannel({
-      name: "Test channel",
-      fee: parseEther("0.02"), // this is default , see ChannelManager.sol
-      writeContract: client.writeContract,
-      channelManagerAddress,
-    });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: channel.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-  });
-});
-
-describe("getChannel()", () => {
-  let channelId: bigint;
-
-  beforeEach(async () => {
-    const result = await createChannel({
-      name: "Test channel",
+  async function resetFees() {
+    const creationFee = await setChannelCreationFee({
       fee: parseEther("0.02"),
       writeContract: client.writeContract,
       channelManagerAddress,
     });
 
     const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
+      hash: creationFee.txHash,
     });
 
     assert.equal(receipt.status, "success");
+  }
 
-    const logs = parseEventLogs({
-      abi: ChannelManagerABI,
-      logs: receipt.logs,
-      eventName: "ChannelCreated",
-    });
-
-    assert.ok(logs.length > 0, "ChannelCreated event should be found");
-
-    channelId = logs[0]!.args.channelId;
+  beforeEach(async () => {
+    await resetFees();
   });
 
-  it("gets channel", async () => {
-    const channel = await getChannel({
-      channelId,
-      readContract: client.readContract,
-      channelManagerAddress,
+  describe("createChannel()", () => {
+    it("fails on insufficient fee", async () => {
+      await assert.rejects(
+        () =>
+          createChannel({
+            name: "Test channel",
+            writeContract: client.writeContract,
+            channelManagerAddress,
+          }),
+        (err) => {
+          assert.ok(
+            err instanceof ContractFunctionExecutionError,
+            "should be a ContractFunctionExecutionError",
+          );
+          assert.ok(
+            err.message.includes("Error: InsufficientFee()"),
+            "should include InsufficientFee",
+          );
+
+          return true;
+        },
+      );
     });
 
-    assert.deepEqual(channel, {
-      name: "Test channel",
-      description: undefined,
-      metadata: undefined,
-      hook: undefined,
-      permissions: {
-        onCommentAdded: false,
-        onCommentDeleted: false,
-        onCommentEdited: false,
-        onInitialized: false,
-        onChannelUpdated: false,
-      },
+    it("creates channel", async () => {
+      const channel = await createChannel({
+        name: "Test channel",
+        fee: parseEther("0.02"), // this is default , see ChannelManager.sol
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: channel.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
     });
   });
-});
 
-describe("channelExists()", () => {
-  it("default channel", async () => {
-    assert.equal(
-      await channelExists({
-        channelId: 0n, // default channel id
+  describe("getChannel()", () => {
+    let channelId: bigint;
+
+    beforeEach(async () => {
+      const result = await createChannel({
+        name: "Test channel",
+        fee: parseEther("0.02"),
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      const logs = parseEventLogs({
+        abi: ChannelManagerABI,
+        logs: receipt.logs,
+        eventName: "ChannelCreated",
+      });
+
+      assert.ok(logs.length > 0, "ChannelCreated event should be found");
+
+      channelId = logs[0]!.args.channelId;
+    });
+
+    it("gets channel", async () => {
+      const channel = await getChannel({
+        channelId,
         readContract: client.readContract,
         channelManagerAddress,
-      }),
-      true,
-      "should return true for default channel id",
-    );
+      });
 
-    assert.equal(
-      await channelExists({
-        channelId: 10n,
-        readContract: client.readContract,
-        channelManagerAddress,
-      }),
-      false,
-      "should return false for non-existent channel id",
-    );
-  });
-});
-
-describe("getChannelCreationFee()", () => {
-  it("returns the fee", async () => {
-    const fee = await getChannelCreationFee({
-      readContract: client.readContract,
-      channelManagerAddress,
-    });
-
-    assert.deepEqual(
-      fee,
-      { fee: parseEther("0.02") },
-      "should return default channel creation fee",
-    );
-  });
-});
-
-describe("getChannelOwner()", () => {
-  let channelId: bigint;
-
-  beforeEach(async () => {
-    const result = await createChannel({
-      name: "Test channel",
-      fee: parseEther("0.02"),
-      writeContract: client.writeContract,
-      channelManagerAddress,
-    });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    const logs = parseEventLogs({
-      abi: ChannelManagerABI,
-      logs: receipt.logs,
-      eventName: "ChannelCreated",
-    });
-
-    assert.ok(logs.length > 0, "ChannelCreated event should be found");
-
-    channelId = logs[0]!.args.channelId;
-  });
-
-  it("default channel", async () => {
-    const owner = await getChannelOwner({
-      channelId,
-      readContract: client.readContract,
-      channelManagerAddress,
-    });
-
-    assert.deepEqual(owner, { owner: account.address });
-  });
-});
-
-describe("updateChannel()", () => {
-  let channelId: bigint;
-
-  beforeEach(async () => {
-    const result = await createChannel({
-      name: "Test channel",
-      fee: parseEther("0.02"),
-      writeContract: client.writeContract,
-      channelManagerAddress,
-    });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    const logs = parseEventLogs({
-      abi: ChannelManagerABI,
-      logs: receipt.logs,
-      eventName: "ChannelCreated",
-    });
-
-    assert.ok(logs.length > 0, "ChannelCreated event should be found");
-
-    channelId = logs[0]!.args.channelId;
-  });
-
-  it("updates channel", async () => {
-    const result = await updateChannel({
-      channelId,
-      name: "Updated channel",
-      description: "New description",
-      metadata: "New metadata",
-      writeContract: client.writeContract,
-      channelManagerAddress,
-    });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    // Verify the update
-    const channel = await getChannel({
-      channelId,
-      readContract: client.readContract,
-      channelManagerAddress,
-    });
-
-    assert.deepEqual(channel, {
-      name: "Updated channel",
-      description: "New description",
-      metadata: "New metadata",
-      hook: undefined,
-      permissions: {
-        onCommentAdded: false,
-        onCommentDeleted: false,
-        onCommentEdited: false,
-        onInitialized: false,
-        onChannelUpdated: false,
-      },
+      assert.deepEqual(channel, {
+        name: "Test channel",
+        description: undefined,
+        metadata: undefined,
+        hook: undefined,
+        permissions: {
+          onCommentAdded: false,
+          onCommentDeleted: false,
+          onCommentEdited: false,
+          onInitialized: false,
+          onChannelUpdated: false,
+        },
+      });
     });
   });
-});
 
-describe("setChannelCreationFee()", () => {
-  it("fails if the account is not an owner", async () => {
-    await assert.rejects(
-      () =>
-        setChannelCreationFee({
-          fee: parseEther("0.05"),
-          writeContract: client2.writeContract,
+  describe("channelExists()", () => {
+    it("default channel", async () => {
+      assert.equal(
+        await channelExists({
+          channelId: 0n, // default channel id
+          readContract: client.readContract,
           channelManagerAddress,
         }),
-      (err) => {
-        assert.ok(err instanceof ContractFunctionExecutionError);
-        assert.ok(err.message.includes("Error: OwnableUnauthorizedAccount("));
-        return true;
-      },
-    );
-  });
+        true,
+        "should return true for default channel id",
+      );
 
-  it("sets new fee", async () => {
-    const newFee = parseEther("0.05");
-    const result = await setChannelCreationFee({
-      fee: newFee,
-      writeContract: client.writeContract,
-      channelManagerAddress,
-    });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    // Verify the new fee
-    const fee = await getChannelCreationFee({
-      readContract: client.readContract,
-      channelManagerAddress,
-    });
-
-    assert.deepEqual(fee, { fee: newFee });
-  });
-});
-
-describe("withdrawFees()", () => {
-  beforeEach(async () => {
-    // Create a channel to generate some fees
-    await createChannel({
-      name: "Fee generation channel",
-      fee: parseEther("0.02"),
-      writeContract: client.writeContract,
-      channelManagerAddress,
+      assert.equal(
+        await channelExists({
+          channelId: 10n,
+          readContract: client.readContract,
+          channelManagerAddress,
+        }),
+        false,
+        "should return false for non-existent channel id",
+      );
     });
   });
 
-  it("withdraws fees", async () => {
-    const result = await withdrawFees({
-      recipient: account.address,
-      writeContract: client.writeContract,
-      channelManagerAddress,
+  describe("getChannelCreationFee()", () => {
+    it("returns the fee", async () => {
+      const fee = await getChannelCreationFee({
+        readContract: client.readContract,
+        channelManagerAddress,
+      });
+
+      assert.deepEqual(
+        fee,
+        { fee: parseEther("0.02") },
+        "should return default channel creation fee",
+      );
     });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    const logs = parseEventLogs({
-      abi: ChannelManagerABI,
-      logs: receipt.logs,
-      eventName: "FeesWithdrawn",
-    });
-
-    assert.ok(logs.length > 0, "FeesWithdrawn event should be found");
   });
-});
 
-describe("updateCommentsContract()", () => {
-  it("updates comments contract", async () => {
-    const newContractAddress = "0x1234567890123456789012345678901234567890";
-    const result = await updateCommentsContract({
-      commentsContract: newContractAddress,
-      writeContract: client.writeContract,
-      channelManagerAddress,
+  describe("getChannelOwner()", () => {
+    let channelId: bigint;
+
+    beforeEach(async () => {
+      const result = await createChannel({
+        name: "Test channel",
+        fee: parseEther("0.02"),
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      const logs = parseEventLogs({
+        abi: ChannelManagerABI,
+        logs: receipt.logs,
+        eventName: "ChannelCreated",
+      });
+
+      assert.ok(logs.length > 0, "ChannelCreated event should be found");
+
+      channelId = logs[0]!.args.channelId;
     });
 
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
+    it("default channel", async () => {
+      const owner = await getChannelOwner({
+        channelId,
+        readContract: client.readContract,
+        channelManagerAddress,
+      });
 
-    assert.equal(receipt.status, "success");
+      assert.deepEqual(owner, { owner: account.address });
+    });
   });
-});
 
-describe("setBaseURI()", () => {
-  it("sets base URI", async () => {
-    const newBaseURI = "https://api.example.com/metadata/";
-    const result = await setBaseURI({
-      baseURI: newBaseURI,
-      writeContract: client.writeContract,
-      channelManagerAddress,
+  describe("updateChannel()", () => {
+    let channelId: bigint;
+
+    beforeEach(async () => {
+      const result = await createChannel({
+        name: "Test channel",
+        fee: parseEther("0.02"),
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      const logs = parseEventLogs({
+        abi: ChannelManagerABI,
+        logs: receipt.logs,
+        eventName: "ChannelCreated",
+      });
+
+      assert.ok(logs.length > 0, "ChannelCreated event should be found");
+
+      channelId = logs[0]!.args.channelId;
     });
 
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
+    it("updates channel", async () => {
+      const result = await updateChannel({
+        channelId,
+        name: "Updated channel",
+        description: "New description",
+        metadata: "New metadata",
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      // Verify the update
+      const channel = await getChannel({
+        channelId,
+        readContract: client.readContract,
+        channelManagerAddress,
+      });
+
+      assert.deepEqual(channel, {
+        name: "Updated channel",
+        description: "New description",
+        metadata: "New metadata",
+        hook: undefined,
+        permissions: {
+          onCommentAdded: false,
+          onCommentDeleted: false,
+          onCommentEdited: false,
+          onInitialized: false,
+          onChannelUpdated: false,
+        },
+      });
+    });
+  });
+
+  describe("setChannelCreationFee()", () => {
+    it("fails if the account is not an owner", async () => {
+      await assert.rejects(
+        () =>
+          setChannelCreationFee({
+            fee: parseEther("0.05"),
+            writeContract: client2.writeContract,
+            channelManagerAddress,
+          }),
+        (err) => {
+          assert.ok(err instanceof ContractFunctionExecutionError);
+          assert.ok(err.message.includes("Error: OwnableUnauthorizedAccount("));
+          return true;
+        },
+      );
     });
 
-    assert.equal(receipt.status, "success");
+    it("sets new fee", async () => {
+      const newFee = parseEther("0.05");
+      const result = await setChannelCreationFee({
+        fee: newFee,
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      // Verify the new fee
+      const fee = await getChannelCreationFee({
+        readContract: client.readContract,
+        channelManagerAddress,
+      });
+
+      assert.deepEqual(fee, { fee: newFee });
+    });
+  });
+
+  describe("withdrawFees()", () => {
+    beforeEach(async () => {
+      // Create a channel to generate some fees
+      await createChannel({
+        name: "Fee generation channel",
+        fee: parseEther("0.02"),
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+    });
+
+    it("withdraws fees", async () => {
+      const result = await withdrawFees({
+        recipient: account.address,
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      const logs = parseEventLogs({
+        abi: ChannelManagerABI,
+        logs: receipt.logs,
+        eventName: "FeesWithdrawn",
+      });
+
+      assert.ok(logs.length > 0, "FeesWithdrawn event should be found");
+    });
+  });
+
+  describe("updateCommentsContract()", () => {
+    it("updates comments contract", async () => {
+      const newContractAddress = "0x1234567890123456789012345678901234567890";
+      const result = await updateCommentsContract({
+        commentsContract: newContractAddress,
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+    });
+  });
+
+  describe("setBaseURI()", () => {
+    it("sets base URI", async () => {
+      const newBaseURI = "https://api.example.com/metadata/";
+      const result = await setBaseURI({
+        baseURI: newBaseURI,
+        writeContract: client.writeContract,
+        channelManagerAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+    });
   });
 });

--- a/packages/sdk/src/comments/test/approval.ts
+++ b/packages/sdk/src/comments/test/approval.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from "node:test";
+import { describe, it, beforeEach, before } from "node:test";
 import assert from "node:assert";
 import {
   createWalletClient,
@@ -26,279 +26,286 @@ import type {
   AddApprovalTypedDataSchemaType,
   RemoveApprovalTypedDataSchemaType,
 } from "../schemas.js";
-const { commentsAddress } = deployContracts();
 
-// Test account setup
-const testPrivateKey =
-  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"; // Anvil's first private key
-const account = privateKeyToAccount(testPrivateKey);
+describe("approval", () => {
+  let commentsAddress: Hex;
 
-const appPrivateKey =
-  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"; // Anvil's second private key
-const app = privateKeyToAccount(appPrivateKey);
-
-// Create wallet client
-const client = createWalletClient({
-  chain: anvil,
-  transport: http("http://localhost:8545"),
-  account,
-}).extend(publicActions);
-
-const appClient = createWalletClient({
-  chain: anvil,
-  transport: http("http://localhost:8545"),
-  account: app,
-}).extend(publicActions);
-
-describe("isApproved()", () => {
-  it("checks if app signer is not approved", async () => {
-    const approved = await isApproved({
-      author: account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
-    });
-
-    assert.equal(
-      approved,
-      false,
-      "app signer should not be approved initially",
-    );
-  });
-});
-
-describe("addApprovalAsAuthor()", () => {
-  it("approves app signer", async () => {
-    const result = await addApprovalAsAuthor({
-      app: app.address,
-      writeContract: client.writeContract,
-      commentsAddress,
-    });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    // Verify approval
-    const approved = await isApproved({
-      author: account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
-    });
-
-    assert.equal(approved, true, "app signer should be approved");
-  });
-});
-
-describe("addApproval()", () => {
-  let authorSignature: Hex;
-  let typedData: AddApprovalTypedDataSchemaType;
-
-  beforeEach(async () => {
-    const nonce = await getNonce({
-      author: client.account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
-    });
-
-    typedData = createApprovalTypedData({
-      author: client.account.address,
-      app: app.address,
-      nonce,
-      commentsAddress,
-      chainId: anvil.id,
-    });
-
-    authorSignature = await client.signTypedData(typedData);
+  before(async () => {
+    commentsAddress = deployContracts().commentsAddress;
   });
 
-  it("adds approval with signature", async () => {
-    const result = await addApproval({
-      typedData,
-      signature: authorSignature,
-      writeContract: appClient.writeContract,
-      commentsAddress,
-    });
+  // Test account setup
+  const testPrivateKey =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"; // Anvil's first private key
+  const account = privateKeyToAccount(testPrivateKey);
 
-    const receipt = await appClient.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
+  const appPrivateKey =
+    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"; // Anvil's second private key
+  const app = privateKeyToAccount(appPrivateKey);
 
-    assert.equal(receipt.status, "success");
+  // Create wallet client
+  const client = createWalletClient({
+    chain: anvil,
+    transport: http("http://localhost:8545"),
+    account,
+  }).extend(publicActions);
 
-    const approved = await isApproved({
-      author: account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
-    });
+  const appClient = createWalletClient({
+    chain: anvil,
+    transport: http("http://localhost:8545"),
+    account: app,
+  }).extend(publicActions);
 
-    assert.equal(approved, true, "app signer should be approved");
-  });
+  describe("isApproved()", () => {
+    it("checks if app signer is not approved", async () => {
+      const approved = await isApproved({
+        author: account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
 
-  it("fails with invalid signature", async () => {
-    await assert.rejects(
-      () =>
-        addApproval({
-          typedData,
-          signature: "0x1234", // Invalid signature
-          writeContract: client.writeContract,
-          commentsAddress,
-        }),
-      (err) => {
-        assert.ok(err instanceof ContractFunctionExecutionError);
-        return true;
-      },
-    );
-  });
-});
-
-describe("revokeApprovalAsAuthor()", () => {
-  beforeEach(async () => {
-    // First approve the app signer
-    const result = await addApprovalAsAuthor({
-      app: app.address,
-      writeContract: client.writeContract,
-      commentsAddress,
-    });
-
-    await client.waitForTransactionReceipt({
-      hash: result.txHash,
+      assert.equal(
+        approved,
+        false,
+        "app signer should not be approved initially",
+      );
     });
   });
 
-  it("revokes approval", async () => {
-    const result = await revokeApprovalAsAuthor({
-      app: app.address,
-      writeContract: client.writeContract,
-      commentsAddress,
+  describe("addApprovalAsAuthor()", () => {
+    it("approves app signer", async () => {
+      const result = await addApprovalAsAuthor({
+        app: app.address,
+        writeContract: client.writeContract,
+        commentsAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      // Verify approval
+      const approved = await isApproved({
+        author: account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      assert.equal(approved, true, "app signer should be approved");
     });
-
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    assert.equal(receipt.status, "success");
-
-    // Verify approval is revoked
-    const approved = await isApproved({
-      author: account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
-    });
-
-    assert.equal(approved, false, "app signer should not be approved");
-  });
-});
-
-describe("revokeApproval()", () => {
-  let signature: Hex;
-  let typedData: RemoveApprovalTypedDataSchemaType;
-
-  beforeEach(async () => {
-    const result = await addApprovalAsAuthor({
-      app: app.address,
-      writeContract: client.writeContract,
-      commentsAddress,
-    });
-
-    await client.waitForTransactionReceipt({
-      hash: result.txHash,
-    });
-
-    const nonce = await getNonce({
-      author: client.account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
-    });
-
-    typedData = createRemoveApprovalTypedData({
-      author: client.account.address,
-      app: app.address,
-      nonce,
-      commentsAddress,
-      chainId: anvil.id,
-    });
-
-    signature = await client.signTypedData(typedData);
   });
 
-  it("revokes approval with signature", async () => {
-    const result = await revokeApproval({
-      typedData,
-      signature,
-      writeContract: client.writeContract,
-      commentsAddress,
+  describe("addApproval()", () => {
+    let authorSignature: Hex;
+    let typedData: AddApprovalTypedDataSchemaType;
+
+    beforeEach(async () => {
+      const nonce = await getNonce({
+        author: client.account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      typedData = createApprovalTypedData({
+        author: client.account.address,
+        app: app.address,
+        nonce,
+        commentsAddress,
+        chainId: anvil.id,
+      });
+
+      authorSignature = await client.signTypedData(typedData);
     });
 
-    const receipt = await client.waitForTransactionReceipt({
-      hash: result.txHash,
+    it("adds approval with signature", async () => {
+      const result = await addApproval({
+        typedData,
+        signature: authorSignature,
+        writeContract: appClient.writeContract,
+        commentsAddress,
+      });
+
+      const receipt = await appClient.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      const approved = await isApproved({
+        author: account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      assert.equal(approved, true, "app signer should be approved");
     });
 
-    assert.equal(receipt.status, "success");
-
-    // Verify approval is revoked
-    const approved = await isApproved({
-      author: account.address,
-      app: app.address,
-      readContract: client.readContract,
-      commentsAddress,
+    it("fails with invalid signature", async () => {
+      await assert.rejects(
+        () =>
+          addApproval({
+            typedData,
+            signature: "0x1234", // Invalid signature
+            writeContract: client.writeContract,
+            commentsAddress,
+          }),
+        (err) => {
+          assert.ok(err instanceof ContractFunctionExecutionError);
+          return true;
+        },
+      );
     });
-
-    assert.equal(approved, false, "app signer should not be approved");
   });
 
-  it("fails with invalid signature", async () => {
-    await assert.rejects(
-      () =>
-        revokeApproval({
-          typedData,
-          signature: "0x1234", // Invalid signature
-          writeContract: client.writeContract,
-          commentsAddress,
-        }),
-      (err) => {
-        assert.ok(err instanceof ContractFunctionExecutionError);
-        return true;
-      },
-    );
-  });
-});
+  describe("revokeApprovalAsAuthor()", () => {
+    beforeEach(async () => {
+      // First approve the app signer
+      const result = await addApprovalAsAuthor({
+        app: app.address,
+        writeContract: client.writeContract,
+        commentsAddress,
+      });
 
-describe("getAddApprovalHash()", () => {
-  it("returns hash for approval", async () => {
-    const result = await getAddApprovalHash({
-      author: account.address,
-      app: app.address,
-      nonce: 0n,
-      deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
-      readContract: client.readContract,
-      commentsAddress,
+      await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
     });
 
-    assert.ok(result.hash.startsWith("0x"), "should return a hex string");
-    assert.equal(result.hash.length, 66, "should be 32 bytes + 0x prefix");
-  });
-});
+    it("revokes approval", async () => {
+      const result = await revokeApprovalAsAuthor({
+        app: app.address,
+        writeContract: client.writeContract,
+        commentsAddress,
+      });
 
-describe("getRemoveApprovalHash()", () => {
-  it("returns hash for removal", async () => {
-    const result = await getRemoveApprovalHash({
-      author: account.address,
-      app: app.address,
-      nonce: 0n,
-      deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
-      readContract: client.readContract,
-      commentsAddress,
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      // Verify approval is revoked
+      const approved = await isApproved({
+        author: account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      assert.equal(approved, false, "app signer should not be approved");
+    });
+  });
+
+  describe("revokeApproval()", () => {
+    let signature: Hex;
+    let typedData: RemoveApprovalTypedDataSchemaType;
+
+    beforeEach(async () => {
+      const result = await addApprovalAsAuthor({
+        app: app.address,
+        writeContract: client.writeContract,
+        commentsAddress,
+      });
+
+      await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      const nonce = await getNonce({
+        author: client.account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      typedData = createRemoveApprovalTypedData({
+        author: client.account.address,
+        app: app.address,
+        nonce,
+        commentsAddress,
+        chainId: anvil.id,
+      });
+
+      signature = await client.signTypedData(typedData);
     });
 
-    assert.ok(result.hash.startsWith("0x"), "should return a hex string");
-    assert.equal(result.hash.length, 66, "should be 32 bytes + 0x prefix");
+    it("revokes approval with signature", async () => {
+      const result = await revokeApproval({
+        typedData,
+        signature,
+        writeContract: client.writeContract,
+        commentsAddress,
+      });
+
+      const receipt = await client.waitForTransactionReceipt({
+        hash: result.txHash,
+      });
+
+      assert.equal(receipt.status, "success");
+
+      // Verify approval is revoked
+      const approved = await isApproved({
+        author: account.address,
+        app: app.address,
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      assert.equal(approved, false, "app signer should not be approved");
+    });
+
+    it("fails with invalid signature", async () => {
+      await assert.rejects(
+        () =>
+          revokeApproval({
+            typedData,
+            signature: "0x1234", // Invalid signature
+            writeContract: client.writeContract,
+            commentsAddress,
+          }),
+        (err) => {
+          assert.ok(err instanceof ContractFunctionExecutionError);
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("getAddApprovalHash()", () => {
+    it("returns hash for approval", async () => {
+      const result = await getAddApprovalHash({
+        author: account.address,
+        app: app.address,
+        nonce: 0n,
+        deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      assert.ok(result.hash.startsWith("0x"), "should return a hex string");
+      assert.equal(result.hash.length, 66, "should be 32 bytes + 0x prefix");
+    });
+  });
+
+  describe("getRemoveApprovalHash()", () => {
+    it("returns hash for removal", async () => {
+      const result = await getRemoveApprovalHash({
+        author: account.address,
+        app: app.address,
+        nonce: 0n,
+        deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+        readContract: client.readContract,
+        commentsAddress,
+      });
+
+      assert.ok(result.hash.startsWith("0x"), "should return a hex string");
+      assert.equal(result.hash.length, 66, "should be 32 bytes + 0x prefix");
+    });
   });
 });


### PR DESCRIPTION
calling deployContract at module level causes:
1. slow start of the tests
2. when some tests are skipped, the corresponding contract deployment still gets executed

Set the `testMatchPattern` to `postComment`, before the PR changes:

```
Anvil node started
✔ scripts/test-helpers.ts (87.933167ms)
✔ src/channel-manager/test/channel.ts (6145.178042ms)
✔ src/channel-manager/test/hook.ts (5867.244708ms)
✔ src/comments/test/approval.ts (5999.773708ms)
▶ postComment()
  ✔ posts a comment as author (4058.779542ms)
✔ postComment() (4059.375042ms)
▶ postCommentWithApproval()
  ✔ posts a comment with signatures (8040.014625ms)
  ✔ posts a comment with author signature when no approval exists (12092.752833ms)
  ✔ fails with invalid app signature (4040.680958ms)
✔ postCommentWithApproval() (24173.916791ms)
Killing anvil node
```

after the changes we can see skipped test does not slow down anymore:

```
Anvil node started
✔ scripts/test-helpers.ts (93.61175ms)
✔ src/channel-manager/test/channel.ts (354.976417ms)
✔ src/channel-manager/test/hook.ts (358.831709ms)
✔ src/comments/test/approval.ts (398.5975ms)
▶ comment
  ▶ postComment()
    ✔ posts a comment as author (4073.473958ms)
  ✔ postComment() (4074.091417ms)
  ▶ postCommentWithApproval()
    ✔ posts a comment with signatures (8048.794459ms)
    ✔ posts a comment with author signature when no approval exists (12091.205958ms)
    ✔ fails with invalid app signature (4023.271375ms)
  ✔ postCommentWithApproval() (24163.68125ms)
✔ comment (33793.250083ms)
Killing anvil node
```