### PR TITLE
fix(embed): mobile iframe wallet button (uri scheme) blocked

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "@privy-io/server-auth": "patches/@privy-io__server-auth.patch",
       "@walletconnect/keyvaluestorage": "patches/@walletconnect__keyvaluestorage.patch",
       "@wagmi/connectors": "patches/@wagmi__connectors.patch",
-      "ponder": "patches/ponder.patch"
+      "ponder": "patches/ponder.patch",
+      "@rainbow-me/rainbowkit": "patches/@rainbow-me__rainbowkit.patch"
     }
   },
   "lint-staged": {

--- a/packages/sdk/src/embed/react.tsx
+++ b/packages/sdk/src/embed/react.tsx
@@ -300,7 +300,7 @@ function useWalletButtonInterceptor(embedUri: string) {
         return;
       }
 
-      const mobileUri = event.data.uri;
+      const mobileUri = event.data.uri.toLowerCase();
 
       if (
         mobileUri.startsWith("javascript:") ||

--- a/packages/sdk/src/embed/react.tsx
+++ b/packages/sdk/src/embed/react.tsx
@@ -221,7 +221,8 @@ function CommentsEmbedInternal({
   iframeProps,
   src,
 }: CommentsEmbedInternalProps) {
-  const { iframeRef, dimensions } = useIframeDimensionsWatcher(src);
+  const { dimensions } = useIframeDimensionsWatcher(src);
+  useWalletButtonInterceptor(src);
 
   return (
     <div
@@ -241,7 +242,6 @@ function CommentsEmbedInternal({
           ...dimensions,
         }}
         src={src}
-        ref={iframeRef}
       ></iframe>
     </div>
   );
@@ -254,7 +254,6 @@ function useIframeDimensionsWatcher(iframeUri: string) {
   const [dimensions, setDimensions] = useState<{
     height: number;
   } | null>(null);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
   const origin = useMemo(() => new URL(iframeUri).origin, [iframeUri]);
 
   useEffect(() => {
@@ -277,6 +276,55 @@ function useIframeDimensionsWatcher(iframeUri: string) {
 
   return {
     dimensions,
-    iframeRef,
   };
+}
+
+/**
+ * On mobile the uri scheme cannot be triggered directly within the iframe, so we had to intercept the message and open the link on the container level.
+ *
+ * p.s. we had to hack rainbowkit to make expose such window message event, check pnpm patch for details.
+ */
+function useWalletButtonInterceptor(embedUri: string) {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const origin = new URL(embedUri).origin;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (
+        event.data.type !== "rainbowkit-wallet-button-mobile-clicked" ||
+        origin !== event.origin
+      ) {
+        return;
+      }
+
+      const mobileUri = event.data.uri;
+
+      if (
+        mobileUri.startsWith("javascript:") ||
+        mobileUri.startsWith("data:")
+      ) {
+        console.warn("Blocked potentially dangerous URI scheme:", mobileUri);
+        return;
+      }
+
+      if (mobileUri.startsWith("http")) {
+        const link = document.createElement("a");
+        link.href = mobileUri;
+        link.target = "_blank";
+        link.rel = "noreferrer noopener";
+        link.click();
+      } else {
+        window.location.href = mobileUri;
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
 }

--- a/packages/sdk/src/embed/react.tsx
+++ b/packages/sdk/src/embed/react.tsx
@@ -326,5 +326,5 @@ function useWalletButtonInterceptor(embedUri: string) {
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  }, []);
+  }, [embedUri]);
 }

--- a/packages/sdk/src/embed/react.tsx
+++ b/packages/sdk/src/embed/react.tsx
@@ -300,17 +300,17 @@ function useWalletButtonInterceptor(embedUri: string) {
         return;
       }
 
-      const mobileUri = event.data.uri.toLowerCase();
+      const mobileUri = event.data.uri;
 
       if (
-        mobileUri.startsWith("javascript:") ||
-        mobileUri.startsWith("data:")
+        mobileUri.toLowerCase().startsWith("javascript:") ||
+        mobileUri.toLowerCase().startsWith("data:")
       ) {
         console.warn("Blocked potentially dangerous URI scheme:", mobileUri);
         return;
       }
 
-      if (mobileUri.startsWith("http")) {
+      if (mobileUri.toLowerCase().startsWith("http")) {
         const link = document.createElement("a");
         link.href = mobileUri;
         link.target = "_blank";

--- a/patches/@rainbow-me__rainbowkit.patch
+++ b/patches/@rainbow-me__rainbowkit.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/index.js b/dist/index.js
+index fc7f634a8c499b1c8a62daa3d69e96a2e8e3786b..290f99a816044ee9366c55052578ac1a00ab7c5d 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -5870,6 +5870,13 @@ function WalletButton({
+       } else {
+         window.location.href = mobileUri;
+       }
++
++      if (window.parent) {
++        window.parent.postMessage({
++          type: "rainbowkit-wallet-button-mobile-clicked",
++          uri: mobileUri
++        }, "*");
++      }
+     };
+     if (id !== "walletConnect") onMobileUri();
+     if (showWalletConnectModal) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ patchedDependencies:
   '@privy-io/server-auth':
     hash: 78088c76aea7ad10983f0789b33590118cecdd976346ac52e3b965b6bed7202a
     path: patches/@privy-io__server-auth.patch
+  '@rainbow-me/rainbowkit':
+    hash: de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8
+    path: patches/@rainbow-me__rainbowkit.patch
   '@wagmi/connectors':
     hash: b8263b5e07ab13f35a11462b88ae2172425a72d8fe4431296555c3afeab1a636
     path: patches/@wagmi__connectors.patch
@@ -115,7 +118,7 @@ importers:
         version: 1.2.7(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.4
-        version: 2.2.5(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.5(patch_hash=de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@tanstack/react-query':
         specifier: ^5.75.6
         version: 5.80.2(react@19.1.0)
@@ -245,7 +248,7 @@ importers:
         version: 1.2.7(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.4
-        version: 2.2.5(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.5(patch_hash=de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@sentry/nextjs':
         specifier: ^9.3.0
         version: 9.25.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9(esbuild@0.25.5))
@@ -1064,7 +1067,7 @@ importers:
         version: 2.44.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.4
-        version: 2.2.5(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.5(patch_hash=de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@tanstack/react-query':
         specifier: ^5.75.6
         version: 5.80.2(react@19.1.0)
@@ -14545,7 +14548,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.5(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
+  '@rainbow-me/rainbowkit@2.2.5(patch_hash=de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
       '@tanstack/react-query': 5.80.2(react@19.1.0)
       '@vanilla-extract/css': 1.15.5


### PR DESCRIPTION
inside mobile iframe `location.href = uri scheme` is blocked, this PR hacks rainbowkit to make it post message to parent window, and relocate to the uri scheme from there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of wallet connection links on mobile devices, enabling smoother redirection and link opening from embedded comments.
* **Bug Fixes**
  * Enhanced compatibility for mobile wallet connections when using embedded components.
* **Chores**
  * Updated configuration to apply a new patch for improved wallet button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->