### PR TITLE
feat(docs): add LLM context documentation page

### DIFF
--- a/docs/pages/llm-context.mdx
+++ b/docs/pages/llm-context.mdx
@@ -1,0 +1,31 @@
+# LLM Context Files
+
+The following context files adhere to the [llms.txt standard](https://llmstxt.org/).
+
+## Full Context (Recommended)
+
+A comprehensive guide including all technical details, API references, and implementation examples.
+
+**Download:** [llms-full.txt](/llms-full.txt)
+
+## Minimal Context
+
+A concise overview of the Ethereum Comments Protocol for LLMs.
+
+**Download:** [llms.txt](/llms.txt)
+
+## ⚠️ CAUTION
+
+Large language models and agents can sometimes 'hallucinate' responses or return otherwise inaccurate data. Always verify information against the official documentation and source code.
+
+## About These Files
+
+These context files provide LLMs with structured information about the Ethereum Comments Protocol, including:
+
+- Protocol overview and architecture
+- Smart contract addresses and ABIs
+- API endpoints and schemas
+- Integration examples and code snippets
+- Best practices and security considerations
+
+The files are designed to help LLMs provide accurate, contextual assistance when working with the Ethereum Comments Protocol ecosystem.

--- a/docs/vocs.config.tsx
+++ b/docs/vocs.config.tsx
@@ -184,6 +184,10 @@ export default defineConfig({
           link: "/gas-costs",
         },
         {
+          text: "LLMs.txt",
+          link: "/llm-context",
+        },
+        {
           text: "FAQ",
           link: "/faq",
         },


### PR DESCRIPTION
## Summary
- Add new LLM context documentation page (`llm-context.mdx`)
- Add navigation link in documentation config

## Test plan
- [ ] Verify new documentation page renders correctly
- [ ] Confirm navigation link works in docs site

🤖 Generated with [Claude Code](https://claude.ai/code)