### PR TITLE
docs: update network from Monad testnet to Base Sepolia

### DIFF
--- a/docs/pages/contracts.mdx
+++ b/docs/pages/contracts.mdx
@@ -26,7 +26,7 @@ For detailed information about all functions, events, and structs, please refer 
 
 - **Contract Address:** `%CHANNEL_MANAGER_ADDRESS`
 - **Networks:**
-  - [Monad testnet](https://monad-testnet.socialscan.io/address/%CHANNEL_MANAGER_ADDRESS)
+  - [Base Sepolia](https://sepolia.basescan.org/address/%CHANNEL_MANAGER_ADDRESS)
 - **Contract ABI:** [View ABI Documentation](/protocol-reference/ChannelManager)
 
 ### ChannelManager Contract Functions


### PR DESCRIPTION
## Summary
- Update contract deployment reference in docs from Monad testnet to Base Sepolia

## Test plan
- Verify the documentation shows Base Sepolia instead of Monad testnet

🤖 Generated with [Claude Code](https://claude.ai/code)