### PR TITLE
fix(indexer): correct API docs for replies endpoint and moderation labels

### DIFF
--- a/apps/indexer/src/api/comments/replies/get.ts
+++ b/apps/indexer/src/api/comments/replies/get.ts
@@ -23,7 +23,7 @@ const getCommentsRoute = createRoute({
   path: "/api/comments/{commentId}/replies",
   tags: ["comments"],
   description:
-    "Return a single comments according to the id and additional criteria",
+    "Return replies to a comment according to the comment id and additional criteria",
   request: {
     query: GetCommentRepliesQuerySchema,
     params: GetCommentRepliesParamSchema,
@@ -35,7 +35,7 @@ const getCommentsRoute = createRoute({
           schema: IndexerAPIListCommentRepliesOutputSchema,
         },
       },
-      description: "Retrieve specific comment with its replies",
+      description: "Retrieve replies to the specified comment",
     },
     400: {
       content: {

--- a/apps/indexer/src/lib/schemas.ts
+++ b/apps/indexer/src/lib/schemas.ts
@@ -245,7 +245,7 @@ export const GetCommentsQuerySchema = z.object({
       type: "string",
       example: "spam,sexual",
       pattern:
-        "^(llm_generated|spam|sexual|hate|violence|harassment|self_harm|sexual_minors|hate_threatening|violence_graphic)$",
+        "^(llm_generated|spam|sexual|hate|violence|harassment|self_harm|sexual_minors|hate_threatening|violence_graphic)(,(llm_generated|spam|sexual|hate|violence|harassment|self_harm|sexual_minors|hate_threatening|violence_graphic))*$",
     }),
   // zod-openapi plugin doesn't automatically infer the minimum value from `int().positive()`
   // so use min(1) for better compatibility


### PR DESCRIPTION
## Summary
- Fixed `/api/comments/{commentId}/replies` endpoint documentation to accurately state it returns replies to a comment, not the comment itself
- Fixed `excludeByModerationLabels` regex pattern to properly validate comma-separated values like `"spam,sexual"`

## Test plan
- [ ] Verify OpenAPI docs generate correctly
- [ ] Test the transaction tester in docs works with comma-separated moderation labels
- [ ] Confirm endpoint documentation accurately reflects actual behavior

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the description of the replies endpoint to clarify that it returns replies to a specific comment.

* **New Features**
  * Enhanced support for filtering comments by allowing multiple moderation labels to be excluded using a comma-separated list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->