### PR TITLE
feat(indexer): allow to change moderation status

### DIFF
--- a/apps/indexer/bin/admin.js
+++ b/apps/indexer/bin/admin.js
@@ -10,6 +10,7 @@ import { randomBytes } from "crypto";
 import { getPublicKeyAsync, signAsync, utils } from "@noble/ed25519";
 import pg from "pg";
 import { z } from "zod";
+import { renderToMarkdown } from "@ecp.eth/shared/renderer";
 
 const HexSchema = z.string().regex(/^0x[0-9a-fA-F]+$/);
 
@@ -424,7 +425,12 @@ moderateComments
         ]);
 
         console.log("Content----------");
-        console.log(comment.content);
+        console.log(
+          renderToMarkdown({
+            content: comment.content,
+            references: comment.references,
+          }).result,
+        );
         console.log("----------");
         console.groupEnd();
       }

--- a/apps/indexer/src/api/webhook/post.ts
+++ b/apps/indexer/src/api/webhook/post.ts
@@ -83,6 +83,42 @@ export function setupWebhook(app: OpenAPIHono) {
             "rejected",
           );
           break;
+        case "pending":
+          comment = await commentModerationService.updateModerationStatus(
+            command.commentId,
+            "pending",
+          );
+          break;
+        case "change":
+          comment = await commentModerationService.getComment(
+            command.commentId,
+          );
+
+          if (comment) {
+            await moderationNotificationsService.updateMessageWithChangeAction(
+              message.message_id,
+              comment,
+            );
+
+            return c.newResponse(null, 204);
+          }
+
+          break;
+        case "cancel":
+          comment = await commentModerationService.getComment(
+            command.commentId,
+          );
+
+          if (comment) {
+            await moderationNotificationsService.updateMessageWithModerationStatus(
+              message.message_id,
+              comment,
+            );
+
+            return c.newResponse(null, 204);
+          }
+
+          break;
         default:
           throw new HTTPException(400, {
             message: "Invalid action",

--- a/apps/indexer/src/management/services/comment-moderation-service.ts
+++ b/apps/indexer/src/management/services/comment-moderation-service.ts
@@ -172,6 +172,14 @@ export class CommentModerationService {
     return updatedComment;
   }
 
+  async getComment(commentId: Hex): Promise<CommentSelectType | undefined> {
+    const comment = await db.query.comment.findFirst({
+      where: eq(schema.comment.id, commentId),
+    });
+
+    return comment;
+  }
+
   private async insertCommentModerationStatus(
     commentId: Hex,
     status: ModerationStatus = "pending",
@@ -210,11 +218,13 @@ export class CommentModerationService {
     references: IndexerAPICommentReferencesSchemaType,
   ) {
     return this.notificationService.notifyPendingModeration({
+      channelId: comment.channelId,
       author: comment.author,
       content: comment.content,
       targetUri: comment.targetUri,
       references,
       id: comment.commentId,
+      parentId: comment.parentId,
     });
   }
 }

--- a/apps/indexer/src/services/noop-notifications.ts
+++ b/apps/indexer/src/services/noop-notifications.ts
@@ -23,6 +23,16 @@ export class NoopNotificationsService
     });
   }
 
+  async updateMessageWithChangeAction(
+    messageId: number,
+    comment: CommentSelectType,
+  ) {
+    console.log("NoopNotificationsService: updateMessageWithChangeAction", {
+      messageId,
+      comment,
+    });
+  }
+
   decryptWebhookCallbackData(data: string): WebhookCallbackData {
     console.log("NoopNotificationsService: decryptWebhookCallbackData", data);
     throw new Error("Not implemented");

--- a/apps/indexer/src/services/types.ts
+++ b/apps/indexer/src/services/types.ts
@@ -5,10 +5,12 @@ import type { IndexerAPICommentReferencesSchemaType } from "@ecp.eth/sdk/indexer
 
 export type ModerationNotificationServicePendingComment = {
   id: Hex;
+  channelId: bigint;
   author: Hex;
   content: string;
   references: IndexerAPICommentReferencesSchemaType;
   targetUri: string;
+  parentId: Hex;
 };
 
 export interface ModerationNotificationsService {
@@ -17,6 +19,10 @@ export interface ModerationNotificationsService {
     comment: ModerationNotificationServicePendingComment,
   ) => Promise<void>;
   updateMessageWithModerationStatus: (
+    messageId: number,
+    comment: CommentSelectType,
+  ) => Promise<void>;
+  updateMessageWithChangeAction: (
     messageId: number,
     comment: CommentSelectType,
   ) => Promise<void>;


### PR DESCRIPTION
This PR implements a way to change moderation status after comment has been moderated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded moderation actions for comments, including "pending", "change", and "cancel" options.
  * Moderation notifications now display additional details such as Channel ID and Parent ID.
  * Telegram moderation messages offer more interactive inline actions for moderators.

* **Improvements**
  * Comment content is now displayed in rendered markdown format for better readability during moderation.
  * Enhanced notification formatting and status indicators for moderation actions.

* **Bug Fixes**
  * Improved error handling and logging in moderation notification updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->