### PR TITLE
fix(embed): add margin to editor to compensate focus outline

### DIFF
--- a/apps/embed/src/components/comments/CommentForm.tsx
+++ b/apps/embed/src/components/comments/CommentForm.tsx
@@ -289,7 +289,7 @@ function BaseCommentForm({
       <Editor
         autoFocus={autoFocus}
         className={cn(
-          "w-full p-2 border border-gray-300 rounded text-foreground",
+          "w-[calc(100%-2px)] p-2 border border-gray-300 rounded text-foreground mx-[1px]",
           disabled && "opacity-50",
           submitMutation.error &&
             submitMutation.error instanceof InvalidCommentError &&


### PR DESCRIPTION
add 1px margin around input editor to allow focus outline to be fully visible, see issue in the pic below:

<img width="262" height="234" alt="image" src="https://github.com/user-attachments/assets/991aa304-1776-4464-8739-83f590a6dce6" />
