### PR TITLE
fix: don't disable buttons on empty text

### DIFF
--- a/apps/demo/src/components/comments/core/CommentForm.tsx
+++ b/apps/demo/src/components/comments/core/CommentForm.tsx
@@ -108,8 +108,6 @@ function BaseCommentForm({
   }, [submitMutation.error]);
 
   const isSubmitting = submitMutation.isPending;
-  const trimmedContent = content.trim();
-  const isContentValid = trimmedContent.length > 0;
 
   return (
     <form

--- a/apps/embed/src/components/comments/CommentForm.tsx
+++ b/apps/embed/src/components/comments/CommentForm.tsx
@@ -125,9 +125,6 @@ function BaseCommentForm({
   }, [submitMutation.error]);
 
   const isSubmitting = submitMutation.isPending;
-  const trimmedContent = content.trim();
-  const isContentValid =
-    trimmedContent.length > 0 && trimmedContent.length <= MAX_COMMENT_LENGTH;
 
   return (
     <form


### PR DESCRIPTION
## Summary
- Removes `isContentValid` validation from submit button to allow submitting empty comments
- Server-side validation will handle empty content if needed

## Test plan
- Test submitting empty comments in both demo and embed apps
- Verify that any server-side validation still correctly handles empty content

🤖 Generated with [Claude Code](https://claude.ai/code)