### PR TITLE
fix: error on wallet connected

### DIFF
--- a/apps/demo/src/components/comments/core/CommentForm.tsx
+++ b/apps/demo/src/components/comments/core/CommentForm.tsx
@@ -105,6 +105,7 @@ function BaseCommentForm({
   const connectAccount = useConnectAccount();
   const editorRef = useRef<EditorRef>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const onSubmitRef = useFreshRef(onSubmit);
   const onSubmitSuccessRef = useFreshRef(onSubmitSuccess);
   const uploads = usePinataUploadFiles({
     allowedMimeTypes: ALLOWED_UPLOAD_MIME_TYPES,
@@ -135,6 +136,11 @@ function BaseCommentForm({
     mutationFn: async (formData: FormData): Promise<void> => {
       try {
         const author = await connectAccount();
+
+        if (!author) {
+          throw new Error("Author not found");
+        }
+
         const submitAction = formData.get("action") as "post";
 
         setFormState(submitAction);
@@ -168,7 +174,11 @@ function BaseCommentForm({
             }),
           );
 
-        const result = await onSubmit({ author, content, references });
+        const result = await onSubmitRef.current({
+          author,
+          content,
+          references,
+        });
 
         return result;
       } catch (e) {


### PR DESCRIPTION
fix https://linear.app/modprotocol/issue/ECP-1388/fixdemo-it-shows-wallet-not-connected-when-wallet-connected

the reason is the `CommentForm.tsx` caches old `onSubmit` prop when is a reference to old `postComment` function which caches the `conntectedAddress` variable before wallet connected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of form submission by ensuring the latest callback is always used.
  * Added a check to prevent comment submission if the author is not connected, providing clearer error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->