### PR TITLE
fix: add comment type to signer

### DIFF
--- a/.changeset/large-ends-run.md
+++ b/.changeset/large-ends-run.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+chore(sdk): export CommentType schema

--- a/apps/signer/src/app/api/post-comment/gasless/prepare/route.ts
+++ b/apps/signer/src/app/api/post-comment/gasless/prepare/route.ts
@@ -50,8 +50,14 @@ export async function POST(
     }
 
     const passedCommentData = parsedBodyResult.data;
-    const { content, author, metadata, chainConfig, submitIfApproved } =
-      passedCommentData;
+    const {
+      content,
+      author,
+      metadata,
+      chainConfig,
+      submitIfApproved,
+      commentType,
+    } = passedCommentData;
 
     if (env.COMMENTS_INDEXER_URL) {
       if (
@@ -80,6 +86,7 @@ export async function POST(
             targetUri: passedCommentData.targetUri,
           }),
       metadata,
+      commentType,
     });
 
     const typedCommentData = createCommentTypedData({

--- a/apps/signer/src/app/api/post-comment/sign/route.ts
+++ b/apps/signer/src/app/api/post-comment/sign/route.ts
@@ -48,7 +48,8 @@ export async function POST(
     }
 
     const passedCommentData = parsedBodyResult.data;
-    const { content, author, metadata, chainConfig } = passedCommentData;
+    const { content, author, metadata, chainConfig, commentType } =
+      passedCommentData;
 
     // Check if author is muted (if indexer URL is configured)
     if (env.COMMENTS_INDEXER_URL) {
@@ -79,6 +80,7 @@ export async function POST(
         : {
             targetUri: passedCommentData.targetUri,
           }),
+      commentType,
     });
 
     const typedCommentData = createCommentTypedData({

--- a/apps/signer/src/lib/schemas.ts
+++ b/apps/signer/src/lib/schemas.ts
@@ -4,6 +4,7 @@ import {
   DeleteCommentTypedDataSchema,
   EditCommentDataSchema,
   EditCommentTypedDataSchema,
+  CommentTypeSchema,
   MetadataArraySchema,
 } from "@ecp.eth/sdk/comments/schemas";
 import { CommentDataWithIdSchema } from "@ecp.eth/shared/schemas";
@@ -35,6 +36,7 @@ const sharedCommentSchema = z.object({
   content: z.string().trim().nonempty(),
   metadata: MetadataArraySchema,
   chainId: AllowedChainIdSchema.default(env.DEFAULT_CHAIN_ID),
+  commentType: CommentTypeSchema.optional(),
 });
 
 // Request schema for standard signing

--- a/docs/pages/sdk-reference/comments/index.mdx
+++ b/docs/pages/sdk-reference/comments/index.mdx
@@ -30,6 +30,7 @@ Core functionality for managing comments and approvals
 | [CommentData](/sdk-reference/comments/type-aliases/CommentData.mdx) | The data structure of a comment returned by the contract |
 | [CommentInputData](/sdk-reference/comments/type-aliases/CommentInputData.mdx) | Comment input data schema. This is used as input of the functions. |
 | [CommentManagerABIType](/sdk-reference/comments/type-aliases/CommentManagerABIType.mdx) | - |
+| [CommentTypeSchemaType](/sdk-reference/comments/type-aliases/CommentTypeSchemaType.mdx) | - |
 | [ContractReadFunctions](/sdk-reference/comments/type-aliases/ContractReadFunctions.mdx) | - |
 | [ContractWriteFunctions](/sdk-reference/comments/type-aliases/ContractWriteFunctions.mdx) | - |
 | [CreateApprovalTypedDataParams](/sdk-reference/comments/type-aliases/CreateApprovalTypedDataParams.mdx) | - |
@@ -103,6 +104,7 @@ Core functionality for managing comments and approvals
 | [AddCommentTypedDataSchema](/sdk-reference/comments/variables/AddCommentTypedDataSchema.mdx) | - |
 | [CommentDataSchema](/sdk-reference/comments/variables/CommentDataSchema.mdx) | - |
 | [CommentInputDataSchema](/sdk-reference/comments/variables/CommentInputDataSchema.mdx) | Comment input data schema. This is used as input of the functions. |
+| [CommentTypeSchema](/sdk-reference/comments/variables/CommentTypeSchema.mdx) | - |
 | [CreateCommentDataSchema](/sdk-reference/comments/variables/CreateCommentDataSchema.mdx) | - |
 | [DELETE\_COMMENT\_TYPE](/sdk-reference/comments/variables/DELETE_COMMENT_TYPE.mdx) | - |
 | [deleteComment](/sdk-reference/comments/variables/deleteComment.mdx) | Delete a comment as an author |

--- a/docs/pages/sdk-reference/comments/type-aliases/AddApprovalTypedDataSchemaType.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/AddApprovalTypedDataSchemaType.mdx
@@ -48,7 +48,7 @@ type AddApprovalTypedDataSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:292](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L292)
+Defined in: [packages/sdk/src/comments/schemas.ts:296](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L296)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/comments/type-aliases/AddCommentTypedDataSchemaType.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/AddCommentTypedDataSchemaType.mdx
@@ -94,7 +94,7 @@ type AddCommentTypedDataSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:185](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L185)
+Defined in: [packages/sdk/src/comments/schemas.ts:189](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L189)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/comments/type-aliases/CommentInputData.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CommentInputData.mdx
@@ -38,7 +38,7 @@ type CommentInputData =
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:131](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L131)
+Defined in: [packages/sdk/src/comments/schemas.ts:135](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L135)
 
 Comment input data schema. This is used as input of the functions.
 

--- a/docs/pages/sdk-reference/comments/type-aliases/CommentTypeSchemaType.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CommentTypeSchemaType.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [comments](/sdk-reference/comments/index.mdx) / CommentTypeSchemaType
+
+# Type Alias: CommentTypeSchemaType
+
+```ts
+type CommentTypeSchemaType = number;
+```
+
+Defined in: [packages/sdk/src/comments/schemas.ts:21](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L21)

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateCommentData.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateCommentData.mdx
@@ -23,7 +23,7 @@ type CreateCommentData = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:79](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L79)
+Defined in: [packages/sdk/src/comments/schemas.ts:83](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L83)
 
 ## Type declaration
 
@@ -48,7 +48,7 @@ channelId: bigint;
 ### commentType
 
 ```ts
-commentType: number;
+commentType: number = CommentTypeSchema;
 ```
 
 ### content

--- a/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentTypedDataSchemaType.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentTypedDataSchemaType.mdx
@@ -43,7 +43,7 @@ type DeleteCommentTypedDataSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:215](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L215)
+Defined in: [packages/sdk/src/comments/schemas.ts:219](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L219)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentData.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentData.mdx
@@ -20,7 +20,7 @@ type EditCommentData = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:148](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L148)
+Defined in: [packages/sdk/src/comments/schemas.ts:152](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L152)
 
 Edit comment data schema. This is used as input of the functions.
 

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentTypedDataSchemaType.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentTypedDataSchemaType.mdx
@@ -70,7 +70,7 @@ type EditCommentTypedDataSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:260](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L260)
+Defined in: [packages/sdk/src/comments/schemas.ts:264](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L264)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/comments/type-aliases/RemoveApprovalTypedDataSchemaType.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/RemoveApprovalTypedDataSchemaType.mdx
@@ -43,7 +43,7 @@ type RemoveApprovalTypedDataSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:322](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L322)
+Defined in: [packages/sdk/src/comments/schemas.ts:326](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L326)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/comments/variables/AddApprovalTypedDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/AddApprovalTypedDataSchema.mdx
@@ -10,4 +10,4 @@
 const AddApprovalTypedDataSchema: ZodObject<AddApprovalTypedDataSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:264](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L264)
+Defined in: [packages/sdk/src/comments/schemas.ts:268](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L268)

--- a/docs/pages/sdk-reference/comments/variables/AddCommentTypedDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/AddCommentTypedDataSchema.mdx
@@ -10,4 +10,4 @@
 const AddCommentTypedDataSchema: ZodObject<AddCommentTypedDataSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:150](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L150)
+Defined in: [packages/sdk/src/comments/schemas.ts:154](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L154)

--- a/docs/pages/sdk-reference/comments/variables/CommentDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/CommentDataSchema.mdx
@@ -61,4 +61,4 @@ const CommentDataSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:50](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L50)
+Defined in: [packages/sdk/src/comments/schemas.ts:54](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L54)

--- a/docs/pages/sdk-reference/comments/variables/CommentInputDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/CommentInputDataSchema.mdx
@@ -10,7 +10,7 @@
 const CommentInputDataSchema: ZodUnion<CommentInputData>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:126](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L126)
+Defined in: [packages/sdk/src/comments/schemas.ts:130](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L130)
 
 Comment input data schema. This is used as input of the functions.
 

--- a/docs/pages/sdk-reference/comments/variables/CommentTypeSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/CommentTypeSchema.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [comments](/sdk-reference/comments/index.mdx) / CommentTypeSchema
+
+# Variable: CommentTypeSchema
+
+```ts
+const CommentTypeSchema: ZodNumber<CommentTypeSchemaType>;
+```
+
+Defined in: [packages/sdk/src/comments/schemas.ts:19](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L19)

--- a/docs/pages/sdk-reference/comments/variables/CreateCommentDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/CreateCommentDataSchema.mdx
@@ -10,4 +10,4 @@
 const CreateCommentDataSchema: ZodObject<CreateCommentData>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:70](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L70)
+Defined in: [packages/sdk/src/comments/schemas.ts:74](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L74)

--- a/docs/pages/sdk-reference/comments/variables/DeleteCommentTypedDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/DeleteCommentTypedDataSchema.mdx
@@ -10,4 +10,4 @@
 const DeleteCommentTypedDataSchema: ZodObject<DeleteCommentTypedDataSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:189](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L189)
+Defined in: [packages/sdk/src/comments/schemas.ts:193](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L193)

--- a/docs/pages/sdk-reference/comments/variables/EditCommentDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/EditCommentDataSchema.mdx
@@ -10,6 +10,6 @@
 const EditCommentDataSchema: ZodObject<EditCommentData>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:139](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L139)
+Defined in: [packages/sdk/src/comments/schemas.ts:143](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L143)
 
 Edit comment data schema. This is used as input of the functions.

--- a/docs/pages/sdk-reference/comments/variables/EditCommentTypedDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/EditCommentTypedDataSchema.mdx
@@ -10,4 +10,4 @@
 const EditCommentTypedDataSchema: ZodObject<EditCommentTypedDataSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:219](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L219)
+Defined in: [packages/sdk/src/comments/schemas.ts:223](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L223)

--- a/docs/pages/sdk-reference/comments/variables/JsonLiteralSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/JsonLiteralSchema.mdx
@@ -10,4 +10,4 @@
 const JsonLiteralSchema: ZodUnion<[ZodString, ZodNumber, ZodBoolean, ZodNull]>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:19](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L19)
+Defined in: [packages/sdk/src/comments/schemas.ts:23](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L23)

--- a/docs/pages/sdk-reference/comments/variables/JsonObjectSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/JsonObjectSchema.mdx
@@ -10,4 +10,4 @@
 const JsonObjectSchema: z.ZodType<JsonObject>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:30](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L30)
+Defined in: [packages/sdk/src/comments/schemas.ts:34](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L34)

--- a/docs/pages/sdk-reference/comments/variables/JsonSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/JsonSchema.mdx
@@ -10,4 +10,4 @@
 const JsonSchema: z.ZodType<Json>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:26](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L26)
+Defined in: [packages/sdk/src/comments/schemas.ts:30](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L30)

--- a/docs/pages/sdk-reference/comments/variables/MetadataArrayOpSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/MetadataArrayOpSchema.mdx
@@ -22,4 +22,4 @@ const MetadataArrayOpSchema: ZodArray<ZodObject<{
 }>, "many">;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:48](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L48)
+Defined in: [packages/sdk/src/comments/schemas.ts:52](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L52)

--- a/docs/pages/sdk-reference/comments/variables/MetadataArraySchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/MetadataArraySchema.mdx
@@ -19,4 +19,4 @@ const MetadataArraySchema: ZodArray<ZodObject<{
 }>, "many">;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:40](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L40)
+Defined in: [packages/sdk/src/comments/schemas.ts:44](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L44)

--- a/docs/pages/sdk-reference/comments/variables/MetadataEntryOpSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/MetadataEntryOpSchema.mdx
@@ -22,4 +22,4 @@ const MetadataEntryOpSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:42](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L42)
+Defined in: [packages/sdk/src/comments/schemas.ts:46](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L46)

--- a/docs/pages/sdk-reference/comments/variables/MetadataEntrySchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/MetadataEntrySchema.mdx
@@ -19,4 +19,4 @@ const MetadataEntrySchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:35](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L35)
+Defined in: [packages/sdk/src/comments/schemas.ts:39](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L39)

--- a/docs/pages/sdk-reference/comments/variables/RemoveApprovalTypedDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/RemoveApprovalTypedDataSchema.mdx
@@ -10,4 +10,4 @@
 const RemoveApprovalTypedDataSchema: ZodObject<RemoveApprovalTypedDataSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:296](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L296)
+Defined in: [packages/sdk/src/comments/schemas.ts:300](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L300)

--- a/docs/pages/sdk-reference/comments/variables/ReplyCommentInputDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/ReplyCommentInputDataSchema.mdx
@@ -57,4 +57,4 @@ const ReplyCommentInputDataSchema: ZodObject<Omit<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:109](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L109)
+Defined in: [packages/sdk/src/comments/schemas.ts:113](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L113)

--- a/docs/pages/sdk-reference/comments/variables/RootCommentInputDataSchema.mdx
+++ b/docs/pages/sdk-reference/comments/variables/RootCommentInputDataSchema.mdx
@@ -58,4 +58,4 @@ const RootCommentInputDataSchema: ZodObject<Omit<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/comments/schemas.ts:95](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L95)
+Defined in: [packages/sdk/src/comments/schemas.ts:99](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/schemas.ts#L99)

--- a/packages/sdk/src/comments/schemas.ts
+++ b/packages/sdk/src/comments/schemas.ts
@@ -16,6 +16,10 @@ import type {
   JsonObject,
 } from "./types.js";
 
+export const CommentTypeSchema = z.number().int().min(0).max(255);
+
+export type CommentTypeSchemaType = z.infer<typeof CommentTypeSchema>;
+
 export const JsonLiteralSchema = z.union([
   z.string(),
   z.number(),
@@ -56,7 +60,7 @@ export const CommentDataSchema = z.object({
 
   content: z.string(),
   targetUri: z.string(),
-  commentType: z.number(),
+  commentType: CommentTypeSchema,
   authMethod: z.nativeEnum(AuthorAuthMethod),
   metadata: MetadataArraySchema.default([]),
 
@@ -89,7 +93,7 @@ const BaseCommentInputDataSchema = z.object({
   content: z.string(),
   metadata: MetadataArraySchema.default([]),
   targetUri: z.string(),
-  commentType: z.number().int().min(0).max(255).default(DEFAULT_COMMENT_TYPE),
+  commentType: CommentTypeSchema.default(DEFAULT_COMMENT_TYPE),
 });
 
 export const RootCommentInputDataSchema = BaseCommentInputDataSchema.omit({


### PR DESCRIPTION
https://linear.app/modprotocol/issue/ECP-1356/add-comment-type-to-signer-app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional comment type field when creating or signing comments.
- **Documentation**
  - Expanded SDK reference documentation to include details on the new comment type schema and related type aliases.
  - Updated documentation links to reflect new source code locations and schema associations.
- **Chores**
  - Improved schema reusability and maintainability for comment types in the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->