### PR TITLE
WIP: refactor(protocol): use modifier and remove non-sig methods

### DIFF
--- a/packages/protocol/src/interfaces/ICommentManager.sol
+++ b/packages/protocol/src/interfaces/ICommentManager.sol
@@ -111,27 +111,15 @@ interface ICommentManager {
   /// @notice Error thrown when comment does not exist
   error CommentDoesNotExist();
 
-  /// @notice Posts a comment directly from the author's address
-  /// @param commentData The comment data struct containing content and metadata
-  /// @param appSignature Signature from the app signer authorizing the comment
-  function postComment(
-    Comments.CreateComment calldata commentData,
-    bytes calldata appSignature
-  ) external payable;
-
   /// @notice Posts a comment with both author and app signer signatures
   /// @param commentData The comment data struct containing content and metadata
   /// @param authorSignature Signature from the author authorizing the comment
   /// @param appSignature Signature from the app signer authorizing the comment
-  function postCommentWithSig(
+  function postComment(
     Comments.CreateComment calldata commentData,
     bytes calldata authorSignature,
     bytes calldata appSignature
   ) external payable;
-
-  /// @notice Deletes a comment when called by the author directly
-  /// @param commentId The unique identifier of the comment to delete
-  function deleteComment(bytes32 commentId) external;
 
   /// @notice Deletes a comment with author signature verification
   /// @param commentId The unique identifier of the comment to delete
@@ -139,7 +127,7 @@ interface ICommentManager {
   /// @param deadline Timestamp after which the signature becomes invalid
   /// @param authorSignature The signature from the author authorizing deletion (empty if app)
   /// @param appSignature The signature from the app signer authorizing deletion (empty if author)
-  function deleteCommentWithSig(
+  function deleteComment(
     bytes32 commentId,
     address app,
     uint256 deadline,
@@ -147,22 +135,12 @@ interface ICommentManager {
     bytes calldata appSignature
   ) external;
 
-  /// @notice Edits a comment when called by the author directly
-  /// @param commentId The unique identifier of the comment to edit
-  /// @param editData The comment data struct containing content and metadata
-  /// @param appSignature The signature from the app signer authorizing the edit
-  function editComment(
-    bytes32 commentId,
-    Comments.EditComment calldata editData,
-    bytes calldata appSignature
-  ) external payable;
-
   /// @notice Edits a comment with both author and app signer signatures
   /// @param commentId The unique identifier of the comment to edit
   /// @param editData The comment data struct containing content and metadata
   /// @param authorSignature The signature from the author authorizing the edit (empty if app)
   /// @param appSignature The signature from the app signer authorizing the edit (empty if author)
-  function editCommentWithSig(
+  function editComment(
     bytes32 commentId,
     Comments.EditComment calldata editData,
     bytes calldata authorSignature,


### PR DESCRIPTION
In this PR:

1. removes non-sig methods
2. I know we are not suppose to refactor the code, but to replace `deleteComment` with `deleteCommentWithSig` I had to change the code slightly to make it gas efficient when it was broadcasted by the app or the user
3. use modifier whenever it can (`guardDeadline` is turned into modifier `notStale`), for the other guard methods, they cannot be turned into modifiers because:
    1. they are be used after a condition, applying them as modifier means they will always run, cost more gas
    2. they require access to SSTORE data.

Do we need to remove the non-sig method for add approvals? @davidfurlong 
I am still working on tests.