### PR TITLE
fix(indexer): ignore transfer on channel created and log warning

### DIFF
--- a/apps/indexer/src/indexing/channels.ts
+++ b/apps/indexer/src/indexing/channels.ts
@@ -93,6 +93,24 @@ export function initializeChannelEventsIndexing(ponder: typeof Ponder) {
   );
 
   ponder.on("CommentsV1ChannelManager:Transfer", async ({ event, context }) => {
+    const channel = await context.db.find(schema.channel, {
+      id: event.args.tokenId,
+    });
+
+    if (!channel) {
+      Sentry.captureMessage(
+        `Channel not found when transferring ownership (probably freshly created channel)`,
+        {
+          level: "warning",
+          extra: {
+            tokenId: event.args.tokenId,
+          },
+        },
+      );
+
+      return;
+    }
+
     await context.db
       .update(schema.channel, {
         id: event.args.tokenId,


### PR DESCRIPTION
This PR fixes an issue when indexing Transfer event on freshly created channel.

This is caused by protocol which first mints the channel (emitting Transfer) and then emitting `ChannelCreated` event.

The issue is happening only when channel is created. Later `Transfer` events will properly change the `owner`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of channel ownership transfers by ensuring updates only occur for existing channels, with warnings sent if a channel is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->