### PR TITLE
fix(sdk): use strict event typing

### DIFF
--- a/.changeset/ready-llamas-warn.md
+++ b/.changeset/ready-llamas-warn.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+fix(sdk): use strict event typing

--- a/packages/sdk/src/core/types.ts
+++ b/packages/sdk/src/core/types.ts
@@ -30,6 +30,7 @@ export type WaitableWriteContractHelperResult<
     getContractEvents: PublicActions["getContractEvents"];
     waitForTransactionReceipt: PublicActions["waitForTransactionReceipt"];
   }) => Promise<
-    GetContractEventsReturnType<TAbi, TEventName>[number]["args"] | undefined
+    | GetContractEventsReturnType<TAbi, TEventName, true>[number]["args"]
+    | undefined
   >;
 };


### PR DESCRIPTION
use strict event typing so event properties are not optional