### PR TITLE
fix(embed): schema default

### DIFF
--- a/apps/embed/src/lib/schemas.ts
+++ b/apps/embed/src/lib/schemas.ts
@@ -5,7 +5,7 @@ import { CommentDataWithIdSchema } from "@ecp.eth/shared/schemas";
 import { MAX_COMMENT_LENGTH } from "./constants";
 import { decompressFromURI } from "lz-ts";
 import { MetadataEntrySchema } from "@ecp.eth/sdk/comments";
-import { DEFAULT_CHAIN_ID, DEFAULT_COMMENT_TYPE } from "@ecp.eth/sdk";
+import { DEFAULT_COMMENT_TYPE } from "@ecp.eth/sdk";
 
 export const BadRequestResponseSchema = z.record(
   z.string(),
@@ -68,19 +68,12 @@ export type SignEditCommentPayloadRequestSchemaType = z.infer<
   typeof SignEditCommentPayloadRequestSchema
 >;
 
-export const EmbedConfigFromSearchParamsSchema = z.preprocess(
-  (value) => {
-    try {
-      if (typeof value === "string") {
-        return JSON.parse(decompressFromURI(value));
-      }
-    } catch (err) {
-      console.warn("failed to parse config", err);
+export const EmbedConfigFromSearchParamsSchema = z.preprocess((value) => {
+  try {
+    if (typeof value === "string") {
+      return JSON.parse(decompressFromURI(value));
     }
-  },
-  EmbedConfigSchema.default({
-    chainId: DEFAULT_CHAIN_ID,
-    restrictMaximumContainerWidth: true,
-    disablePromotion: true,
-  }),
-);
+  } catch (err) {
+    console.warn("failed to parse config", err);
+  }
+}, EmbedConfigSchema.default({}));


### PR DESCRIPTION
previously added those schema default due to testing out zod v4 (v4 complaints when there is no props).
but since we are still on v3 these are not necessary and cause problem testing locally, with these default local testing will use base mainnet instead of following what is defined in sdk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined configuration schema handling for embed settings, simplifying default value management. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->