### PR TITLE
fix(shared): generate unique key for paragraph elements

### DIFF
--- a/packages/shared/src/renderer.tsx
+++ b/packages/shared/src/renderer.tsx
@@ -353,21 +353,30 @@ function generateKey(
   if (
     typeof element.props === "object" &&
     element.props != null &&
-    "children" in element.props &&
-    typeof element.props.children === "object" &&
-    element.props.children != null &&
-    Array.isArray(element.props.children)
+    "children" in element.props
   ) {
-    return element.props.children
-      .map((child: unknown, index: number): undefined | string => {
-        if (typeof child !== "string" && !isValidElement(child)) {
-          return;
-        }
-        return generateKey(child) ?? `key-${index.toString()}`;
-      })
-      .filter(Boolean)
-      .join("-");
+    if (typeof element.props.children === "string") {
+      return hashKey(element.props.children);
+    }
+
+    if (
+      typeof element.props.children === "object" &&
+      element.props.children != null &&
+      Array.isArray(element.props.children)
+    ) {
+      return element.props.children
+        .map((child: unknown, index: number): undefined | string => {
+          if (typeof child !== "string" && !isValidElement(child)) {
+            return;
+          }
+          return generateKey(child) ?? `key-inner-${index.toString()}`;
+        })
+        .filter(Boolean)
+        .join("-");
+    }
   }
+
+  console.warn("No key found for element", element);
 
   return;
 }


### PR DESCRIPTION
getting an warning from react due to key not unique for paragraphs generated from the text render, this PR fixes that by using a very naive hashing function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the stability and uniqueness of keys assigned to rendered paragraphs and URLs, reducing potential rendering issues in the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->