### PR TITLE
docs: grammar fixes

### DIFF
--- a/docs/pages/architecture-overview.mdx
+++ b/docs/pages/architecture-overview.mdx
@@ -43,7 +43,7 @@ See [ChannelManager](/contracts#channel-manager-contract-details) for more detai
 
 ### 3. Indexer
 
-- Listens for comment events on-chain
+- Listens for comment events onchain
 - Processes and indexes comments for efficient querying
 - Maintains a synchronized database of all comments
 

--- a/docs/pages/channels.mdx
+++ b/docs/pages/channels.mdx
@@ -10,7 +10,7 @@ The channel owner can set the **hooks** for their channel that enable flexible a
 
 To prevent spam and ensure quality channels, creating a new channel requires paying a small fee. The current channel creation fee can be retrieved by calling `getChannelCreationFee` from the SDK. This fee helps maintain the quality of channels in the protocol while still keeping channel creation accessible.
 
-Together with [hooks](/hooks), channels create a flexible system for building on-chain communities and apps with customizable rules.
+Together with [hooks](/hooks), channels create a flexible system for building onchain communities and apps with customizable rules.
 
 Creating a channel currently requires paying a fee, currently set to 0.02 ETH, to deter initial spam, while we figure out how to combat it. If you are building an app that will create channels, feel free to reach out to us and we may be able to sponsor the channel fee.
 

--- a/docs/pages/contracts.mdx
+++ b/docs/pages/contracts.mdx
@@ -19,22 +19,22 @@ import { CommentManagerABI, ChannelManagerABI } from "@ecp.eth/sdk/abis";
 
 ### Comment Manager Contract Functions
 
-| Function                  | Description                                        | Note                                                           |
-| ------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
-| `postComment`             | Post a comment with app signature verification     | Requires author to be msg.sender                               |
-| `postCommentWithSig`      | Post a comment with both author and app signatures | Allows posting on behalf of author with signatures             |
-| `editComment`             | Edit a comment with app signature verification     | Requires author to be msg.sender                               |
-| `editCommentWithSig`      | Edit a comment with both author and app signatures | Allows editing on behalf of author with signatures             |
-| `deleteComment`           | Delete a comment when called by the author         | ⚠️ Deleted data may still be traceable or recoverable on-chain |
-| `deleteCommentWithSig`    | Delete a comment with signature verification       | ⚠️ Deleted data may still be traceable or recoverable on-chain |
-| `addApproval`             | Approve an app signer directly                     | Called by the author                                           |
-| `addApprovalWithSig`      | Approve an app signer with signature               | Allows approving on behalf of author with signature            |
-| `revokeApproval`          | Remove an app signer approval directly             | Called by the author                                           |
-| `removeApprovalWithSig`   | Remove an app signer approval with signature       | Allows revoking on behalf of author with signature             |
-| `getComment`              | Get a comment by ID                                |                                                                |
-| `getCommentMetadataKeys`  | Get the metadata keys for a comment                |                                                                |
-| `getCommentMetadataValue` | Get the metadata value for a comment               |                                                                |
-| ...                       | ...                                                | ...                                                            |
+| Function                  | Description                                        | Note                                                          |
+| ------------------------- | -------------------------------------------------- | ------------------------------------------------------------- |
+| `postComment`             | Post a comment with app signature verification     | Requires author to be msg.sender                              |
+| `postCommentWithSig`      | Post a comment with both author and app signatures | Allows posting on behalf of author with signatures            |
+| `editComment`             | Edit a comment with app signature verification     | Requires author to be msg.sender                              |
+| `editCommentWithSig`      | Edit a comment with both author and app signatures | Allows editing on behalf of author with signatures            |
+| `deleteComment`           | Delete a comment when called by the author         | ⚠️ Deleted data may still be traceable or recoverable onchain |
+| `deleteCommentWithSig`    | Delete a comment with signature verification       | ⚠️ Deleted data may still be traceable or recoverable onchain |
+| `addApproval`             | Approve an app signer directly                     | Called by the author                                          |
+| `addApprovalWithSig`      | Approve an app signer with signature               | Allows approving on behalf of author with signature           |
+| `revokeApproval`          | Remove an app signer approval directly             | Called by the author                                          |
+| `removeApprovalWithSig`   | Remove an app signer approval with signature       | Allows revoking on behalf of author with signature            |
+| `getComment`              | Get a comment by ID                                |                                                               |
+| `getCommentMetadataKeys`  | Get the metadata keys for a comment                |                                                               |
+| `getCommentMetadataValue` | Get the metadata value for a comment               |                                                               |
+| ...                       | ...                                                | ...                                                           |
 
 For detailed information about all functions, events, and structs, please refer to the [Contract ABI Documentation](/protocol-reference/CommentManager).
 

--- a/docs/pages/dual-signature-system.mdx
+++ b/docs/pages/dual-signature-system.mdx
@@ -82,7 +82,7 @@ If interacting with the protocol directly, the user can also choose to self sign
 
 ## Authentication Methods
 
-Each comment stores how it was authenticated on-chain via an `authMethod` field.
+Each comment stores how it was authenticated onchain via an `authMethod` field.
 
 - **`0` (DIRECT_TX)** - User signed transaction directly
 - **`1` (APP_APPROVAL)** - User pre-approved the app

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -35,7 +35,7 @@ If there's enough interest from developers we are open to adding support for new
 
 ## Will ECP build an App to compete with my App built on ECP?
 
-We want to avoid misalignment and competition between the ECP protocol team and potential integrators. We may build apps in the future to try to help drive the growth of ECP, but our current approach is to focused on aligning other builders to build on ECP, and avoiding building a traditional social super app.
+We want to avoid misalignment and competition between the ECP protocol team and potential integrators. We may build apps in the future to try to help drive the growth of ECP, but our current approach is focused on aligning other builders to build on ECP, and avoiding building a traditional social super app.
 
 ## Is there a way to quickly deploy signer api?
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to consistently use the term "onchain" instead of "on-chain."
  * Fixed a grammatical error in the FAQ section for improved clarity.
  * Adjusted table formatting in the contracts documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->