### PR TITLE
fix(shared): workaround default export missing on client

### DIFF
--- a/packages/shared/src/components/HeartButton/index.tsx
+++ b/packages/shared/src/components/HeartButton/index.tsx
@@ -1,6 +1,14 @@
-import Lottie, { LottieRefCurrentProps } from "lottie-react";
+import LottieRaw, { LottieRefCurrentProps } from "lottie-react";
 import heartJSON from "./heart.json";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+// when peer dep `lottie-react` is transpiled by next js, and then got imported/required by module transpiled using tsup,
+// the client side default export somehow got wrapped into an object `{ __esModule: true, default, ... }`,
+// while the default export was correctly imported on server side SSR.
+//
+// This is a workaround to ensure the default export is correctly imported on client side.
+const Lottie: typeof LottieRaw =
+  "default" in LottieRaw ? (LottieRaw.default as typeof LottieRaw) : LottieRaw;
 
 const lottieSize = 64;
 const END_FRAME = 60;

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -6,5 +6,5 @@ export * from "./CommentMediaFile.js";
 export * from "./CommentMediaImage.js";
 export * from "./CommentMediaVideo.js";
 export * from "./CommentMediaReference.js";
-export { HeartButton } from "./HeartButton/";
+export { HeartButton } from "./HeartButton/index.js";
 export * from "./PendingWalletConnectionActionsContext.js";


### PR DESCRIPTION
Had a very mystic issue that next js transpiled peer dep (lottie-react) default export became an object only on client side (was correct on SSR 🤷‍♂️).

Spent hours trying to figure it out, updating tsoncfig configuration, turn on/off `esModuleInterop` /`allowSyntheticDefaultImport`/`cjsInterop`, upgrade libs... nothing works, so here is the workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for animation components to ensure consistent behavior between server-side and client-side rendering. No visible changes to functionality.
* **Chores**
  * Updated internal export paths for better module resolution without affecting user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->