### PR TITLE
chore: stop coderabbit on WIP or draft PR

### DIFF
--- a/. coderabbit.yaml
+++ b/. coderabbit.yaml
@@ -1,0 +1,2 @@
+ignored_titles: "WIP"
+ignore_draft_pr: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new configuration file to improve handling of pull requests by ignoring those marked as "WIP" or drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->