### PR TITLE
fix(comments): conditionally render report option based on comment status

### DIFF
--- a/apps/embed/src/components/comments/Comment.tsx
+++ b/apps/embed/src/components/comments/Comment.tsx
@@ -120,14 +120,19 @@ export function Comment({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="apply-theme">
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onClick={connectBeforeAction(() => {
-                open(comment);
-              })}
-            >
-              Report
-            </DropdownMenuItem>
+            {!comment.deletedAt &&
+              comment.moderationStatus === "approved" &&
+              (!comment.pendingOperation ||
+                comment.pendingOperation.state.status === "success") && (
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={connectBeforeAction(() => {
+                    open(comment);
+                  })}
+                >
+                  Report
+                </DropdownMenuItem>
+              )}
             <DropdownMenuItem className="cursor-pointer" asChild>
               <Link
                 href={publicEnv.NEXT_PUBLIC_BLOCK_EXPLORER_TX_URL.replace(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Report" option in the comment menu is now only shown for approved, non-deleted comments with no pending operations or successful pending operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->