### PR TITLE
fix(docs, embed): colour and iframe configurator

### DIFF
--- a/apps/embed/src/components/comments/CommentForm.tsx
+++ b/apps/embed/src/components/comments/CommentForm.tsx
@@ -289,7 +289,7 @@ function BaseCommentForm({
       <Editor
         autoFocus={autoFocus}
         className={cn(
-          "w-full p-2 border border-gray-300 rounded",
+          "w-full p-2 border border-gray-300 rounded text-foreground",
           disabled && "opacity-50",
           submitMutation.error &&
             submitMutation.error instanceof InvalidCommentError &&
@@ -324,7 +324,7 @@ function BaseCommentForm({
                   onClick={handleAddFileClick}
                   disabled={isSubmitting || disabled}
                 >
-                  <ImageIcon />
+                  <ImageIcon className="stroke-foreground" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>

--- a/docs/components/IframeConfigurator/index.tsx
+++ b/docs/components/IframeConfigurator/index.tsx
@@ -68,6 +68,7 @@ export default function IframeConfigurator() {
       source: {
         targetUri: "",
       },
+      embedUri: "",
       config: DEFAULT_CONFIG,
       autoHeightAdjustment: true,
     },
@@ -82,39 +83,18 @@ export default function IframeConfigurator() {
   });
 
   const [debouncedConfig] = useDebounce(config, 500);
+  const getEmbedUri = React.useCallback(() => {
+    return mode === "post"
+      ? publicEnv.VITE_ECP_ETH_EMBED_URL
+      : mode === "author"
+        ? publicEnv.VITE_ECP_ETH_EMBED_BY_AUTHOR_URL
+        : publicEnv.VITE_ECP_ETH_EMBED_BY_REPLIES_URL;
+  }, [mode]);
 
   // Update embedUri when mode changes
   useEffect(() => {
-    form.setValue(
-      "embedUri",
-      mode === "post"
-        ? publicEnv.VITE_ECP_ETH_EMBED_URL
-        : mode === "author"
-          ? publicEnv.VITE_ECP_ETH_EMBED_BY_AUTHOR_URL
-          : publicEnv.VITE_ECP_ETH_EMBED_BY_REPLIES_URL,
-    );
-  }, [mode]);
-
-  const updateThemeColor = (
-    mode: "light" | "dark",
-    key: (typeof COLOR_FIELDS)[number]["key"],
-    value: string,
-  ) => {
-    const prev = form.getValues("config");
-    form.setValue("config", {
-      ...prev,
-      theme: {
-        ...prev.theme,
-        colors: {
-          ...prev.theme?.colors,
-          [mode]: {
-            ...prev.theme?.colors?.[mode],
-            [key]: value,
-          },
-        },
-      },
-    });
-  };
+    form.setValue("embedUri", getEmbedUri());
+  }, [getEmbedUri]);
 
   const updateFontFamily = (type: "system" | "google", value: string) => {
     const prev = form.getValues("config");
@@ -195,7 +175,6 @@ export default function IframeConfigurator() {
                           field.onChange({
                             targetUri: e.target.value,
                           });
-                          form.trigger();
                         }}
                         placeholder="https://example.com"
                       />
@@ -218,7 +197,6 @@ export default function IframeConfigurator() {
                         field.onChange({
                           author: e.target.value,
                         });
-                        form.trigger();
                       }}
                       placeholder="0x..."
                     />
@@ -241,7 +219,6 @@ export default function IframeConfigurator() {
                         field.onChange({
                           commentId: e.target.value,
                         });
-                        form.trigger();
                       }}
                       placeholder="0x..."
                     />
@@ -637,11 +614,7 @@ export default function IframeConfigurator() {
                     <FormControl>
                       <Input
                         type="text"
-                        placeholder={
-                          mode === "post"
-                            ? "https://embed.ethcomments.xyz"
-                            : "https://embed.ethcomments.xyz/by-author"
-                        }
+                        placeholder={getEmbedUri()}
                         {...field}
                       />
                     </FormControl>


### PR DESCRIPTION
1. fix(docs): fix minor issues in iframe configurator form:
    1. embedUri field placeholder is not updated accordingly
    2. extra form triggers are not needed
    3. removed some unused functions
4. fix(embed): add default colour when system theme does not match: e.g. previously when OS selected dark theme, embed is using light theme, the text colour is white (due to dark system theme), colour text colour cannot be seen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new embed URI field to the Iframe Configurator, with improved handling and display based on selected mode.

* **Style**
  * Updated the comment editor and image icon to use consistent text and stroke colors for better visual appearance.

* **Refactor**
  * Simplified and centralized the logic for determining the embed URI in the Iframe Configurator.
  * Removed redundant form validation triggers and unused functions for a cleaner configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->