### PR TITLE
fix(shared): set min height when connecting wallet

### DIFF
--- a/packages/shared/src/hooks/useConnectAccount.ts
+++ b/packages/shared/src/hooks/useConnectAccount.ts
@@ -5,6 +5,7 @@ import { useAccount, useAccountEffect } from "wagmi";
 import { useFreshRef } from "./useFreshRef.js";
 
 const CONNECT_WALLET_TIMEOUT = 2 * 60 * 1000; // 2 minutes
+const WALLET_CONNECT_DIALOG_MINIMAL_HEIGHT = 480;
 
 type Deferred = {
   resolve: (account: Hex) => void;
@@ -70,6 +71,7 @@ export function useConnectAccount() {
     deferredRef.current = deferred;
 
     if (openConnectModal) {
+      setDialogMinimalHeight();
       openConnectModal();
     } else {
       deferred.reject(
@@ -80,6 +82,23 @@ export function useConnectAccount() {
     return deferred.promise.finally(() => {
       clearTimeout(deferred.timeout);
       deferredRef.current = null;
+      resetDialogMinimalHeight();
     });
   }, [address, openConnectModal]);
+}
+
+let originalMinHeight: string | undefined;
+
+function setDialogMinimalHeight() {
+  originalMinHeight = document.body.style.minHeight;
+
+  document.body.style.minHeight = `${WALLET_CONNECT_DIALOG_MINIMAL_HEIGHT}px`;
+}
+
+function resetDialogMinimalHeight() {
+  if (originalMinHeight == null) {
+    return;
+  }
+  document.body.style.minHeight = originalMinHeight;
+  originalMinHeight = undefined;
 }

--- a/packages/shared/src/hooks/useConnectAccount.ts
+++ b/packages/shared/src/hooks/useConnectAccount.ts
@@ -90,12 +90,22 @@ export function useConnectAccount() {
 let originalMinHeight: string | undefined;
 
 function setDialogMinimalHeight() {
-  originalMinHeight = document.body.style.minHeight;
+  if (!document) {
+    return;
+  }
+
+  if (originalMinHeight == null) {
+    originalMinHeight = document.body.style.minHeight;
+  }
 
   document.body.style.minHeight = `${WALLET_CONNECT_DIALOG_MINIMAL_HEIGHT}px`;
 }
 
 function resetDialogMinimalHeight() {
+  if (!document) {
+    return;
+  }
+
   if (originalMinHeight == null) {
     return;
   }


### PR DESCRIPTION
enlarge body height to the minimal needed for wallet connect dialog to be fully visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved wallet connection experience by ensuring the connect modal displays with an appropriate minimum height.
* **Bug Fixes**
  * The document body’s minimum height is now properly restored after closing the wallet connect modal, preventing layout issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->