### PR TITLE
chore(sdk): metadata no need to be optional in based type

### DIFF
--- a/packages/sdk/src/comments/schemas.ts
+++ b/packages/sdk/src/comments/schemas.ts
@@ -10,7 +10,6 @@ import type {
   CommentData,
   CreateReplyCommentDataParams,
   CreateRootCommentDataParams,
-  MetadataEntry,
   Json,
   JsonObject,
 } from "./types.js";
@@ -90,10 +89,9 @@ export const RootCommentInputDataSchema = BaseCommentInputDataSchema.omit({
 });
 
 // this just tests if the shape is correct
-({}) as z.infer<typeof RootCommentInputDataSchema> satisfies Omit<
-  CreateRootCommentDataParams,
-  "metadata"
-> & { metadata: MetadataEntry[] };
+({}) as z.infer<
+  typeof RootCommentInputDataSchema
+> satisfies CreateRootCommentDataParams;
 
 export const ReplyCommentInputDataSchema = BaseCommentInputDataSchema.omit({
   targetUri: true,
@@ -102,10 +100,9 @@ export const ReplyCommentInputDataSchema = BaseCommentInputDataSchema.omit({
 });
 
 // this just tests if the shape is correct
-({}) as z.infer<typeof ReplyCommentInputDataSchema> satisfies Omit<
-  CreateReplyCommentDataParams,
-  "metadata"
-> & { metadata: MetadataEntry[] };
+({}) as z.infer<
+  typeof ReplyCommentInputDataSchema
+> satisfies CreateReplyCommentDataParams;
 
 /**
  * Comment input data schema. This is used as input of the functions.

--- a/packages/sdk/src/comments/types.ts
+++ b/packages/sdk/src/comments/types.ts
@@ -50,7 +50,7 @@ export type CreateCommentDataParamsShared = {
    */
   commentType?: number;
   /** Metadata about the comment as key-value pairs */
-  metadata?: MetadataEntry[];
+  metadata: MetadataEntry[];
   /** The address of the author of the comment */
   author: Hex;
   /** The address of the app signer */


### PR DESCRIPTION
@michalkvasnicak why did we set metadata optional in the based type then add it back with mandatory?