### PR TITLE
fix(indexer): allow empty strings in 0x swap "to" data

### DIFF
--- a/.changeset/silly-brooms-sell.md
+++ b/.changeset/silly-brooms-sell.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+fix(indexer): allow empty strings in 0x swap "to" data

--- a/docs/pages/sdk-reference/indexer/functions/convertIndexerMetadataToRecord.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/convertIndexerMetadataToRecord.mdx
@@ -10,7 +10,7 @@
 function convertIndexerMetadataToRecord(metadataEntries, keyTypeMap?): MetadataRecord;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:508](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L508)
+Defined in: [packages/sdk/src/indexer/schemas.ts:510](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L510)
 
 Converts IndexerAPI MetadataEntry array to Record format for easier manipulation
 

--- a/docs/pages/sdk-reference/indexer/functions/convertIndexerMetadataToRecord.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/convertIndexerMetadataToRecord.mdx
@@ -10,7 +10,7 @@
 function convertIndexerMetadataToRecord(metadataEntries, keyTypeMap?): MetadataRecord;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:510](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L510)
+Defined in: [packages/sdk/src/indexer/schemas.ts:516](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L516)
 
 Converts IndexerAPI MetadataEntry array to Record format for easier manipulation
 

--- a/docs/pages/sdk-reference/indexer/functions/convertRecordToIndexerMetadata.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/convertRecordToIndexerMetadata.mdx
@@ -13,7 +13,7 @@ function convertRecordToIndexerMetadata(metadataRecord): {
 }[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:521](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L521)
+Defined in: [packages/sdk/src/indexer/schemas.ts:523](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L523)
 
 Converts Record format metadata to IndexerAPI MetadataEntry array format
 

--- a/docs/pages/sdk-reference/indexer/functions/convertRecordToIndexerMetadata.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/convertRecordToIndexerMetadata.mdx
@@ -13,7 +13,7 @@ function convertRecordToIndexerMetadata(metadataRecord): {
 }[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:523](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L523)
+Defined in: [packages/sdk/src/indexer/schemas.ts:529](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L529)
 
 Converts Record format metadata to IndexerAPI MetadataEntry array format
 

--- a/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
@@ -156,7 +156,7 @@ function fetchCommentReplies(options): Promise<{
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -326,7 +326,7 @@ Fetch replies for a comment from the Indexer API
            `symbol`: `string`;
         \};
         `to`: \{
-           `address`: `` `0x${string}` ``;
+           `address`: `string`;
            `amount`: `string`;
            `symbol`: `string`;
         \};

--- a/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
@@ -156,7 +156,7 @@ function fetchCommentReplies(options): Promise<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -326,7 +326,7 @@ Fetch replies for a comment from the Indexer API
            `symbol`: `string`;
         \};
         `to`: \{
-           `address`: `string`;
+           `address`: `""` \| `` `0x${string}` ``;
            `amount`: `string`;
            `symbol`: `string`;
         \};

--- a/docs/pages/sdk-reference/indexer/functions/fetchComments.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchComments.mdx
@@ -316,7 +316,7 @@ function fetchComments(options): Promise<{
                  symbol: string;
               };
               to: {
-                 address: `0x${(...)}`;
+                 address: string;
                  amount: string;
                  symbol: string;
               };
@@ -455,7 +455,7 @@ function fetchComments(options): Promise<{
               symbol: string;
            };
            to: {
-              address: `0x${(...)}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -469,7 +469,7 @@ function fetchComments(options): Promise<{
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -799,7 +799,7 @@ Fetch comments from the Indexer API
                  `symbol`: `string`;
               \};
               `to`: \{
-                 `address`: `` `0x${(...)}` ``;
+                 `address`: `string`;
                  `amount`: `string`;
                  `symbol`: `string`;
               \};
@@ -938,7 +938,7 @@ Fetch comments from the Indexer API
               `symbol`: `string`;
            \};
            `to`: \{
-              `address`: `` `0x${(...)}` ``;
+              `address`: `string`;
               `amount`: `string`;
               `symbol`: `string`;
            \};
@@ -952,7 +952,7 @@ Fetch comments from the Indexer API
            `symbol`: `string`;
         \};
         `to`: \{
-           `address`: `` `0x${string}` ``;
+           `address`: `string`;
            `amount`: `string`;
            `symbol`: `string`;
         \};

--- a/docs/pages/sdk-reference/indexer/functions/fetchComments.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchComments.mdx
@@ -316,7 +316,7 @@ function fetchComments(options): Promise<{
                  symbol: string;
               };
               to: {
-                 address: string;
+                 address: ... | ...;
                  amount: string;
                  symbol: string;
               };
@@ -455,7 +455,7 @@ function fetchComments(options): Promise<{
               symbol: string;
            };
            to: {
-              address: string;
+              address: ... | ...;
               amount: string;
               symbol: string;
            };
@@ -469,7 +469,7 @@ function fetchComments(options): Promise<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -799,7 +799,7 @@ Fetch comments from the Indexer API
                  `symbol`: `string`;
               \};
               `to`: \{
-                 `address`: `string`;
+                 `address`: ... \| ...;
                  `amount`: `string`;
                  `symbol`: `string`;
               \};
@@ -938,7 +938,7 @@ Fetch comments from the Indexer API
               `symbol`: `string`;
            \};
            `to`: \{
-              `address`: `string`;
+              `address`: ... \| ...;
               `amount`: `string`;
               `symbol`: `string`;
            \};
@@ -952,7 +952,7 @@ Fetch comments from the Indexer API
            `symbol`: `string`;
         \};
         `to`: \{
-           `address`: `string`;
+           `address`: `""` \| `` `0x${string}` ``;
            `amount`: `string`;
            `symbol`: `string`;
         \};

--- a/docs/pages/sdk-reference/indexer/index.mdx
+++ b/docs/pages/sdk-reference/indexer/index.mdx
@@ -124,6 +124,8 @@ Functionality for indexing and querying comments data
 | [IndexerAPIReportsListPendingSchema](/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx) | - |
 | [IndexerAPIReportStatusSchema](/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx) | - |
 | [IndexerAPISortSchema](/sdk-reference/indexer/variables/IndexerAPISortSchema.mdx) | - |
+| [IndexerAPIZeroExSwapPossibleEmptyAddressSchema](/sdk-reference/indexer/variables/IndexerAPIZeroExSwapPossibleEmptyAddressSchema.mdx) | - |
+| [IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema](/sdk-reference/indexer/variables/IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema.mdx) | - |
 | [IndexerAPIZeroExTokenAmountSchema](/sdk-reference/indexer/variables/IndexerAPIZeroExTokenAmountSchema.mdx) | - |
 
 ## Functions

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteENSSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteENSSchemaType.mdx
@@ -17,7 +17,7 @@ type IndexerAPIAutocompleteENSSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:540](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L540)
+Defined in: [packages/sdk/src/indexer/schemas.ts:546](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L546)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteENSSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteENSSchemaType.mdx
@@ -17,7 +17,7 @@ type IndexerAPIAutocompleteENSSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:538](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L538)
+Defined in: [packages/sdk/src/indexer/schemas.ts:540](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L540)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteERC20SchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteERC20SchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPIAutocompleteERC20SchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:558](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L558)
+Defined in: [packages/sdk/src/indexer/schemas.ts:560](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L560)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteERC20SchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteERC20SchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPIAutocompleteERC20SchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:560](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L560)
+Defined in: [packages/sdk/src/indexer/schemas.ts:566](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L566)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteFarcasterSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteFarcasterSchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPIAutocompleteFarcasterSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:578](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L578)
+Defined in: [packages/sdk/src/indexer/schemas.ts:584](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L584)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteFarcasterSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteFarcasterSchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPIAutocompleteFarcasterSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:576](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L576)
+Defined in: [packages/sdk/src/indexer/schemas.ts:578](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L578)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteSchemaType.mdx
@@ -40,4 +40,4 @@ type IndexerAPIAutocompleteSchemaType =
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:588](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L588)
+Defined in: [packages/sdk/src/indexer/schemas.ts:594](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L594)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteSchemaType.mdx
@@ -40,4 +40,4 @@ type IndexerAPIAutocompleteSchemaType =
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:586](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L586)
+Defined in: [packages/sdk/src/indexer/schemas.ts:588](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L588)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentOutputSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPICommentOutputSchemaType = {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPICommentOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:357](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L357)
+Defined in: [packages/sdk/src/indexer/schemas.ts:363](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L363)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentOutputSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPICommentOutputSchemaType = {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPICommentOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:355](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L355)
+Defined in: [packages/sdk/src/indexer/schemas.ts:357](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L357)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceENSSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceENSSchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPICommentReferenceENSSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:192](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L192)
+Defined in: [packages/sdk/src/indexer/schemas.ts:194](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L194)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceENSSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceENSSchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPICommentReferenceENSSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:194](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L194)
+Defined in: [packages/sdk/src/indexer/schemas.ts:200](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L200)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceERC20SchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceERC20SchemaType.mdx
@@ -26,7 +26,7 @@ type IndexerAPICommentReferenceERC20SchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:235](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L235)
+Defined in: [packages/sdk/src/indexer/schemas.ts:241](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L241)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceERC20SchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceERC20SchemaType.mdx
@@ -26,7 +26,7 @@ type IndexerAPICommentReferenceERC20SchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:233](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L233)
+Defined in: [packages/sdk/src/indexer/schemas.ts:235](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L235)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceFarcasterSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceFarcasterSchemaType.mdx
@@ -23,7 +23,7 @@ type IndexerAPICommentReferenceFarcasterSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:210](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L210)
+Defined in: [packages/sdk/src/indexer/schemas.ts:216](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L216)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceFarcasterSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceFarcasterSchemaType.mdx
@@ -23,7 +23,7 @@ type IndexerAPICommentReferenceFarcasterSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:208](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L208)
+Defined in: [packages/sdk/src/indexer/schemas.ts:210](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L210)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceSchemaType.mdx
@@ -97,4 +97,4 @@ type IndexerAPICommentReferenceSchemaType =
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:301](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L301)
+Defined in: [packages/sdk/src/indexer/schemas.ts:303](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L303)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceSchemaType.mdx
@@ -97,4 +97,4 @@ type IndexerAPICommentReferenceSchemaType =
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:303](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L303)
+Defined in: [packages/sdk/src/indexer/schemas.ts:309](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L309)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLFileSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:265](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L265)
+Defined in: [packages/sdk/src/indexer/schemas.ts:267](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L267)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLFileSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:267](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L267)
+Defined in: [packages/sdk/src/indexer/schemas.ts:273](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L273)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLImageSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:276](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L276)
+Defined in: [packages/sdk/src/indexer/schemas.ts:278](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L278)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLImageSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:278](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L278)
+Defined in: [packages/sdk/src/indexer/schemas.ts:284](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L284)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLVideoSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLVideoSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLVideoSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:287](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L287)
+Defined in: [packages/sdk/src/indexer/schemas.ts:289](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L289)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLVideoSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLVideoSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLVideoSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:289](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L289)
+Defined in: [packages/sdk/src/indexer/schemas.ts:295](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L295)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLWebPageSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLWebPageSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPICommentReferenceURLWebPageSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:254](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L254)
+Defined in: [packages/sdk/src/indexer/schemas.ts:256](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L256)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLWebPageSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLWebPageSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPICommentReferenceURLWebPageSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:256](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L256)
+Defined in: [packages/sdk/src/indexer/schemas.ts:262](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L262)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx
@@ -97,4 +97,4 @@ type IndexerAPICommentReferencesSchemaType = (
 })[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:311](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L311)
+Defined in: [packages/sdk/src/indexer/schemas.ts:317](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L317)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx
@@ -97,4 +97,4 @@ type IndexerAPICommentReferencesSchemaType = (
 })[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:309](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L309)
+Defined in: [packages/sdk/src/indexer/schemas.ts:311](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L311)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPICommentSchemaType = {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPICommentSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:345](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L345)
+Defined in: [packages/sdk/src/indexer/schemas.ts:351](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L351)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPICommentSchemaType = {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPICommentSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:343](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L343)
+Defined in: [packages/sdk/src/indexer/schemas.ts:345](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L345)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesOutputSchemaType.mdx
@@ -403,7 +403,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: `0x${(...)}`;
+                 address: string;
                  amount: string;
                  symbol: string;
               };
@@ -417,7 +417,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -565,7 +565,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -579,7 +579,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -587,7 +587,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:409](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L409)
+Defined in: [packages/sdk/src/indexer/schemas.ts:411](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L411)
 
 ## Type declaration
 
@@ -1151,7 +1151,7 @@ replies: {
               symbol: string;
            };
            to: {
-              address: `0x${(...)}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -1165,7 +1165,7 @@ replies: {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1498,7 +1498,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: `0x${(...)}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1512,7 +1512,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1684,7 +1684,7 @@ viewerReactions: Record<string, {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1704,7 +1704,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesOutputSchemaType.mdx
@@ -403,7 +403,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: string;
+                 address: ... | ...;
                  amount: string;
                  symbol: string;
               };
@@ -417,7 +417,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${string}`;
               amount: string;
               symbol: string;
            };
@@ -565,7 +565,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -579,7 +579,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -587,7 +587,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:411](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L411)
+Defined in: [packages/sdk/src/indexer/schemas.ts:417](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L417)
 
 ## Type declaration
 
@@ -1151,7 +1151,7 @@ replies: {
               symbol: string;
            };
            to: {
-              address: string;
+              address: ... | ...;
               amount: string;
               symbol: string;
            };
@@ -1165,7 +1165,7 @@ replies: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -1498,7 +1498,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: ... | ...;
            amount: string;
            symbol: string;
         };
@@ -1512,7 +1512,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1684,7 +1684,7 @@ viewerReactions: Record<string, {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1704,7 +1704,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesSchemaType.mdx
@@ -403,7 +403,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: `0x${(...)}`;
+                 address: string;
                  amount: string;
                  symbol: string;
               };
@@ -417,7 +417,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -565,7 +565,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -579,7 +579,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -587,7 +587,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:396](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L396)
+Defined in: [packages/sdk/src/indexer/schemas.ts:398](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L398)
 
 ## Type declaration
 
@@ -1151,7 +1151,7 @@ replies: {
               symbol: string;
            };
            to: {
-              address: `0x${(...)}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -1165,7 +1165,7 @@ replies: {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1498,7 +1498,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: `0x${(...)}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1512,7 +1512,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1684,7 +1684,7 @@ viewerReactions: Record<string, {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1704,7 +1704,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesSchemaType.mdx
@@ -403,7 +403,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: string;
+                 address: ... | ...;
                  amount: string;
                  symbol: string;
               };
@@ -417,7 +417,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${string}`;
               amount: string;
               symbol: string;
            };
@@ -565,7 +565,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -579,7 +579,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -587,7 +587,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:398](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L398)
+Defined in: [packages/sdk/src/indexer/schemas.ts:404](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L404)
 
 ## Type declaration
 
@@ -1151,7 +1151,7 @@ replies: {
               symbol: string;
            };
            to: {
-              address: string;
+              address: ... | ...;
               amount: string;
               symbol: string;
            };
@@ -1165,7 +1165,7 @@ replies: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -1498,7 +1498,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: ... | ...;
            amount: string;
            symbol: string;
         };
@@ -1512,7 +1512,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1684,7 +1684,7 @@ viewerReactions: Record<string, {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1704,7 +1704,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentZeroExSwapSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentZeroExSwapSchemaType.mdx
@@ -14,14 +14,14 @@ type IndexerAPICommentZeroExSwapSchemaType = {
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:174](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L174)
+Defined in: [packages/sdk/src/indexer/schemas.ts:176](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L176)
 
 ## Type declaration
 
@@ -57,7 +57,7 @@ symbol: string;
 
 ```ts
 to: {
-  address: `0x${string}`;
+  address: string;
   amount: string;
   symbol: string;
 };
@@ -66,13 +66,13 @@ to: {
 #### to.address
 
 ```ts
-address: `0x${string}` = HexSchema;
+address: string;
 ```
 
 #### to.amount
 
 ```ts
-amount: string = IndexerAPIZeroExTokenAmountSchema;
+amount: string;
 ```
 
 #### to.symbol

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentZeroExSwapSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentZeroExSwapSchemaType.mdx
@@ -14,14 +14,14 @@ type IndexerAPICommentZeroExSwapSchemaType = {
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:176](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L176)
+Defined in: [packages/sdk/src/indexer/schemas.ts:182](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L182)
 
 ## Type declaration
 
@@ -57,7 +57,7 @@ symbol: string;
 
 ```ts
 to: {
-  address: string;
+  address: "" | `0x${string}`;
   amount: string;
   symbol: string;
 };
@@ -66,13 +66,13 @@ to: {
 #### to.address
 
 ```ts
-address: string;
+address: "" | `0x${string}` = IndexerAPIZeroExSwapPossibleEmptyAddressSchema;
 ```
 
 #### to.amount
 
 ```ts
-amount: string;
+amount: string = IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema;
 ```
 
 #### to.symbol

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIExtraSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIExtraSchemaType.mdx
@@ -13,7 +13,7 @@ type IndexerAPIExtraSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:385](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L385)
+Defined in: [packages/sdk/src/indexer/schemas.ts:387](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L387)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIExtraSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIExtraSchemaType.mdx
@@ -13,7 +13,7 @@ type IndexerAPIExtraSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:387](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L387)
+Defined in: [packages/sdk/src/indexer/schemas.ts:393](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L393)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIGetAutocompleteOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIGetAutocompleteOutputSchemaType.mdx
@@ -42,7 +42,7 @@ type IndexerAPIGetAutocompleteOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:596](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L596)
+Defined in: [packages/sdk/src/indexer/schemas.ts:602](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L602)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIGetAutocompleteOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIGetAutocompleteOutputSchemaType.mdx
@@ -42,7 +42,7 @@ type IndexerAPIGetAutocompleteOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:594](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L594)
+Defined in: [packages/sdk/src/indexer/schemas.ts:596](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L596)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesOutputSchemaType.mdx
@@ -335,7 +335,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: `0x${string}`;
+                 address: string;
                  amount: string;
                  symbol: string;
               };
@@ -483,7 +483,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -497,7 +497,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -506,7 +506,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:451](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L451)
+Defined in: [packages/sdk/src/indexer/schemas.ts:453](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L453)
 
 ## Type declaration
 
@@ -892,7 +892,7 @@ results: {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -1040,7 +1040,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1054,7 +1054,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesOutputSchemaType.mdx
@@ -335,7 +335,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: string;
+                 address: "" | `0x${(...)}`;
                  amount: string;
                  symbol: string;
               };
@@ -483,7 +483,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${(...)}`;
               amount: string;
               symbol: string;
            };
@@ -497,7 +497,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -506,7 +506,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:453](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L453)
+Defined in: [packages/sdk/src/indexer/schemas.ts:459](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L459)
 
 ## Type declaration
 
@@ -892,7 +892,7 @@ results: {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${(...)}`;
               amount: string;
               symbol: string;
            };
@@ -1040,7 +1040,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${(...)}`;
            amount: string;
            symbol: string;
         };
@@ -1054,7 +1054,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
@@ -156,7 +156,7 @@ type IndexerAPIListCommentRepliesSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -165,7 +165,7 @@ type IndexerAPIListCommentRepliesSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:442](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L442)
+Defined in: [packages/sdk/src/indexer/schemas.ts:448](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L448)
 
 ## Type declaration
 
@@ -372,7 +372,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
@@ -156,7 +156,7 @@ type IndexerAPIListCommentRepliesSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -165,7 +165,7 @@ type IndexerAPIListCommentRepliesSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:440](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L440)
+Defined in: [packages/sdk/src/indexer/schemas.ts:442](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L442)
 
 ## Type declaration
 
@@ -372,7 +372,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsOutputSchemaType.mdx
@@ -335,7 +335,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: string;
+                 address: "" | `0x${(...)}`;
                  amount: string;
                  symbol: string;
               };
@@ -483,7 +483,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${(...)}`;
               amount: string;
               symbol: string;
            };
@@ -497,7 +497,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -506,7 +506,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:432](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L432)
+Defined in: [packages/sdk/src/indexer/schemas.ts:438](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L438)
 
 ## Type declaration
 
@@ -892,7 +892,7 @@ results: {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${(...)}`;
               amount: string;
               symbol: string;
            };
@@ -1040,7 +1040,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${(...)}`;
            amount: string;
            symbol: string;
         };
@@ -1054,7 +1054,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsOutputSchemaType.mdx
@@ -335,7 +335,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: `0x${string}`;
+                 address: string;
                  amount: string;
                  symbol: string;
               };
@@ -483,7 +483,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -497,7 +497,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -506,7 +506,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:430](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L430)
+Defined in: [packages/sdk/src/indexer/schemas.ts:432](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L432)
 
 ## Type declaration
 
@@ -892,7 +892,7 @@ results: {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -1040,7 +1040,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1054,7 +1054,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsSchemaType.mdx
@@ -335,7 +335,7 @@ type IndexerAPIListCommentsSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: string;
+                 address: "" | `0x${(...)}`;
                  amount: string;
                  symbol: string;
               };
@@ -483,7 +483,7 @@ type IndexerAPIListCommentsSchemaType = {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${(...)}`;
               amount: string;
               symbol: string;
            };
@@ -497,7 +497,7 @@ type IndexerAPIListCommentsSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -506,7 +506,7 @@ type IndexerAPIListCommentsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:421](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L421)
+Defined in: [packages/sdk/src/indexer/schemas.ts:427](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L427)
 
 ## Type declaration
 
@@ -892,7 +892,7 @@ results: {
               symbol: string;
            };
            to: {
-              address: string;
+              address: "" | `0x${(...)}`;
               amount: string;
               symbol: string;
            };
@@ -1040,7 +1040,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${(...)}`;
            amount: string;
            symbol: string;
         };
@@ -1054,7 +1054,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsSchemaType.mdx
@@ -335,7 +335,7 @@ type IndexerAPIListCommentsSchemaType = {
                  symbol: string;
               };
               to: {
-                 address: `0x${string}`;
+                 address: string;
                  amount: string;
                  symbol: string;
               };
@@ -483,7 +483,7 @@ type IndexerAPIListCommentsSchemaType = {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -497,7 +497,7 @@ type IndexerAPIListCommentsSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -506,7 +506,7 @@ type IndexerAPIListCommentsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:419](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L419)
+Defined in: [packages/sdk/src/indexer/schemas.ts:421](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L421)
 
 ## Type declaration
 
@@ -892,7 +892,7 @@ results: {
               symbol: string;
            };
            to: {
-              address: `0x${string}`;
+              address: string;
               amount: string;
               symbol: string;
            };
@@ -1040,7 +1040,7 @@ results: {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1054,7 +1054,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType = {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:487](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L487)
+Defined in: [packages/sdk/src/indexer/schemas.ts:493](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L493)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType = {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:485](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L485)
+Defined in: [packages/sdk/src/indexer/schemas.ts:487](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L487)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentSchemaType = {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:479](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L479)
+Defined in: [packages/sdk/src/indexer/schemas.ts:485](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L485)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: string;
+     address: "" | `0x${string}`;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentSchemaType.mdx
@@ -144,7 +144,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentSchemaType = {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -152,7 +152,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:477](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L477)
+Defined in: [packages/sdk/src/indexer/schemas.ts:479](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L479)
 
 ## Type declaration
 
@@ -473,7 +473,7 @@ zeroExSwap:
      symbol: string;
   };
   to: {
-     address: `0x${string}`;
+     address: string;
      amount: string;
      symbol: string;
   };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsOutputSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPIModerationGetPendingCommentsOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -161,7 +161,7 @@ type IndexerAPIModerationGetPendingCommentsOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:470](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L470)
+Defined in: [packages/sdk/src/indexer/schemas.ts:472](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L472)
 
 ## Type declaration
 
@@ -347,7 +347,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsOutputSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPIModerationGetPendingCommentsOutputSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -161,7 +161,7 @@ type IndexerAPIModerationGetPendingCommentsOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:472](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L472)
+Defined in: [packages/sdk/src/indexer/schemas.ts:478](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L478)
 
 ## Type declaration
 
@@ -347,7 +347,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPIModerationGetPendingCommentsSchemaType = {
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -161,7 +161,7 @@ type IndexerAPIModerationGetPendingCommentsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:460](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L460)
+Defined in: [packages/sdk/src/indexer/schemas.ts:462](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L462)
 
 ## Type declaration
 
@@ -347,7 +347,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPIModerationGetPendingCommentsSchemaType = {
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -161,7 +161,7 @@ type IndexerAPIModerationGetPendingCommentsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:462](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L462)
+Defined in: [packages/sdk/src/indexer/schemas.ts:468](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L468)
 
 ## Type declaration
 
@@ -347,7 +347,7 @@ results: {
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIPaginationSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIPaginationSchemaType.mdx
@@ -14,7 +14,7 @@ type IndexerAPIPaginationSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:376](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L376)
+Defined in: [packages/sdk/src/indexer/schemas.ts:378](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L378)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIPaginationSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIPaginationSchemaType.mdx
@@ -14,7 +14,7 @@ type IndexerAPIPaginationSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:378](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L378)
+Defined in: [packages/sdk/src/indexer/schemas.ts:384](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L384)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportOutputSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPIReportOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:624](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L624)
+Defined in: [packages/sdk/src/indexer/schemas.ts:630](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L630)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportOutputSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPIReportOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:622](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L622)
+Defined in: [packages/sdk/src/indexer/schemas.ts:624](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L624)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPIReportSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:614](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L614)
+Defined in: [packages/sdk/src/indexer/schemas.ts:616](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L616)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPIReportSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:616](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L616)
+Defined in: [packages/sdk/src/indexer/schemas.ts:622](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L622)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingOutputSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPIReportsListPendingOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:641](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L641)
+Defined in: [packages/sdk/src/indexer/schemas.ts:643](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L643)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingOutputSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPIReportsListPendingOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:643](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L643)
+Defined in: [packages/sdk/src/indexer/schemas.ts:649](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L649)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPIReportsListPendingSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:633](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L633)
+Defined in: [packages/sdk/src/indexer/schemas.ts:639](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L639)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPIReportsListPendingSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:631](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L631)
+Defined in: [packages/sdk/src/indexer/schemas.ts:633](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L633)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteENSSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteENSSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteENSSchema: ZodObject<IndexerAPIAutocompleteENSSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:527](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L527)
+Defined in: [packages/sdk/src/indexer/schemas.ts:529](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L529)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteENSSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteENSSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteENSSchema: ZodObject<IndexerAPIAutocompleteENSSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:529](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L529)
+Defined in: [packages/sdk/src/indexer/schemas.ts:535](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L535)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteERC20Schema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteERC20Schema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteERC20Schema: ZodObject<IndexerAPIAutocompleteERC20SchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:542](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L542)
+Defined in: [packages/sdk/src/indexer/schemas.ts:544](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L544)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteERC20Schema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteERC20Schema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteERC20Schema: ZodObject<IndexerAPIAutocompleteERC20SchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:544](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L544)
+Defined in: [packages/sdk/src/indexer/schemas.ts:550](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L550)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteFarcasterSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteFarcasterSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteFarcasterSchema: ZodObject<IndexerAPIAutocompleteFarcasterSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:564](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L564)
+Defined in: [packages/sdk/src/indexer/schemas.ts:570](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L570)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteFarcasterSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteFarcasterSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteFarcasterSchema: ZodObject<IndexerAPIAutocompleteFarcasterSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:562](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L562)
+Defined in: [packages/sdk/src/indexer/schemas.ts:564](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L564)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteSchema: ZodDiscriminatedUnion<IndexerAPIAutocompleteSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:580](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L580)
+Defined in: [packages/sdk/src/indexer/schemas.ts:582](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L582)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteSchema: ZodDiscriminatedUnion<IndexerAPIAutocompleteSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:582](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L582)
+Defined in: [packages/sdk/src/indexer/schemas.ts:588](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L588)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentOutputSchema: ZodObject<IndexerAPICommentOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:349](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L349)
+Defined in: [packages/sdk/src/indexer/schemas.ts:355](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L355)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentOutputSchema: ZodObject<IndexerAPICommentOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:347](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L347)
+Defined in: [packages/sdk/src/indexer/schemas.ts:349](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L349)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionOutputSchema.mdx
@@ -252,15 +252,15 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      }>;
      to: ZodObject<{
-        address: ZodUnion<[ZodType<..., ..., ...>, ZodString]>;
-        amount: ZodUnion<[ZodString, ZodString]>;
+        address: ZodUnion<[ZodType<..., ..., ...>, ZodLiteral<...>]>;
+        amount: ZodUnion<[ZodString, ZodLiteral<...>]>;
         symbol: ZodString;
       }, "strip", ZodTypeAny, {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
       }, {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      }>;
@@ -271,7 +271,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -282,7 +282,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -488,7 +488,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: ... | ...;
            amount: string;
            symbol: string;
         };
@@ -621,7 +621,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: ... | ...;
            amount: string;
            symbol: string;
         };
@@ -894,7 +894,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -908,7 +908,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1180,7 +1180,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -1194,7 +1194,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1202,4 +1202,4 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:366](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L366)
+Defined in: [packages/sdk/src/indexer/schemas.ts:372](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L372)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionOutputSchema.mdx
@@ -252,15 +252,15 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      }>;
      to: ZodObject<{
-        address: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
-        amount: ZodString;
+        address: ZodUnion<[ZodType<..., ..., ...>, ZodString]>;
+        amount: ZodUnion<[ZodString, ZodString]>;
         symbol: ZodString;
       }, "strip", ZodTypeAny, {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
       }, {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      }>;
@@ -271,7 +271,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -282,7 +282,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -488,7 +488,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${(...)}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -621,7 +621,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${(...)}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -894,7 +894,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -908,7 +908,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1180,7 +1180,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1194,7 +1194,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1202,4 +1202,4 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:364](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L364)
+Defined in: [packages/sdk/src/indexer/schemas.ts:366](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L366)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionSchema.mdx
@@ -257,15 +257,15 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      }>;
      to: ZodObject<{
-        address: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
-        amount: ZodString;
+        address: ZodUnion<[ZodType<..., ..., ...>, ZodString]>;
+        amount: ZodUnion<[ZodString, ZodString]>;
         symbol: ZodString;
       }, "strip", ZodTypeAny, {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
       }, {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      }>;
@@ -276,7 +276,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -287,7 +287,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -518,7 +518,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${(...)}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -651,7 +651,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${(...)}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -924,7 +924,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -938,7 +938,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1210,7 +1210,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: `0x${string}`;
+           address: string;
            amount: string;
            symbol: string;
         };
@@ -1224,7 +1224,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: `0x${string}`;
+        address: string;
         amount: string;
         symbol: string;
      };
@@ -1232,4 +1232,4 @@ const IndexerAPICommentReactionSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:359](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L359)
+Defined in: [packages/sdk/src/indexer/schemas.ts:361](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L361)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionSchema.mdx
@@ -257,15 +257,15 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      }>;
      to: ZodObject<{
-        address: ZodUnion<[ZodType<..., ..., ...>, ZodString]>;
-        amount: ZodUnion<[ZodString, ZodString]>;
+        address: ZodUnion<[ZodType<..., ..., ...>, ZodLiteral<...>]>;
+        amount: ZodUnion<[ZodString, ZodLiteral<...>]>;
         symbol: ZodString;
       }, "strip", ZodTypeAny, {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
       }, {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      }>;
@@ -276,7 +276,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -287,7 +287,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -518,7 +518,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: ... | ...;
            amount: string;
            symbol: string;
         };
@@ -651,7 +651,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: ... | ...;
            amount: string;
            symbol: string;
         };
@@ -924,7 +924,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -938,7 +938,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1210,7 +1210,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
            symbol: string;
         };
         to: {
-           address: string;
+           address: "" | `0x${string}`;
            amount: string;
            symbol: string;
         };
@@ -1224,7 +1224,7 @@ const IndexerAPICommentReactionSchema: ZodObject<{
         symbol: string;
      };
      to: {
-        address: string;
+        address: "" | `0x${string}`;
         amount: string;
         symbol: string;
      };
@@ -1232,4 +1232,4 @@ const IndexerAPICommentReactionSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:361](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L361)
+Defined in: [packages/sdk/src/indexer/schemas.ts:367](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L367)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceENSSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceENSSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceENSSchema: ZodObject<IndexerAPICommentReferenceENSSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:183](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L183)
+Defined in: [packages/sdk/src/indexer/schemas.ts:185](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L185)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceENSSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceENSSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceENSSchema: ZodObject<IndexerAPICommentReferenceENSSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:185](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L185)
+Defined in: [packages/sdk/src/indexer/schemas.ts:191](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L191)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceERC20Schema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceERC20Schema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceERC20Schema: ZodObject<IndexerAPICommentReferenceERC20SchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:214](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L214)
+Defined in: [packages/sdk/src/indexer/schemas.ts:220](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L220)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceERC20Schema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceERC20Schema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceERC20Schema: ZodObject<IndexerAPICommentReferenceERC20SchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:212](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L212)
+Defined in: [packages/sdk/src/indexer/schemas.ts:214](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L214)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceFarcasterSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceFarcasterSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceFarcasterSchema: ZodObject<IndexerAPICommentReferenceFarcasterSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:196](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L196)
+Defined in: [packages/sdk/src/indexer/schemas.ts:198](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L198)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceFarcasterSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceFarcasterSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceFarcasterSchema: ZodObject<IndexerAPICommentReferenceFarcasterSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:198](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L198)
+Defined in: [packages/sdk/src/indexer/schemas.ts:204](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L204)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencePositionSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencePositionSchema.mdx
@@ -19,4 +19,4 @@ const IndexerAPICommentReferencePositionSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:180](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L180)
+Defined in: [packages/sdk/src/indexer/schemas.ts:186](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L186)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencePositionSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencePositionSchema.mdx
@@ -19,4 +19,4 @@ const IndexerAPICommentReferencePositionSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:178](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L178)
+Defined in: [packages/sdk/src/indexer/schemas.ts:180](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L180)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceSchema: ZodUnion<IndexerAPICommentReferenceSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:293](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L293)
+Defined in: [packages/sdk/src/indexer/schemas.ts:299](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L299)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceSchema: ZodUnion<IndexerAPICommentReferenceSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:291](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L291)
+Defined in: [packages/sdk/src/indexer/schemas.ts:293](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L293)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLFileSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLFileSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLFileSchema: ZodObject<IndexerAPICommentReferenceURLFileSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:258](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L258)
+Defined in: [packages/sdk/src/indexer/schemas.ts:260](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L260)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLFileSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLFileSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLFileSchema: ZodObject<IndexerAPICommentReferenceURLFileSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:260](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L260)
+Defined in: [packages/sdk/src/indexer/schemas.ts:266](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L266)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLImageSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLImageSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLImageSchema: ZodObject<IndexerAPICommentReferenceURLImageSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:269](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L269)
+Defined in: [packages/sdk/src/indexer/schemas.ts:271](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L271)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLImageSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLImageSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLImageSchema: ZodObject<IndexerAPICommentReferenceURLImageSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:271](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L271)
+Defined in: [packages/sdk/src/indexer/schemas.ts:277](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L277)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLVideoSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLVideoSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLVideoSchema: ZodObject<IndexerAPICommentReferenceURLVideoSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:280](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L280)
+Defined in: [packages/sdk/src/indexer/schemas.ts:282](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L282)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLVideoSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLVideoSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLVideoSchema: ZodObject<IndexerAPICommentReferenceURLVideoSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:282](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L282)
+Defined in: [packages/sdk/src/indexer/schemas.ts:288](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L288)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLWebPageSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLWebPageSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLWebPageSchema: ZodObject<IndexerAPICommentReferenceURLWebPageSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:237](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L237)
+Defined in: [packages/sdk/src/indexer/schemas.ts:239](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L239)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLWebPageSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLWebPageSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLWebPageSchema: ZodObject<IndexerAPICommentReferenceURLWebPageSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:239](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L239)
+Defined in: [packages/sdk/src/indexer/schemas.ts:245](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L245)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferencesSchema: ZodArray<IndexerAPICommentReferencesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:307](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L307)
+Defined in: [packages/sdk/src/indexer/schemas.ts:313](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L313)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferencesSchema: ZodArray<IndexerAPICommentReferencesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:305](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L305)
+Defined in: [packages/sdk/src/indexer/schemas.ts:307](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L307)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentSchema: ZodObject<IndexerAPICommentSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:315](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L315)
+Defined in: [packages/sdk/src/indexer/schemas.ts:321](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L321)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentSchema: ZodObject<IndexerAPICommentSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:313](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L313)
+Defined in: [packages/sdk/src/indexer/schemas.ts:315](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L315)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentWithRepliesOutputSchema: ZodObject<IndexerAPICommentWithRepliesOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:402](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L402)
+Defined in: [packages/sdk/src/indexer/schemas.ts:408](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L408)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentWithRepliesOutputSchema: ZodObject<IndexerAPICommentWithRepliesOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:400](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L400)
+Defined in: [packages/sdk/src/indexer/schemas.ts:402](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L402)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentWithRepliesSchema: ZodObject<IndexerAPICommentWithRepliesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:387](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L387)
+Defined in: [packages/sdk/src/indexer/schemas.ts:389](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L389)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentWithRepliesSchema: ZodObject<IndexerAPICommentWithRepliesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:389](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L389)
+Defined in: [packages/sdk/src/indexer/schemas.ts:395](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L395)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentZeroExSwapSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentZeroExSwapSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentZeroExSwapSchema: ZodObject<IndexerAPICommentZeroExSwapSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:161](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L161)
+Defined in: [packages/sdk/src/indexer/schemas.ts:167](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L167)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIExtraSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIExtraSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIExtraSchema: ZodObject<IndexerAPIExtraSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:380](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L380)
+Defined in: [packages/sdk/src/indexer/schemas.ts:382](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L382)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIExtraSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIExtraSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIExtraSchema: ZodObject<IndexerAPIExtraSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:382](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L382)
+Defined in: [packages/sdk/src/indexer/schemas.ts:388](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L388)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIGetAutocompleteOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIGetAutocompleteOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIGetAutocompleteOutputSchema: ZodObject<IndexerAPIGetAutocompleteOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:592](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L592)
+Defined in: [packages/sdk/src/indexer/schemas.ts:598](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L598)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIGetAutocompleteOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIGetAutocompleteOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIGetAutocompleteOutputSchema: ZodObject<IndexerAPIGetAutocompleteOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:590](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L590)
+Defined in: [packages/sdk/src/indexer/schemas.ts:592](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L592)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentRepliesOutputSchema: ZodObject<IndexerAPIListCommentRepliesOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:444](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L444)
+Defined in: [packages/sdk/src/indexer/schemas.ts:446](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L446)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentRepliesOutputSchema: ZodObject<IndexerAPIListCommentRepliesOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:446](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L446)
+Defined in: [packages/sdk/src/indexer/schemas.ts:452](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L452)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentRepliesSchema: ZodObject<IndexerAPIListCommentRepliesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:434](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L434)
+Defined in: [packages/sdk/src/indexer/schemas.ts:436](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L436)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentRepliesSchema: ZodObject<IndexerAPIListCommentRepliesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:436](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L436)
+Defined in: [packages/sdk/src/indexer/schemas.ts:442](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L442)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentsOutputSchema: ZodObject<IndexerAPIListCommentsOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:425](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L425)
+Defined in: [packages/sdk/src/indexer/schemas.ts:431](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L431)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentsOutputSchema: ZodObject<IndexerAPIListCommentsOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:423](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L423)
+Defined in: [packages/sdk/src/indexer/schemas.ts:425](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L425)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentsSchema: ZodObject<IndexerAPIListCommentsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:413](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L413)
+Defined in: [packages/sdk/src/indexer/schemas.ts:415](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L415)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentsSchema: ZodObject<IndexerAPIListCommentsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:415](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L415)
+Defined in: [packages/sdk/src/indexer/schemas.ts:421](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L421)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema: ZodObject<IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:482](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L482)
+Defined in: [packages/sdk/src/indexer/schemas.ts:488](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L488)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema: ZodObject<IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:480](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L480)
+Defined in: [packages/sdk/src/indexer/schemas.ts:482](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L482)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationChangeModerationStatusOnCommentSchema: ZodObject<IndexerAPIModerationChangeModerationStatusOnCommentSchemaType> = IndexerAPICommentSchema;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:476](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L476)
+Defined in: [packages/sdk/src/indexer/schemas.ts:482](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L482)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationChangeModerationStatusOnCommentSchema: ZodObject<IndexerAPIModerationChangeModerationStatusOnCommentSchemaType> = IndexerAPICommentSchema;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:474](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L474)
+Defined in: [packages/sdk/src/indexer/schemas.ts:476](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L476)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationGetPendingCommentsOutputSchema: ZodObject<IndexerAPIModerationGetPendingCommentsOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:466](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L466)
+Defined in: [packages/sdk/src/indexer/schemas.ts:472](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L472)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationGetPendingCommentsOutputSchema: ZodObject<IndexerAPIModerationGetPendingCommentsOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:464](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L464)
+Defined in: [packages/sdk/src/indexer/schemas.ts:466](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L466)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationGetPendingCommentsSchema: ZodObject<IndexerAPIModerationGetPendingCommentsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:455](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L455)
+Defined in: [packages/sdk/src/indexer/schemas.ts:457](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L457)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationGetPendingCommentsSchema: ZodObject<IndexerAPIModerationGetPendingCommentsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:457](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L457)
+Defined in: [packages/sdk/src/indexer/schemas.ts:463](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L463)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIPaginationSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIPaginationSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIPaginationSchema: ZodObject<IndexerAPIPaginationSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:370](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L370)
+Defined in: [packages/sdk/src/indexer/schemas.ts:372](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L372)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIPaginationSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIPaginationSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIPaginationSchema: ZodObject<IndexerAPIPaginationSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:372](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L372)
+Defined in: [packages/sdk/src/indexer/schemas.ts:378](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L378)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportOutputSchema: ZodObject<IndexerAPIReportOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:616](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L616)
+Defined in: [packages/sdk/src/indexer/schemas.ts:618](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L618)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportOutputSchema: ZodObject<IndexerAPIReportOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:618](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L618)
+Defined in: [packages/sdk/src/indexer/schemas.ts:624](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L624)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportSchema: ZodObject<IndexerAPIReportSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:606](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L606)
+Defined in: [packages/sdk/src/indexer/schemas.ts:612](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L612)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportSchema: ZodObject<IndexerAPIReportSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:604](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L604)
+Defined in: [packages/sdk/src/indexer/schemas.ts:606](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L606)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportStatusSchema: ZodEnum<["pending", "resolved", "closed"]>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:600](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L600)
+Defined in: [packages/sdk/src/indexer/schemas.ts:606](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L606)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportStatusSchema: ZodEnum<["pending", "resolved", "closed"]>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:598](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L598)
+Defined in: [packages/sdk/src/indexer/schemas.ts:600](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L600)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportsListPendingOutputSchema: ZodObject<IndexerAPIReportsListPendingOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:635](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L635)
+Defined in: [packages/sdk/src/indexer/schemas.ts:637](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L637)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportsListPendingOutputSchema: ZodObject<IndexerAPIReportsListPendingOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:637](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L637)
+Defined in: [packages/sdk/src/indexer/schemas.ts:643](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L643)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportsListPendingSchema: ZodObject<IndexerAPIReportsListPendingSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:626](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L626)
+Defined in: [packages/sdk/src/indexer/schemas.ts:628](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L628)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportsListPendingSchema: ZodObject<IndexerAPIReportsListPendingSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:628](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L628)
+Defined in: [packages/sdk/src/indexer/schemas.ts:634](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L634)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIZeroExSwapPossibleEmptyAddressSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIZeroExSwapPossibleEmptyAddressSchema.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [indexer](/sdk-reference/indexer/index.mdx) / IndexerAPIZeroExSwapPossibleEmptyAddressSchema
+
+# Variable: IndexerAPIZeroExSwapPossibleEmptyAddressSchema
+
+```ts
+const IndexerAPIZeroExSwapPossibleEmptyAddressSchema: ZodUnion<[ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>, ZodLiteral<"">]>;
+```
+
+Defined in: [packages/sdk/src/indexer/schemas.ts:161](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L161)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [indexer](/sdk-reference/indexer/index.mdx) / IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema
+
+# Variable: IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema
+
+```ts
+const IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema: ZodUnion<[ZodString, ZodLiteral<"">]>;
+```
+
+Defined in: [packages/sdk/src/indexer/schemas.ts:164](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L164)

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -477,10 +477,15 @@ paths:
                             to:
                               type: object
                               properties:
-                                address: {}
+                                address:
+                                  anyOf:
+                                    - {}
+                                    - type: string
                                 amount:
-                                  type: string
-                                  pattern: ^\d+(\.\d+)?$
+                                  anyOf:
+                                    - type: string
+                                      pattern: ^\d+(\.\d+)?$
+                                    - type: string
                                 symbol:
                                   type: string
                               required:
@@ -897,10 +902,15 @@ paths:
                                     to:
                                       type: object
                                       properties:
-                                        address: {}
+                                        address:
+                                          anyOf:
+                                            - {}
+                                            - type: string
                                         amount:
-                                          type: string
-                                          pattern: ^\d+(\.\d+)?$
+                                          anyOf:
+                                            - type: string
+                                              pattern: ^\d+(\.\d+)?$
+                                            - type: string
                                         symbol:
                                           type: string
                                       required:
@@ -1359,10 +1369,15 @@ paths:
                                       to:
                                         type: object
                                         properties:
-                                          address: {}
+                                          address:
+                                            anyOf:
+                                              - {}
+                                              - type: string
                                           amount:
-                                            type: string
-                                            pattern: ^\d+(\.\d+)?$
+                                            anyOf:
+                                              - type: string
+                                                pattern: ^\d+(\.\d+)?$
+                                              - type: string
                                           symbol:
                                             type: string
                                         required:
@@ -1779,10 +1794,15 @@ paths:
                                               to:
                                                 type: object
                                                 properties:
-                                                  address: {}
+                                                  address:
+                                                    anyOf:
+                                                      - {}
+                                                      - type: string
                                                   amount:
-                                                    type: string
-                                                    pattern: ^\d+(\.\d+)?$
+                                                    anyOf:
+                                                      - type: string
+                                                        pattern: ^\d+(\.\d+)?$
+                                                      - type: string
                                                   symbol:
                                                     type: string
                                                 required:
@@ -2468,10 +2488,15 @@ paths:
                             to:
                               type: object
                               properties:
-                                address: {}
+                                address:
+                                  anyOf:
+                                    - {}
+                                    - type: string
                                 amount:
-                                  type: string
-                                  pattern: ^\d+(\.\d+)?$
+                                  anyOf:
+                                    - type: string
+                                      pattern: ^\d+(\.\d+)?$
+                                    - type: string
                                 symbol:
                                   type: string
                               required:
@@ -2888,10 +2913,15 @@ paths:
                                     to:
                                       type: object
                                       properties:
-                                        address: {}
+                                        address:
+                                          anyOf:
+                                            - {}
+                                            - type: string
                                         amount:
-                                          type: string
-                                          pattern: ^\d+(\.\d+)?$
+                                          anyOf:
+                                            - type: string
+                                              pattern: ^\d+(\.\d+)?$
+                                            - type: string
                                         symbol:
                                           type: string
                                       required:
@@ -3350,10 +3380,15 @@ paths:
                                       to:
                                         type: object
                                         properties:
-                                          address: {}
+                                          address:
+                                            anyOf:
+                                              - {}
+                                              - type: string
                                           amount:
-                                            type: string
-                                            pattern: ^\d+(\.\d+)?$
+                                            anyOf:
+                                              - type: string
+                                                pattern: ^\d+(\.\d+)?$
+                                              - type: string
                                           symbol:
                                             type: string
                                         required:
@@ -3770,10 +3805,15 @@ paths:
                                               to:
                                                 type: object
                                                 properties:
-                                                  address: {}
+                                                  address:
+                                                    anyOf:
+                                                      - {}
+                                                      - type: string
                                                   amount:
-                                                    type: string
-                                                    pattern: ^\d+(\.\d+)?$
+                                                    anyOf:
+                                                      - type: string
+                                                        pattern: ^\d+(\.\d+)?$
+                                                      - type: string
                                                   symbol:
                                                     type: string
                                                 required:
@@ -4704,10 +4744,15 @@ paths:
                             to:
                               type: object
                               properties:
-                                address: {}
+                                address:
+                                  anyOf:
+                                    - {}
+                                    - type: string
                                 amount:
-                                  type: string
-                                  pattern: ^\d+(\.\d+)?$
+                                  anyOf:
+                                    - type: string
+                                      pattern: ^\d+(\.\d+)?$
+                                    - type: string
                                 symbol:
                                   type: string
                               required:
@@ -5217,10 +5262,15 @@ paths:
                       to:
                         type: object
                         properties:
-                          address: {}
+                          address:
+                            anyOf:
+                              - {}
+                              - type: string
                           amount:
-                            type: string
-                            pattern: ^\d+(\.\d+)?$
+                            anyOf:
+                              - type: string
+                                pattern: ^\d+(\.\d+)?$
+                              - type: string
                           symbol:
                             type: string
                         required:
@@ -5711,10 +5761,15 @@ paths:
                       to:
                         type: object
                         properties:
-                          address: {}
+                          address:
+                            anyOf:
+                              - {}
+                              - type: string
                           amount:
-                            type: string
-                            pattern: ^\d+(\.\d+)?$
+                            anyOf:
+                              - type: string
+                                pattern: ^\d+(\.\d+)?$
+                              - type: string
                           symbol:
                             type: string
                         required:

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -481,11 +481,15 @@ paths:
                                   anyOf:
                                     - {}
                                     - type: string
+                                      enum:
+                                        - ''
                                 amount:
                                   anyOf:
                                     - type: string
                                       pattern: ^\d+(\.\d+)?$
                                     - type: string
+                                      enum:
+                                        - ''
                                 symbol:
                                   type: string
                               required:
@@ -906,11 +910,15 @@ paths:
                                           anyOf:
                                             - {}
                                             - type: string
+                                              enum:
+                                                - ''
                                         amount:
                                           anyOf:
                                             - type: string
                                               pattern: ^\d+(\.\d+)?$
                                             - type: string
+                                              enum:
+                                                - ''
                                         symbol:
                                           type: string
                                       required:
@@ -1373,11 +1381,15 @@ paths:
                                             anyOf:
                                               - {}
                                               - type: string
+                                                enum:
+                                                  - ''
                                           amount:
                                             anyOf:
                                               - type: string
                                                 pattern: ^\d+(\.\d+)?$
                                               - type: string
+                                                enum:
+                                                  - ''
                                           symbol:
                                             type: string
                                         required:
@@ -1798,11 +1810,15 @@ paths:
                                                     anyOf:
                                                       - {}
                                                       - type: string
+                                                        enum:
+                                                          - ''
                                                   amount:
                                                     anyOf:
                                                       - type: string
                                                         pattern: ^\d+(\.\d+)?$
                                                       - type: string
+                                                        enum:
+                                                          - ''
                                                   symbol:
                                                     type: string
                                                 required:
@@ -2492,11 +2508,15 @@ paths:
                                   anyOf:
                                     - {}
                                     - type: string
+                                      enum:
+                                        - ''
                                 amount:
                                   anyOf:
                                     - type: string
                                       pattern: ^\d+(\.\d+)?$
                                     - type: string
+                                      enum:
+                                        - ''
                                 symbol:
                                   type: string
                               required:
@@ -2917,11 +2937,15 @@ paths:
                                           anyOf:
                                             - {}
                                             - type: string
+                                              enum:
+                                                - ''
                                         amount:
                                           anyOf:
                                             - type: string
                                               pattern: ^\d+(\.\d+)?$
                                             - type: string
+                                              enum:
+                                                - ''
                                         symbol:
                                           type: string
                                       required:
@@ -3384,11 +3408,15 @@ paths:
                                             anyOf:
                                               - {}
                                               - type: string
+                                                enum:
+                                                  - ''
                                           amount:
                                             anyOf:
                                               - type: string
                                                 pattern: ^\d+(\.\d+)?$
                                               - type: string
+                                                enum:
+                                                  - ''
                                           symbol:
                                             type: string
                                         required:
@@ -3809,11 +3837,15 @@ paths:
                                                     anyOf:
                                                       - {}
                                                       - type: string
+                                                        enum:
+                                                          - ''
                                                   amount:
                                                     anyOf:
                                                       - type: string
                                                         pattern: ^\d+(\.\d+)?$
                                                       - type: string
+                                                        enum:
+                                                          - ''
                                                   symbol:
                                                     type: string
                                                 required:
@@ -4748,11 +4780,15 @@ paths:
                                   anyOf:
                                     - {}
                                     - type: string
+                                      enum:
+                                        - ''
                                 amount:
                                   anyOf:
                                     - type: string
                                       pattern: ^\d+(\.\d+)?$
                                     - type: string
+                                      enum:
+                                        - ''
                                 symbol:
                                   type: string
                               required:
@@ -5266,11 +5302,15 @@ paths:
                             anyOf:
                               - {}
                               - type: string
+                                enum:
+                                  - ''
                           amount:
                             anyOf:
                               - type: string
                                 pattern: ^\d+(\.\d+)?$
                               - type: string
+                                enum:
+                                  - ''
                           symbol:
                             type: string
                         required:
@@ -5765,11 +5805,15 @@ paths:
                             anyOf:
                               - {}
                               - type: string
+                                enum:
+                                  - ''
                           amount:
                             anyOf:
                               - type: string
                                 pattern: ^\d+(\.\d+)?$
                               - type: string
+                                enum:
+                                  - ''
                           symbol:
                             type: string
                         required:

--- a/packages/sdk/src/indexer/schemas.ts
+++ b/packages/sdk/src/indexer/schemas.ts
@@ -158,6 +158,12 @@ export const IndexerAPIZeroExTokenAmountSchema = z.coerce
     message: "Amount must be a number with optional decimal part",
   });
 
+export const IndexerAPIZeroExSwapPossibleEmptyAddressSchema = HexSchema.or(
+  z.literal(""),
+);
+export const IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema =
+  IndexerAPIZeroExTokenAmountSchema.or(z.literal(""));
+
 export const IndexerAPICommentZeroExSwapSchema = z.object({
   from: z.object({
     address: HexSchema,
@@ -167,8 +173,8 @@ export const IndexerAPICommentZeroExSwapSchema = z.object({
   // in case of native sell 0x swap parser can fallback to empty strings
   // if it can't find the log for the taker
   to: z.object({
-    address: HexSchema.or(z.string()),
-    amount: IndexerAPIZeroExTokenAmountSchema.or(z.string()),
+    address: IndexerAPIZeroExSwapPossibleEmptyAddressSchema,
+    amount: IndexerAPIZeroExSwapPossiblyEmptyTokenAmountSchema,
     symbol: z.string(),
   }),
 });

--- a/packages/sdk/src/indexer/schemas.ts
+++ b/packages/sdk/src/indexer/schemas.ts
@@ -164,9 +164,11 @@ export const IndexerAPICommentZeroExSwapSchema = z.object({
     amount: IndexerAPIZeroExTokenAmountSchema,
     symbol: z.string(),
   }),
+  // in case of native sell 0x swap parser can fallback to empty strings
+  // if it can't find the log for the taker
   to: z.object({
-    address: HexSchema,
-    amount: IndexerAPIZeroExTokenAmountSchema,
+    address: HexSchema.or(z.string()),
+    amount: IndexerAPIZeroExTokenAmountSchema.or(z.string()),
     symbol: z.string(),
   }),
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for empty strings in address and amount fields related to 0x swap data, improving API response handling and SDK compatibility.

* **Documentation**
  * Updated documentation to reflect relaxed type constraints for address and amount fields.
  * Corrected source code line references across multiple SDK and API docs for improved accuracy.
  * Added new schema references for handling possible empty addresses and token amounts.

* **Style**
  * Minor formatting improvements in schemas and documentation for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->