### PR TITLE
fix(indexer): correctly escape markdown v1 syntax for telegram

### DIFF
--- a/.changeset/ready-cows-rescue.md
+++ b/.changeset/ready-cows-rescue.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/shared": patch
+---
+
+feat(shared): add a possibility to override element renderers in renderToMarkdown

--- a/apps/indexer/src/services/admin-telegram-bot-service/commands/moderate-menu.ts
+++ b/apps/indexer/src/services/admin-telegram-bot-service/commands/moderate-menu.ts
@@ -9,6 +9,7 @@ import {
 import { CommentModerationStatus } from "../../../management/types";
 import { b, fmt } from "@grammyjs/parse-mode";
 import { renderToMarkdown } from "@ecp.eth/shared/renderer";
+import { escapeTelegramMarkdownTextElement } from "../../../utils/escapeTelegramMarkdownTextElement";
 
 export const moderateMenu = new Menu<AdminTelegramBotServiceContext>(
   MenuId.MODERATE_MAIN_MENU,
@@ -60,6 +61,9 @@ export const moderateMenu = new Menu<AdminTelegramBotServiceContext>(
         content: comment.content,
         references: comment.references,
         maxLength: 4000,
+        elementRenderers: {
+          text: escapeTelegramMarkdownTextElement,
+        },
       });
 
       await ctx.reply(renderResult.result, {

--- a/apps/indexer/src/services/moderation-notifications-service.ts
+++ b/apps/indexer/src/services/moderation-notifications-service.ts
@@ -13,6 +13,7 @@ import type {
 import type { CommentSelectType } from "ponder:schema";
 import { isZeroHex } from "@ecp.eth/sdk/core";
 import { env } from "../env";
+import { escapeTelegramMarkdownTextElement } from "../utils/escapeTelegramMarkdownTextElement";
 
 class CommentLengthLimitExceededError extends Error {
   constructor(message: string) {
@@ -316,6 +317,9 @@ Content:
       content: comment.content,
       references: comment.references,
       maxLength: remainingLength,
+      elementRenderers: {
+        text: (text) => escapeTelegramMarkdownTextElement(text),
+      },
     });
 
     return message + renderResult.result;

--- a/apps/indexer/src/utils/escapeTelegramMarkdownTextElement.ts
+++ b/apps/indexer/src/utils/escapeTelegramMarkdownTextElement.ts
@@ -1,0 +1,11 @@
+/**
+ * Escapes special characters in a string for use in Telegram Markdown V1.
+ * This function replaces characters that have special meaning in Telegram Markdown V1 with their escaped versions.
+ * It ensures that the text can be safely used in Telegram messages without formatting issues.
+ *
+ * @param text - The text to escape
+ * @returns The escaped text.
+ */
+export function escapeTelegramMarkdownTextElement(text: string): string {
+  return text.replace(/([_*`[])/g, "\\$1"); // escape special characters
+}

--- a/apps/indexer/tests/utils/escapeTelegramMarkdownTextElement.test.ts
+++ b/apps/indexer/tests/utils/escapeTelegramMarkdownTextElement.test.ts
@@ -1,0 +1,22 @@
+import { renderToMarkdown } from "@ecp.eth/shared/renderer";
+import { describe, expect, it } from "vitest";
+import { escapeTelegramMarkdownTextElement } from "../../src/utils/escapeTelegramMarkdownTextElement";
+
+describe("escapeTelegramMarkdownTextElement", () => {
+  it("correctly escapes the text content", () => {
+    const result = renderToMarkdown({
+      content: `There is no Take
+{\\__/}
+( • . •)
+/ > I Love you all ♥️`,
+      references: [],
+      elementRenderers: {
+        text: escapeTelegramMarkdownTextElement,
+      },
+    });
+
+    expect(result.result).toBe(
+      "There is no Take\n\n{\\\\_\\_/}\n\n( • . •)\n\n/ > I Love you all ♥️\n\n",
+    );
+  });
+});

--- a/packages/shared/src/renderer.test.ts
+++ b/packages/shared/src/renderer.test.ts
@@ -1108,5 +1108,19 @@ describe("renderToMarkdown", () => {
         "[https://example.com](https://example.com)\n\n",
       );
     });
+
+    it("allows to pass custom element renderers", () => {
+      const elementRenderers = {
+        text: (text: string) => `**${text}**`,
+      };
+
+      const result = renderToMarkdown({
+        content: "Hello, world!",
+        references: [],
+        elementRenderers,
+      });
+
+      expect(result.result).toBe("**Hello, world!**\n\n");
+    });
   });
 });

--- a/packages/shared/src/renderer.tsx
+++ b/packages/shared/src/renderer.tsx
@@ -531,7 +531,14 @@ export function renderToMarkdown(
   options: Omit<
     RenderOptions<string, IndexerAPICommentReferenceSchemaType>,
     "renderers" | "elementRenderers" | "processMediaReferences"
-  >,
+  > & {
+    elementRenderers?: Partial<
+      RenderOptions<
+        string,
+        IndexerAPICommentReferenceSchemaType
+      >["elementRenderers"]
+    >;
+  },
 ): RenderToMarkdownResult {
   const { result, mediaReferences, isTruncated } = render<
     string,
@@ -539,7 +546,10 @@ export function renderToMarkdown(
   >({
     ...options,
     renderers: markdownReferenceRenderers,
-    elementRenderers: markdownElementRenderers,
+    elementRenderers: {
+      ...markdownElementRenderers,
+      ...options.elementRenderers,
+    },
     processMediaReferences(content) {
       return {
         content,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to customize how elements are rendered when converting content to Markdown, allowing user-defined renderers.
  * Introduced a utility to properly escape special characters for Telegram Markdown formatting, improving message display accuracy.

* **Bug Fixes**
  * Ensured that comment content is safely escaped when rendered for Telegram, preventing unintended formatting.

* **Tests**
  * Added tests to verify custom element renderer support and correct escaping of special characters for Telegram Markdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->