### PR TITLE
fix(demo,embed): reply mode

### DIFF
--- a/apps/demo/src/components/comments/core/CommentItem.tsx
+++ b/apps/demo/src/components/comments/core/CommentItem.tsx
@@ -151,7 +151,7 @@ export function CommentItem({ comment }: CommentItemProps) {
         commentId: comment.id,
         signal,
         viewer: connectedAddress,
-        mode: "flat",
+        mode: comment.parentId ? undefined : "flat",
         commentType: COMMENT_TYPE_COMMENT,
       });
 
@@ -184,7 +184,7 @@ export function CommentItem({ comment }: CommentItemProps) {
         sort: "asc",
         signal,
         viewer: connectedAddress,
-        mode: "flat",
+        mode: comment.parentId ? undefined : "flat",
         commentType: COMMENT_TYPE_COMMENT,
       });
     },

--- a/apps/embed/src/components/comments/CommentItem.tsx
+++ b/apps/embed/src/components/comments/CommentItem.tsx
@@ -96,7 +96,7 @@ export function CommentItem({ comment }: CommentItemProps) {
         commentId: comment.id,
         signal,
         viewer: connectedAddress,
-        mode: "flat",
+        mode: comment.parentId ? undefined : "flat",
         commentType: COMMENT_TYPE_COMMENT,
       });
 
@@ -129,7 +129,7 @@ export function CommentItem({ comment }: CommentItemProps) {
         sort: "asc",
         signal,
         viewer: connectedAddress,
-        mode: "flat",
+        mode: comment.parentId ? undefined : "flat",
         commentType: COMMENT_TYPE_COMMENT,
       });
     },


### PR DESCRIPTION
non-root comment cannot use flat mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the way comment replies are loaded by adjusting how replies are fetched for top-level comments versus nested replies, resulting in more accurate display and updating of comment threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->