### PR TITLE
feat(sdk): add api for fetching one single comment from indexer

### DIFF
--- a/.changeset/eight-shrimps-reply.md
+++ b/.changeset/eight-shrimps-reply.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+feat(sdk): add api to retrieve single comment from indexer

--- a/docs/pages/sdk-reference/indexer/functions/fetchAuthorData.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchAuthorData.mdx
@@ -22,7 +22,7 @@ function fetchAuthorData(options): Promise<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:519](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L519)
+Defined in: [packages/sdk/src/indexer/api.ts:628](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L628)
 
 Fetch author data from the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/functions/fetchAutocomplete.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchAutocomplete.mdx
@@ -42,7 +42,7 @@ function fetchAutocomplete(options): Promise<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:831](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L831)
+Defined in: [packages/sdk/src/indexer/api.ts:940](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L940)
 
 Fetch autocomplete suggestions from the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/functions/fetchChannel.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchChannel.mdx
@@ -23,7 +23,7 @@ function fetchChannel(options): Promise<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:759](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L759)
+Defined in: [packages/sdk/src/indexer/api.ts:868](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L868)
 
 Fetch a single channel by ID from the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/functions/fetchChannels.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchChannels.mdx
@@ -32,7 +32,7 @@ function fetchChannels(options): Promise<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:676](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L676)
+Defined in: [packages/sdk/src/indexer/api.ts:785](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L785)
 
 Fetch channels from the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/functions/fetchComment.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchComment.mdx
@@ -1,0 +1,1204 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [indexer](/sdk-reference/indexer/index.mdx) / fetchComment
+
+# Function: fetchComment()
+
+```ts
+function fetchComment(options): Promise<{
+  app: `0x${string}`;
+  author: {
+     address: `0x${string}`;
+     ens?: {
+        avatarUrl: null | string;
+        name: string;
+     };
+     farcaster?: {
+        displayName?: string;
+        fid: number;
+        pfpUrl?: string;
+        username: string;
+     };
+  };
+  chainId: number;
+  channelId: bigint;
+  commentType: number;
+  content: string;
+  createdAt: Date;
+  cursor: `0x${string}`;
+  deletedAt: null | Date;
+  hookMetadata: {
+     key: `0x${string}`;
+     value: `0x${string}`;
+  }[];
+  id: `0x${string}`;
+  logIndex: null | number;
+  metadata: {
+     key: `0x${string}`;
+     value: `0x${string}`;
+  }[];
+  moderationClassifierResult: Record<string, number>;
+  moderationClassifierScore: number;
+  moderationStatus: "approved" | "pending" | "rejected";
+  moderationStatusChangedAt: Date;
+  parentId: null | `0x${string}`;
+  reactionCounts: Record<string, number>;
+  references: (
+     | {
+     address: `0x${string}`;
+     avatarUrl: null | string;
+     name: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "ens";
+     url: string;
+   }
+     | {
+     address: `0x${string}`;
+     displayName: null | string;
+     fid: number;
+     fname: string;
+     pfpUrl: null | string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "farcaster";
+     url: string;
+     username: string;
+   }
+     | {
+     address: `0x${string}`;
+     chainId: null | number;
+     chains: {
+        caip: string;
+        chainId: number;
+     }[];
+     decimals: number;
+     logoURI: null | string;
+     name: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     symbol: string;
+     type: "erc20";
+   }
+     | {
+     description: null | string;
+     favicon: null | string;
+     opengraph:   | null
+        | {
+        description: null | string;
+        image: string;
+        title: string;
+        url: string;
+      };
+     position: {
+        end: number;
+        start: number;
+     };
+     title: string;
+     type: "webpage";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "file";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "image";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "video";
+     url: string;
+  })[];
+  replies: {
+     extra: {
+        moderationEnabled: boolean;
+        moderationKnownReactions: string[];
+     };
+     pagination: {
+        endCursor?: `0x${string}`;
+        hasNext: boolean;
+        hasPrevious: boolean;
+        limit: number;
+        startCursor?: `0x${string}`;
+     };
+     results: {
+        app: `0x${string}`;
+        author: {
+           address: `0x${string}`;
+           ens?: {
+              avatarUrl: null | string;
+              name: string;
+           };
+           farcaster?: {
+              displayName?: string;
+              fid: number;
+              pfpUrl?: string;
+              username: string;
+           };
+        };
+        chainId: number;
+        channelId: bigint;
+        commentType: number;
+        content: string;
+        createdAt: Date;
+        cursor: `0x${string}`;
+        deletedAt: null | Date;
+        hookMetadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        id: `0x${string}`;
+        logIndex: null | number;
+        metadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        moderationClassifierResult: Record<string, number>;
+        moderationClassifierScore: number;
+        moderationStatus: "approved" | "pending" | "rejected";
+        moderationStatusChangedAt: Date;
+        parentId: null | `0x${string}`;
+        reactionCounts: Record<string, number>;
+        references: (
+           | {
+           address: `0x${string}`;
+           avatarUrl: null | string;
+           name: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "ens";
+           url: string;
+         }
+           | {
+           address: `0x${string}`;
+           displayName: null | string;
+           fid: number;
+           fname: string;
+           pfpUrl: null | string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "farcaster";
+           url: string;
+           username: string;
+         }
+           | {
+           address: `0x${string}`;
+           chainId: null | number;
+           chains: {
+              caip: string;
+              chainId: number;
+           }[];
+           decimals: number;
+           logoURI: null | string;
+           name: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           symbol: string;
+           type: "erc20";
+         }
+           | {
+           description: null | string;
+           favicon: null | string;
+           opengraph:   | null
+              | {
+              description: ... | ...;
+              image: string;
+              title: string;
+              url: string;
+            };
+           position: {
+              end: number;
+              start: number;
+           };
+           title: string;
+           type: "webpage";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "file";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "image";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "video";
+           url: string;
+        })[];
+        revision: number;
+        targetUri: string;
+        txHash: `0x${string}`;
+        updatedAt: Date;
+        viewerReactions: Record<string, {
+           app: `0x${string}`;
+           author: {
+              address: `0x${string}`;
+              ens?: {
+                 avatarUrl: ...;
+                 name: ...;
+              };
+              farcaster?: {
+                 displayName?: ...;
+                 fid: ...;
+                 pfpUrl?: ...;
+                 username: ...;
+              };
+           };
+           chainId: number;
+           channelId: bigint;
+           commentType: number;
+           content: string;
+           createdAt: Date;
+           cursor: `0x${string}`;
+           deletedAt: null | Date;
+           hookMetadata: {
+              key: `0x${(...)}`;
+              value: `0x${(...)}`;
+           }[];
+           id: `0x${string}`;
+           logIndex: null | number;
+           metadata: {
+              key: `0x${(...)}`;
+              value: `0x${(...)}`;
+           }[];
+           moderationClassifierResult: Record<string, number>;
+           moderationClassifierScore: number;
+           moderationStatus: "approved" | "pending" | "rejected";
+           moderationStatusChangedAt: Date;
+           parentId: null | `0x${string}`;
+           references: (
+              | {
+              address: ...;
+              avatarUrl: ...;
+              name: ...;
+              position: ...;
+              type: ...;
+              url: ...;
+            }
+              | {
+              address: ...;
+              displayName: ...;
+              fid: ...;
+              fname: ...;
+              pfpUrl: ...;
+              position: ...;
+              type: ...;
+              url: ...;
+              username: ...;
+            }
+              | {
+              address: ...;
+              chainId: ...;
+              chains: ...;
+              decimals: ...;
+              logoURI: ...;
+              name: ...;
+              position: ...;
+              symbol: ...;
+              type: ...;
+            }
+              | {
+              description: ...;
+              favicon: ...;
+              opengraph: ...;
+              position: ...;
+              title: ...;
+              type: ...;
+              url: ...;
+            }
+              | {
+              mediaType: ...;
+              position: ...;
+              type: ...;
+              url: ...;
+            }
+              | {
+              mediaType: ...;
+              position: ...;
+              type: ...;
+              url: ...;
+            }
+              | {
+              mediaType: ...;
+              position: ...;
+              type: ...;
+              url: ...;
+           })[];
+           revision: number;
+           targetUri: string;
+           txHash: `0x${string}`;
+           updatedAt: Date;
+           zeroExSwap:   | null
+              | {
+              from: {
+                 address: ...;
+                 amount: ...;
+                 symbol: ...;
+              };
+              to: {
+                 address: ...;
+                 amount: ...;
+                 symbol: ...;
+              };
+            };
+        }[]>;
+        zeroExSwap:   | null
+           | {
+           from: {
+              address: `0x${string}`;
+              amount: string;
+              symbol: string;
+           };
+           to: {
+              address: "" | `0x${string}`;
+              amount: string;
+              symbol: string;
+           };
+         };
+     }[];
+  };
+  revision: number;
+  targetUri: string;
+  txHash: `0x${string}`;
+  updatedAt: Date;
+  viewerReactions: Record<string, {
+     app: `0x${string}`;
+     author: {
+        address: `0x${string}`;
+        ens?: {
+           avatarUrl: null | string;
+           name: string;
+        };
+        farcaster?: {
+           displayName?: string;
+           fid: number;
+           pfpUrl?: string;
+           username: string;
+        };
+     };
+     chainId: number;
+     channelId: bigint;
+     commentType: number;
+     content: string;
+     createdAt: Date;
+     cursor: `0x${string}`;
+     deletedAt: null | Date;
+     hookMetadata: {
+        key: `0x${string}`;
+        value: `0x${string}`;
+     }[];
+     id: `0x${string}`;
+     logIndex: null | number;
+     metadata: {
+        key: `0x${string}`;
+        value: `0x${string}`;
+     }[];
+     moderationClassifierResult: Record<string, number>;
+     moderationClassifierScore: number;
+     moderationStatus: "approved" | "pending" | "rejected";
+     moderationStatusChangedAt: Date;
+     parentId: null | `0x${string}`;
+     references: (
+        | {
+        address: `0x${string}`;
+        avatarUrl: null | string;
+        name: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "ens";
+        url: string;
+      }
+        | {
+        address: `0x${string}`;
+        displayName: null | string;
+        fid: number;
+        fname: string;
+        pfpUrl: null | string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "farcaster";
+        url: string;
+        username: string;
+      }
+        | {
+        address: `0x${string}`;
+        chainId: null | number;
+        chains: {
+           caip: string;
+           chainId: number;
+        }[];
+        decimals: number;
+        logoURI: null | string;
+        name: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        symbol: string;
+        type: "erc20";
+      }
+        | {
+        description: null | string;
+        favicon: null | string;
+        opengraph:   | null
+           | {
+           description: ... | ...;
+           image: string;
+           title: string;
+           url: string;
+         };
+        position: {
+           end: number;
+           start: number;
+        };
+        title: string;
+        type: "webpage";
+        url: string;
+      }
+        | {
+        mediaType: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "file";
+        url: string;
+      }
+        | {
+        mediaType: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "image";
+        url: string;
+      }
+        | {
+        mediaType: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "video";
+        url: string;
+     })[];
+     revision: number;
+     targetUri: string;
+     txHash: `0x${string}`;
+     updatedAt: Date;
+     zeroExSwap:   | null
+        | {
+        from: {
+           address: `0x${string}`;
+           amount: string;
+           symbol: string;
+        };
+        to: {
+           address: "" | `0x${string}`;
+           amount: string;
+           symbol: string;
+        };
+      };
+  }[]>;
+  zeroExSwap:   | null
+     | {
+     from: {
+        address: `0x${string}`;
+        amount: string;
+        symbol: string;
+     };
+     to: {
+        address: "" | `0x${string}`;
+        amount: string;
+        symbol: string;
+     };
+   };
+}>;
+```
+
+Defined in: [packages/sdk/src/indexer/api.ts:79](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L79)
+
+Fetch one single comment from the Indexer API
+
+## Parameters
+
+### options
+
+#### apiUrl?
+
+`string` = `...`
+
+URL on which /api/comments endpoint will be called
+
+**Default**
+
+```ts
+"https://api.ethcomments.xyz"
+```
+
+#### chainId
+
+`number` \| `number`[] = `...`
+
+Filter comments by chain ID(s)
+
+#### commentId
+
+`` `0x${string}` `` = `HexSchema`
+
+The ID of the comment to fetch
+
+#### commentType?
+
+`number` = `...`
+
+Filter comments by comment type
+
+#### mode?
+
+`"flat"` \| `"nested"` = `...`
+
+The mode to fetch comments in by default it returns only the first level of comments.
+If flat is used it will return all comments sorted by timestamp in descending order.
+
+**Default**
+
+```ts
+"nested"
+```
+
+#### retries?
+
+`number` = `...`
+
+Number of times to retry the signing operation in case of failure.
+
+**Default**
+
+```ts
+3
+```
+
+#### signal?
+
+`AbortSignal` = `...`
+
+The signal to abort the request
+
+#### viewer?
+
+`` `0x${string}` `` = `...`
+
+The viewer's address. This is useful when the content moderation is enabled on the indexer.
+
+## Returns
+
+`Promise`\<\{
+  `app`: `` `0x${string}` ``;
+  `author`: \{
+     `address`: `` `0x${string}` ``;
+     `ens?`: \{
+        `avatarUrl`: `null` \| `string`;
+        `name`: `string`;
+     \};
+     `farcaster?`: \{
+        `displayName?`: `string`;
+        `fid`: `number`;
+        `pfpUrl?`: `string`;
+        `username`: `string`;
+     \};
+  \};
+  `chainId`: `number`;
+  `channelId`: `bigint`;
+  `commentType`: `number`;
+  `content`: `string`;
+  `createdAt`: `Date`;
+  `cursor`: `` `0x${string}` ``;
+  `deletedAt`: `null` \| `Date`;
+  `hookMetadata`: \{
+     `key`: `` `0x${string}` ``;
+     `value`: `` `0x${string}` ``;
+  \}[];
+  `id`: `` `0x${string}` ``;
+  `logIndex`: `null` \| `number`;
+  `metadata`: \{
+     `key`: `` `0x${string}` ``;
+     `value`: `` `0x${string}` ``;
+  \}[];
+  `moderationClassifierResult`: `Record`\<`string`, `number`\>;
+  `moderationClassifierScore`: `number`;
+  `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
+  `moderationStatusChangedAt`: `Date`;
+  `parentId`: `null` \| `` `0x${string}` ``;
+  `reactionCounts`: `Record`\<`string`, `number`\>;
+  `references`: (
+     \| \{
+     `address`: `` `0x${string}` ``;
+     `avatarUrl`: `null` \| `string`;
+     `name`: `string`;
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `type`: `"ens"`;
+     `url`: `string`;
+   \}
+     \| \{
+     `address`: `` `0x${string}` ``;
+     `displayName`: `null` \| `string`;
+     `fid`: `number`;
+     `fname`: `string`;
+     `pfpUrl`: `null` \| `string`;
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `type`: `"farcaster"`;
+     `url`: `string`;
+     `username`: `string`;
+   \}
+     \| \{
+     `address`: `` `0x${string}` ``;
+     `chainId`: `null` \| `number`;
+     `chains`: \{
+        `caip`: `string`;
+        `chainId`: `number`;
+     \}[];
+     `decimals`: `number`;
+     `logoURI`: `null` \| `string`;
+     `name`: `string`;
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `symbol`: `string`;
+     `type`: `"erc20"`;
+   \}
+     \| \{
+     `description`: `null` \| `string`;
+     `favicon`: `null` \| `string`;
+     `opengraph`:   \| `null`
+        \| \{
+        `description`: `null` \| `string`;
+        `image`: `string`;
+        `title`: `string`;
+        `url`: `string`;
+      \};
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `title`: `string`;
+     `type`: `"webpage"`;
+     `url`: `string`;
+   \}
+     \| \{
+     `mediaType`: `string`;
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `type`: `"file"`;
+     `url`: `string`;
+   \}
+     \| \{
+     `mediaType`: `string`;
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `type`: `"image"`;
+     `url`: `string`;
+   \}
+     \| \{
+     `mediaType`: `string`;
+     `position`: \{
+        `end`: `number`;
+        `start`: `number`;
+     \};
+     `type`: `"video"`;
+     `url`: `string`;
+  \})[];
+  `replies`: \{
+     `extra`: \{
+        `moderationEnabled`: `boolean`;
+        `moderationKnownReactions`: `string`[];
+     \};
+     `pagination`: \{
+        `endCursor?`: `` `0x${string}` ``;
+        `hasNext`: `boolean`;
+        `hasPrevious`: `boolean`;
+        `limit`: `number`;
+        `startCursor?`: `` `0x${string}` ``;
+     \};
+     `results`: \{
+        `app`: `` `0x${string}` ``;
+        `author`: \{
+           `address`: `` `0x${string}` ``;
+           `ens?`: \{
+              `avatarUrl`: `null` \| `string`;
+              `name`: `string`;
+           \};
+           `farcaster?`: \{
+              `displayName?`: `string`;
+              `fid`: `number`;
+              `pfpUrl?`: `string`;
+              `username`: `string`;
+           \};
+        \};
+        `chainId`: `number`;
+        `channelId`: `bigint`;
+        `commentType`: `number`;
+        `content`: `string`;
+        `createdAt`: `Date`;
+        `cursor`: `` `0x${string}` ``;
+        `deletedAt`: `null` \| `Date`;
+        `hookMetadata`: \{
+           `key`: `` `0x${string}` ``;
+           `value`: `` `0x${string}` ``;
+        \}[];
+        `id`: `` `0x${string}` ``;
+        `logIndex`: `null` \| `number`;
+        `metadata`: \{
+           `key`: `` `0x${string}` ``;
+           `value`: `` `0x${string}` ``;
+        \}[];
+        `moderationClassifierResult`: `Record`\<`string`, `number`\>;
+        `moderationClassifierScore`: `number`;
+        `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
+        `moderationStatusChangedAt`: `Date`;
+        `parentId`: `null` \| `` `0x${string}` ``;
+        `reactionCounts`: `Record`\<`string`, `number`\>;
+        `references`: (
+           \| \{
+           `address`: `` `0x${string}` ``;
+           `avatarUrl`: `null` \| `string`;
+           `name`: `string`;
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `type`: `"ens"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `address`: `` `0x${string}` ``;
+           `displayName`: `null` \| `string`;
+           `fid`: `number`;
+           `fname`: `string`;
+           `pfpUrl`: `null` \| `string`;
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `type`: `"farcaster"`;
+           `url`: `string`;
+           `username`: `string`;
+         \}
+           \| \{
+           `address`: `` `0x${string}` ``;
+           `chainId`: `null` \| `number`;
+           `chains`: \{
+              `caip`: `string`;
+              `chainId`: `number`;
+           \}[];
+           `decimals`: `number`;
+           `logoURI`: `null` \| `string`;
+           `name`: `string`;
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `symbol`: `string`;
+           `type`: `"erc20"`;
+         \}
+           \| \{
+           `description`: `null` \| `string`;
+           `favicon`: `null` \| `string`;
+           `opengraph`:   \| `null`
+              \| \{
+              `description`: ... \| ...;
+              `image`: `string`;
+              `title`: `string`;
+              `url`: `string`;
+            \};
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `title`: `string`;
+           `type`: `"webpage"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `mediaType`: `string`;
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `type`: `"file"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `mediaType`: `string`;
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `type`: `"image"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `mediaType`: `string`;
+           `position`: \{
+              `end`: `number`;
+              `start`: `number`;
+           \};
+           `type`: `"video"`;
+           `url`: `string`;
+        \})[];
+        `revision`: `number`;
+        `targetUri`: `string`;
+        `txHash`: `` `0x${string}` ``;
+        `updatedAt`: `Date`;
+        `viewerReactions`: `Record`\<`string`, \{
+           `app`: `` `0x${string}` ``;
+           `author`: \{
+              `address`: `` `0x${string}` ``;
+              `ens?`: \{
+                 `avatarUrl`: ...;
+                 `name`: ...;
+              \};
+              `farcaster?`: \{
+                 `displayName?`: ...;
+                 `fid`: ...;
+                 `pfpUrl?`: ...;
+                 `username`: ...;
+              \};
+           \};
+           `chainId`: `number`;
+           `channelId`: `bigint`;
+           `commentType`: `number`;
+           `content`: `string`;
+           `createdAt`: `Date`;
+           `cursor`: `` `0x${string}` ``;
+           `deletedAt`: `null` \| `Date`;
+           `hookMetadata`: \{
+              `key`: `` `0x${(...)}` ``;
+              `value`: `` `0x${(...)}` ``;
+           \}[];
+           `id`: `` `0x${string}` ``;
+           `logIndex`: `null` \| `number`;
+           `metadata`: \{
+              `key`: `` `0x${(...)}` ``;
+              `value`: `` `0x${(...)}` ``;
+           \}[];
+           `moderationClassifierResult`: `Record`\<`string`, `number`\>;
+           `moderationClassifierScore`: `number`;
+           `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
+           `moderationStatusChangedAt`: `Date`;
+           `parentId`: `null` \| `` `0x${string}` ``;
+           `references`: (
+              \| \{
+              `address`: ...;
+              `avatarUrl`: ...;
+              `name`: ...;
+              `position`: ...;
+              `type`: ...;
+              `url`: ...;
+            \}
+              \| \{
+              `address`: ...;
+              `displayName`: ...;
+              `fid`: ...;
+              `fname`: ...;
+              `pfpUrl`: ...;
+              `position`: ...;
+              `type`: ...;
+              `url`: ...;
+              `username`: ...;
+            \}
+              \| \{
+              `address`: ...;
+              `chainId`: ...;
+              `chains`: ...;
+              `decimals`: ...;
+              `logoURI`: ...;
+              `name`: ...;
+              `position`: ...;
+              `symbol`: ...;
+              `type`: ...;
+            \}
+              \| \{
+              `description`: ...;
+              `favicon`: ...;
+              `opengraph`: ...;
+              `position`: ...;
+              `title`: ...;
+              `type`: ...;
+              `url`: ...;
+            \}
+              \| \{
+              `mediaType`: ...;
+              `position`: ...;
+              `type`: ...;
+              `url`: ...;
+            \}
+              \| \{
+              `mediaType`: ...;
+              `position`: ...;
+              `type`: ...;
+              `url`: ...;
+            \}
+              \| \{
+              `mediaType`: ...;
+              `position`: ...;
+              `type`: ...;
+              `url`: ...;
+           \})[];
+           `revision`: `number`;
+           `targetUri`: `string`;
+           `txHash`: `` `0x${string}` ``;
+           `updatedAt`: `Date`;
+           `zeroExSwap`:   \| `null`
+              \| \{
+              `from`: \{
+                 `address`: ...;
+                 `amount`: ...;
+                 `symbol`: ...;
+              \};
+              `to`: \{
+                 `address`: ...;
+                 `amount`: ...;
+                 `symbol`: ...;
+              \};
+            \};
+        \}[]\>;
+        `zeroExSwap`:   \| `null`
+           \| \{
+           `from`: \{
+              `address`: `` `0x${string}` ``;
+              `amount`: `string`;
+              `symbol`: `string`;
+           \};
+           `to`: \{
+              `address`: `""` \| `` `0x${string}` ``;
+              `amount`: `string`;
+              `symbol`: `string`;
+           \};
+         \};
+     \}[];
+  \};
+  `revision`: `number`;
+  `targetUri`: `string`;
+  `txHash`: `` `0x${string}` ``;
+  `updatedAt`: `Date`;
+  `viewerReactions`: `Record`\<`string`, \{
+     `app`: `` `0x${string}` ``;
+     `author`: \{
+        `address`: `` `0x${string}` ``;
+        `ens?`: \{
+           `avatarUrl`: `null` \| `string`;
+           `name`: `string`;
+        \};
+        `farcaster?`: \{
+           `displayName?`: `string`;
+           `fid`: `number`;
+           `pfpUrl?`: `string`;
+           `username`: `string`;
+        \};
+     \};
+     `chainId`: `number`;
+     `channelId`: `bigint`;
+     `commentType`: `number`;
+     `content`: `string`;
+     `createdAt`: `Date`;
+     `cursor`: `` `0x${string}` ``;
+     `deletedAt`: `null` \| `Date`;
+     `hookMetadata`: \{
+        `key`: `` `0x${string}` ``;
+        `value`: `` `0x${string}` ``;
+     \}[];
+     `id`: `` `0x${string}` ``;
+     `logIndex`: `null` \| `number`;
+     `metadata`: \{
+        `key`: `` `0x${string}` ``;
+        `value`: `` `0x${string}` ``;
+     \}[];
+     `moderationClassifierResult`: `Record`\<`string`, `number`\>;
+     `moderationClassifierScore`: `number`;
+     `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
+     `moderationStatusChangedAt`: `Date`;
+     `parentId`: `null` \| `` `0x${string}` ``;
+     `references`: (
+        \| \{
+        `address`: `` `0x${string}` ``;
+        `avatarUrl`: `null` \| `string`;
+        `name`: `string`;
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `type`: `"ens"`;
+        `url`: `string`;
+      \}
+        \| \{
+        `address`: `` `0x${string}` ``;
+        `displayName`: `null` \| `string`;
+        `fid`: `number`;
+        `fname`: `string`;
+        `pfpUrl`: `null` \| `string`;
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `type`: `"farcaster"`;
+        `url`: `string`;
+        `username`: `string`;
+      \}
+        \| \{
+        `address`: `` `0x${string}` ``;
+        `chainId`: `null` \| `number`;
+        `chains`: \{
+           `caip`: `string`;
+           `chainId`: `number`;
+        \}[];
+        `decimals`: `number`;
+        `logoURI`: `null` \| `string`;
+        `name`: `string`;
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `symbol`: `string`;
+        `type`: `"erc20"`;
+      \}
+        \| \{
+        `description`: `null` \| `string`;
+        `favicon`: `null` \| `string`;
+        `opengraph`:   \| `null`
+           \| \{
+           `description`: ... \| ...;
+           `image`: `string`;
+           `title`: `string`;
+           `url`: `string`;
+         \};
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `title`: `string`;
+        `type`: `"webpage"`;
+        `url`: `string`;
+      \}
+        \| \{
+        `mediaType`: `string`;
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `type`: `"file"`;
+        `url`: `string`;
+      \}
+        \| \{
+        `mediaType`: `string`;
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `type`: `"image"`;
+        `url`: `string`;
+      \}
+        \| \{
+        `mediaType`: `string`;
+        `position`: \{
+           `end`: `number`;
+           `start`: `number`;
+        \};
+        `type`: `"video"`;
+        `url`: `string`;
+     \})[];
+     `revision`: `number`;
+     `targetUri`: `string`;
+     `txHash`: `` `0x${string}` ``;
+     `updatedAt`: `Date`;
+     `zeroExSwap`:   \| `null`
+        \| \{
+        `from`: \{
+           `address`: `` `0x${string}` ``;
+           `amount`: `string`;
+           `symbol`: `string`;
+        \};
+        `to`: \{
+           `address`: `""` \| `` `0x${string}` ``;
+           `amount`: `string`;
+           `symbol`: `string`;
+        \};
+      \};
+  \}[]\>;
+  `zeroExSwap`:   \| `null`
+     \| \{
+     `from`: \{
+        `address`: `` `0x${string}` ``;
+        `amount`: `string`;
+        `symbol`: `string`;
+     \};
+     `to`: \{
+        `address`: `""` \| `` `0x${string}` ``;
+        `amount`: `string`;
+        `symbol`: `string`;
+     \};
+   \};
+\}\>
+
+A promise that resolves the comment fetched from the Indexer API

--- a/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
@@ -165,7 +165,7 @@ function fetchCommentReplies(options): Promise<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:382](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L382)
+Defined in: [packages/sdk/src/indexer/api.ts:491](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L491)
 
 Fetch replies for a comment from the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/functions/fetchComments.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchComments.mdx
@@ -478,7 +478,7 @@ function fetchComments(options): Promise<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:154](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L154)
+Defined in: [packages/sdk/src/indexer/api.ts:263](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L263)
 
 Fetch comments from the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/functions/isMuted.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/isMuted.mdx
@@ -10,7 +10,7 @@
 function isMuted(options): Promise<boolean>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:587](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L587)
+Defined in: [packages/sdk/src/indexer/api.ts:696](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L696)
 
 Checks if an address is marked as a muted on the indexer of your choice.
 

--- a/docs/pages/sdk-reference/indexer/functions/reportComment.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/reportComment.mdx
@@ -10,7 +10,7 @@
 function reportComment(options): Promise<void>;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:920](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L920)
+Defined in: [packages/sdk/src/indexer/api.ts:1029](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L1029)
 
 Report a comment to the Indexer API
 

--- a/docs/pages/sdk-reference/indexer/index.mdx
+++ b/docs/pages/sdk-reference/indexer/index.mdx
@@ -17,6 +17,7 @@ Functionality for indexing and querying comments data
 | [FetchAutocompleteOptions](/sdk-reference/indexer/type-aliases/FetchAutocompleteOptions.mdx) | The options for `fetchAutocomplete()` |
 | [FetchChannelOptions](/sdk-reference/indexer/type-aliases/FetchChannelOptions.mdx) | The options for `fetchChannel()` |
 | [FetchChannelsOptions](/sdk-reference/indexer/type-aliases/FetchChannelsOptions.mdx) | The options for `fetchChannels()` |
+| [FetchCommentOptions](/sdk-reference/indexer/type-aliases/FetchCommentOptions.mdx) | - |
 | [FetchCommentRepliesOptions](/sdk-reference/indexer/type-aliases/FetchCommentRepliesOptions.mdx) | The options for `fetchCommentReplies()` |
 | [FetchCommentsOptions](/sdk-reference/indexer/type-aliases/FetchCommentsOptions.mdx) | The options for `fetchComments()` |
 | [IndexerAPIAuthorDataSchemaType](/sdk-reference/indexer/type-aliases/IndexerAPIAuthorDataSchemaType.mdx) | - |
@@ -138,6 +139,7 @@ Functionality for indexing and querying comments data
 | [fetchAutocomplete](/sdk-reference/indexer/functions/fetchAutocomplete.mdx) | Fetch autocomplete suggestions from the Indexer API |
 | [fetchChannel](/sdk-reference/indexer/functions/fetchChannel.mdx) | Fetch a single channel by ID from the Indexer API |
 | [fetchChannels](/sdk-reference/indexer/functions/fetchChannels.mdx) | Fetch channels from the Indexer API |
+| [fetchComment](/sdk-reference/indexer/functions/fetchComment.mdx) | Fetch one single comment from the Indexer API |
 | [fetchCommentReplies](/sdk-reference/indexer/functions/fetchCommentReplies.mdx) | Fetch replies for a comment from the Indexer API |
 | [fetchComments](/sdk-reference/indexer/functions/fetchComments.mdx) | Fetch comments from the Indexer API |
 | [getChannelCursor](/sdk-reference/indexer/functions/getChannelCursor.mdx) | Get the cursor for a channel |

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchAuthorDataOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchAuthorDataOptions.mdx
@@ -15,7 +15,7 @@ type FetchAuthorDataOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:487](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L487)
+Defined in: [packages/sdk/src/indexer/api.ts:596](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L596)
 
 The options for `fetchAuthorData()`
 
@@ -27,7 +27,7 @@ The options for `fetchAuthorData()`
 address: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:491](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L491)
+Defined in: [packages/sdk/src/indexer/api.ts:600](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L600)
 
 Author's address
 
@@ -39,7 +39,7 @@ Author's address
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:503](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L503)
+Defined in: [packages/sdk/src/indexer/api.ts:612](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L612)
 
 URL on which /api/authors/$address endpoint will be called
 
@@ -57,7 +57,7 @@ URL on which /api/authors/$address endpoint will be called
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:497](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L497)
+Defined in: [packages/sdk/src/indexer/api.ts:606](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L606)
 
 Number of times to retry the signing operation in case of failure.
 
@@ -75,4 +75,4 @@ Number of times to retry the signing operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:504](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L504)
+Defined in: [packages/sdk/src/indexer/api.ts:613](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L613)

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchAutocompleteOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchAutocompleteOptions.mdx
@@ -16,7 +16,7 @@ type FetchAutocompleteOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:793](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L793)
+Defined in: [packages/sdk/src/indexer/api.ts:902](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L902)
 
 The options for `fetchAutocomplete()`
 
@@ -28,7 +28,7 @@ The options for `fetchAutocomplete()`
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:808](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L808)
+Defined in: [packages/sdk/src/indexer/api.ts:917](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L917)
 
 URL on which /api/autocomplete endpoint will be called
 
@@ -46,7 +46,7 @@ URL on which /api/autocomplete endpoint will be called
 char: "@" | "$";
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:802](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L802)
+Defined in: [packages/sdk/src/indexer/api.ts:911](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L911)
 
 The prefix character. $ is more specific and looks only for ERC20 tokens (by address or symbol),
 @ is more general and looks for ENS/Farcaster name and ERC20 tokens.
@@ -59,7 +59,7 @@ The prefix character. $ is more specific and looks only for ERC20 tokens (by add
 query: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:797](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L797)
+Defined in: [packages/sdk/src/indexer/api.ts:906](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L906)
 
 The query to autocomplete
 
@@ -71,7 +71,7 @@ The query to autocomplete
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:814](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L814)
+Defined in: [packages/sdk/src/indexer/api.ts:923](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L923)
 
 Number of times to retry the signing operation in case of failure.
 
@@ -89,4 +89,4 @@ Number of times to retry the signing operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:815](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L815)
+Defined in: [packages/sdk/src/indexer/api.ts:924](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L924)

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchChannelOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchChannelOptions.mdx
@@ -15,7 +15,7 @@ type FetchChannelOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:727](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L727)
+Defined in: [packages/sdk/src/indexer/api.ts:836](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L836)
 
 The options for `fetchChannel()`
 
@@ -27,7 +27,7 @@ The options for `fetchChannel()`
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:737](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L737)
+Defined in: [packages/sdk/src/indexer/api.ts:846](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L846)
 
 URL on which /api/channels/$channelId endpoint will be called
 
@@ -45,7 +45,7 @@ URL on which /api/channels/$channelId endpoint will be called
 channelId: bigint;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:731](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L731)
+Defined in: [packages/sdk/src/indexer/api.ts:840](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L840)
 
 The ID of the channel to fetch
 
@@ -57,7 +57,7 @@ The ID of the channel to fetch
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:743](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L743)
+Defined in: [packages/sdk/src/indexer/api.ts:852](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L852)
 
 Number of times to retry the signing operation in case of failure.
 
@@ -75,4 +75,4 @@ Number of times to retry the signing operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:744](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L744)
+Defined in: [packages/sdk/src/indexer/api.ts:853](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L853)

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchChannelsOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchChannelsOptions.mdx
@@ -19,7 +19,7 @@ type FetchChannelsOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:620](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L620)
+Defined in: [packages/sdk/src/indexer/api.ts:729](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L729)
 
 The options for `fetchChannels()`
 
@@ -31,7 +31,7 @@ The options for `fetchChannels()`
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:626](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L626)
+Defined in: [packages/sdk/src/indexer/api.ts:735](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L735)
 
 URL on which /api/channels endpoint will be called
 
@@ -49,7 +49,7 @@ URL on which /api/channels endpoint will be called
 chainId: number | number[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:634](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L634)
+Defined in: [packages/sdk/src/indexer/api.ts:743](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L743)
 
 Filter channels by chain ID(s)
 
@@ -61,7 +61,7 @@ Filter channels by chain ID(s)
 optional cursor: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:644](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L644)
+Defined in: [packages/sdk/src/indexer/api.ts:753](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L753)
 
 The cursor to fetch channels from
 
@@ -73,7 +73,7 @@ The cursor to fetch channels from
 optional limit: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:656](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L656)
+Defined in: [packages/sdk/src/indexer/api.ts:765](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L765)
 
 The number of channels to fetch
 
@@ -91,7 +91,7 @@ The number of channels to fetch
 optional owner: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:630](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L630)
+Defined in: [packages/sdk/src/indexer/api.ts:739](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L739)
 
 Filter channels by owner
 
@@ -103,7 +103,7 @@ Filter channels by owner
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:640](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L640)
+Defined in: [packages/sdk/src/indexer/api.ts:749](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L749)
 
 Number of times to retry the signing operation in case of failure.
 
@@ -121,7 +121,7 @@ Number of times to retry the signing operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:657](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L657)
+Defined in: [packages/sdk/src/indexer/api.ts:766](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L766)
 
 ***
 
@@ -131,7 +131,7 @@ Defined in: [packages/sdk/src/indexer/api.ts:657](https://github.com/ecp-eth/com
 optional sort: IndexerAPISortSchemaType;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:650](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L650)
+Defined in: [packages/sdk/src/indexer/api.ts:759](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L759)
 
 The sort order, either `asc` or `desc`
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchCommentOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchCommentOptions.mdx
@@ -1,0 +1,107 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [indexer](/sdk-reference/indexer/index.mdx) / FetchCommentOptions
+
+# Type Alias: FetchCommentOptions
+
+```ts
+type FetchCommentOptions = {
+  apiUrl?: string;
+  chainId: number | number[];
+  commentId: `0x${string}`;
+  commentType?: number;
+  mode?: "flat" | "nested";
+  retries?: number;
+  signal?: AbortSignal;
+  viewer?: `0x${string}`;
+};
+```
+
+Defined in: [packages/sdk/src/indexer/api.ts:72](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L72)
+
+## Type declaration
+
+### apiUrl?
+
+```ts
+optional apiUrl: string;
+```
+
+URL on which /api/comments endpoint will be called
+
+#### Default
+
+```ts
+"https://api.ethcomments.xyz"
+```
+
+### chainId
+
+```ts
+chainId: number | number[];
+```
+
+Filter comments by chain ID(s)
+
+### commentId
+
+```ts
+commentId: `0x${string}` = HexSchema;
+```
+
+The ID of the comment to fetch
+
+### commentType?
+
+```ts
+optional commentType: number;
+```
+
+Filter comments by comment type
+
+### mode?
+
+```ts
+optional mode: "flat" | "nested";
+```
+
+The mode to fetch comments in by default it returns only the first level of comments.
+If flat is used it will return all comments sorted by timestamp in descending order.
+
+#### Default
+
+```ts
+"nested"
+```
+
+### retries?
+
+```ts
+optional retries: number;
+```
+
+Number of times to retry the signing operation in case of failure.
+
+#### Default
+
+```ts
+3
+```
+
+### signal?
+
+```ts
+optional signal: AbortSignal;
+```
+
+The signal to abort the request
+
+### viewer?
+
+```ts
+optional viewer: `0x${string}`;
+```
+
+The viewer's address. This is useful when the content moderation is enabled on the indexer.

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchCommentRepliesOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchCommentRepliesOptions.mdx
@@ -28,7 +28,7 @@ type FetchCommentRepliesOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:268](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L268)
+Defined in: [packages/sdk/src/indexer/api.ts:377](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L377)
 
 The options for `fetchCommentReplies()`
 
@@ -40,7 +40,7 @@ The options for `fetchCommentReplies()`
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:286](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L286)
+Defined in: [packages/sdk/src/indexer/api.ts:395](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L395)
 
 URL on which /api/comments/$commentId/replies endpoint will be called
 
@@ -58,7 +58,7 @@ URL on which /api/comments/$commentId/replies endpoint will be called
 optional app: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:290](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L290)
+Defined in: [packages/sdk/src/indexer/api.ts:399](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L399)
 
 Filters to only comments sent using this app signer key.
 
@@ -70,7 +70,7 @@ Filters to only comments sent using this app signer key.
 chainId: number | number[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:276](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L276)
+Defined in: [packages/sdk/src/indexer/api.ts:385](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L385)
 
 Filter replies by chain ID(s)
 
@@ -82,7 +82,7 @@ Filter replies by chain ID(s)
 optional channelId: bigint;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:346](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L346)
+Defined in: [packages/sdk/src/indexer/api.ts:455](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L455)
 
 Filter replies by channel ID
 
@@ -94,7 +94,7 @@ Filter replies by channel ID
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:272](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L272)
+Defined in: [packages/sdk/src/indexer/api.ts:381](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L381)
 
 The ID of the comment to fetch replies for
 
@@ -106,7 +106,7 @@ The ID of the comment to fetch replies for
 optional commentType: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:315](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L315)
+Defined in: [packages/sdk/src/indexer/api.ts:424](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L424)
 
 Filter replies by comment type
 
@@ -118,7 +118,7 @@ Filter replies by comment type
 optional cursor: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:300](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L300)
+Defined in: [packages/sdk/src/indexer/api.ts:409](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L409)
 
 The cursor to fetch comments from
 
@@ -130,7 +130,7 @@ The cursor to fetch comments from
 optional excludeByModerationLabels: IndexerAPIModerationClassificationLabelSchemaType[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:342](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L342)
+Defined in: [packages/sdk/src/indexer/api.ts:451](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L451)
 
 Filter replies by moderation labels.
 
@@ -146,7 +146,7 @@ if the premoderation is enabled.
 optional limit: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:350](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L350)
+Defined in: [packages/sdk/src/indexer/api.ts:459](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L459)
 
 #### Default
 
@@ -162,7 +162,7 @@ Defined in: [packages/sdk/src/indexer/api.ts:350](https://github.com/ecp-eth/com
 optional mode: IndexerAPICommentListModeSchemaType;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:311](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L311)
+Defined in: [packages/sdk/src/indexer/api.ts:420](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L420)
 
 The mode to fetch replies in by default it returns only the first level of replies.
 If flat is used it will return all replies sorted by timestamp in descending order.
@@ -181,7 +181,7 @@ If flat is used it will return all replies sorted by timestamp in descending ord
 optional moderationScore: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:334](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L334)
+Defined in: [packages/sdk/src/indexer/api.ts:443](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L443)
 
 Filter replies by moderation score.
 
@@ -199,7 +199,7 @@ optional moderationStatus:
   | IndexerAPICommentModerationStatusSchemaType[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:324](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L324)
+Defined in: [packages/sdk/src/indexer/api.ts:433](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L433)
 
 Filter replies by moderation status.
 
@@ -216,7 +216,7 @@ If moderation is disabled, this parameter is ignored.
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:296](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L296)
+Defined in: [packages/sdk/src/indexer/api.ts:405](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L405)
 
 Number of times to retry the signing operation in case of failure.
 
@@ -234,7 +234,7 @@ Number of times to retry the signing operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:351](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L351)
+Defined in: [packages/sdk/src/indexer/api.ts:460](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L460)
 
 ***
 
@@ -244,7 +244,7 @@ Defined in: [packages/sdk/src/indexer/api.ts:351](https://github.com/ecp-eth/com
 optional sort: IndexerAPISortSchemaType;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:304](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L304)
+Defined in: [packages/sdk/src/indexer/api.ts:413](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L413)
 
 #### Default
 
@@ -260,6 +260,6 @@ Defined in: [packages/sdk/src/indexer/api.ts:304](https://github.com/ecp-eth/com
 optional viewer: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:280](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L280)
+Defined in: [packages/sdk/src/indexer/api.ts:389](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L389)
 
 The viewer's address. This is useful when the content moderation is enabled on the indexer.

--- a/docs/pages/sdk-reference/indexer/type-aliases/FetchCommentsOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/FetchCommentsOptions.mdx
@@ -29,7 +29,7 @@ type FetchCommentsOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:31](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L31)
+Defined in: [packages/sdk/src/indexer/api.ts:140](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L140)
 
 The options for `fetchComments()`
 
@@ -41,7 +41,7 @@ The options for `fetchComments()`
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:53](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L53)
+Defined in: [packages/sdk/src/indexer/api.ts:162](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L162)
 
 URL on which /api/comments endpoint will be called
 
@@ -59,7 +59,7 @@ URL on which /api/comments endpoint will be called
 optional app: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:57](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L57)
+Defined in: [packages/sdk/src/indexer/api.ts:166](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L166)
 
 Filter comments sent using this app signer key.
 
@@ -71,7 +71,7 @@ Filter comments sent using this app signer key.
 optional author: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:39](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L39)
+Defined in: [packages/sdk/src/indexer/api.ts:148](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L148)
 
 Filter comments by author
 
@@ -83,7 +83,7 @@ Filter comments by author
 chainId: number | number[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:43](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L43)
+Defined in: [packages/sdk/src/indexer/api.ts:152](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L152)
 
 Filter comments by chain ID(s)
 
@@ -95,7 +95,7 @@ Filter comments by chain ID(s)
 optional channelId: bigint;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:61](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L61)
+Defined in: [packages/sdk/src/indexer/api.ts:170](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L170)
 
 Filter comments by channel ID
 
@@ -107,7 +107,7 @@ Filter comments by channel ID
 optional commentType: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:65](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L65)
+Defined in: [packages/sdk/src/indexer/api.ts:174](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L174)
 
 Filter comments by comment type
 
@@ -119,7 +119,7 @@ Filter comments by comment type
 optional cursor: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:86](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L86)
+Defined in: [packages/sdk/src/indexer/api.ts:195](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L195)
 
 The cursor to fetch comments from
 
@@ -131,7 +131,7 @@ The cursor to fetch comments from
 optional excludeByModerationLabels: IndexerAPIModerationClassificationLabelSchemaType[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:115](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L115)
+Defined in: [packages/sdk/src/indexer/api.ts:224](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L224)
 
 Filter comments by moderation labels.
 
@@ -147,7 +147,7 @@ if the premoderation is enabled.
 optional limit: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:121](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L121)
+Defined in: [packages/sdk/src/indexer/api.ts:230](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L230)
 
 The number of comments to fetch
 
@@ -165,7 +165,7 @@ The number of comments to fetch
 optional mode: IndexerAPICommentListModeSchemaType;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:99](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L99)
+Defined in: [packages/sdk/src/indexer/api.ts:208](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L208)
 
 The mode to fetch comments in by default it returns only the first level of comments.
 If flat is used it will return all comments sorted by timestamp in descending order.
@@ -184,7 +184,7 @@ If flat is used it will return all comments sorted by timestamp in descending or
 optional moderationScore: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:107](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L107)
+Defined in: [packages/sdk/src/indexer/api.ts:216](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L216)
 
 Filter comments by moderation score.
 
@@ -202,7 +202,7 @@ optional moderationStatus:
   | IndexerAPICommentModerationStatusSchemaType[];
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:74](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L74)
+Defined in: [packages/sdk/src/indexer/api.ts:183](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L183)
 
 Filter comments by moderation status.
 
@@ -219,7 +219,7 @@ If moderation is disabled, this parameter is ignored.
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:82](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L82)
+Defined in: [packages/sdk/src/indexer/api.ts:191](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L191)
 
 Number of times to retry the signing operation in case of failure.
 
@@ -237,7 +237,7 @@ Number of times to retry the signing operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:122](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L122)
+Defined in: [packages/sdk/src/indexer/api.ts:231](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L231)
 
 ***
 
@@ -247,7 +247,7 @@ Defined in: [packages/sdk/src/indexer/api.ts:122](https://github.com/ecp-eth/com
 optional sort: IndexerAPISortSchemaType;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:92](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L92)
+Defined in: [packages/sdk/src/indexer/api.ts:201](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L201)
 
 The sort order, either `asc` or `desc`
 
@@ -265,7 +265,7 @@ The sort order, either `asc` or `desc`
 optional targetUri: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:35](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L35)
+Defined in: [packages/sdk/src/indexer/api.ts:144](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L144)
 
 The target URI to fetch comments for
 
@@ -277,6 +277,6 @@ The target URI to fetch comments for
 optional viewer: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:47](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L47)
+Defined in: [packages/sdk/src/indexer/api.ts:156](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L156)
 
 The viewer's address. This is useful when the content moderation is enabled on the indexer.

--- a/docs/pages/sdk-reference/indexer/type-aliases/IsMutedOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IsMutedOptions.mdx
@@ -15,7 +15,7 @@ type IsMutedOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:579](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L579)
+Defined in: [packages/sdk/src/indexer/api.ts:688](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L688)
 
 The options for `isMuted()`
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/ReportCommentOptions.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/ReportCommentOptions.mdx
@@ -19,7 +19,7 @@ type ReportCommentOptions = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:868](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L868)
+Defined in: [packages/sdk/src/indexer/api.ts:977](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L977)
 
 The options for `reportComment()`
 
@@ -31,7 +31,7 @@ The options for `reportComment()`
 optional apiUrl: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:894](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L894)
+Defined in: [packages/sdk/src/indexer/api.ts:1003](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L1003)
 
 URL on which /api/comments/$commentId/reports endpoint will be called
 
@@ -49,7 +49,7 @@ URL on which /api/comments/$commentId/reports endpoint will be called
 chainId: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:888](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L888)
+Defined in: [packages/sdk/src/indexer/api.ts:997](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L997)
 
 The chain ID where the comment was posted
 
@@ -61,7 +61,7 @@ The chain ID where the comment was posted
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:872](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L872)
+Defined in: [packages/sdk/src/indexer/api.ts:981](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L981)
 
 The ID of the comment to report
 
@@ -73,7 +73,7 @@ The ID of the comment to report
 optional message: string;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:880](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L880)
+Defined in: [packages/sdk/src/indexer/api.ts:989](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L989)
 
 Optional message explaining the reason for the report
 
@@ -85,7 +85,7 @@ Optional message explaining the reason for the report
 reportee: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:876](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L876)
+Defined in: [packages/sdk/src/indexer/api.ts:985](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L985)
 
 The address of the user reporting the comment
 
@@ -97,7 +97,7 @@ The address of the user reporting the comment
 optional retries: number;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:900](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L900)
+Defined in: [packages/sdk/src/indexer/api.ts:1009](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L1009)
 
 Number of times to retry the operation in case of failure.
 
@@ -115,7 +115,7 @@ Number of times to retry the operation in case of failure.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:901](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L901)
+Defined in: [packages/sdk/src/indexer/api.ts:1010](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L1010)
 
 ***
 
@@ -125,6 +125,6 @@ Defined in: [packages/sdk/src/indexer/api.ts:901](https://github.com/ecp-eth/com
 signature: Hex;
 ```
 
-Defined in: [packages/sdk/src/indexer/api.ts:884](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L884)
+Defined in: [packages/sdk/src/indexer/api.ts:993](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/api.ts#L993)
 
 The signature of the report typed data

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -106,6 +106,7 @@
     "@types/node": "^22.14.1",
     "@types/react": "~19.1.0",
     "eslint": "^9.19.0",
+    "nock": "^14.0.5",
     "node-resolve-ts": "^1.0.2",
     "react": "~19.1.0",
     "viem": "^2.29.2",

--- a/packages/sdk/src/indexer/api.ts
+++ b/packages/sdk/src/indexer/api.ts
@@ -20,9 +20,9 @@ import {
   IndexerAPIGetAutocompleteOutputSchema,
   type IndexerAPIGetAutocompleteOutputSchemaType,
   IndexerAPIModerationClassificationLabelSchema,
-  IndexerAPIModerationClassificationLabelSchemaType,
+  type IndexerAPIModerationClassificationLabelSchemaType,
   IndexerAPICommentWithRepliesSchema,
-  IndexerAPICommentWithRepliesSchemaType,
+  type IndexerAPICommentWithRepliesSchemaType,
 } from "./schemas.js";
 import { INDEXER_API_URL } from "../constants.js";
 import { z } from "zod";

--- a/packages/sdk/src/indexer/test/api.ts
+++ b/packages/sdk/src/indexer/test/api.ts
@@ -1,0 +1,106 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import nock from "nock";
+import { fetchComment } from "../api.js";
+import type { Hex } from "../../core/schemas.js";
+
+describe("fetchComment", () => {
+  it("should fetch a comment", async () => {
+    const commentId: Hex =
+      "0x9e928d74c573428f69aa87aa084cc801c6c9a9c04c0512813abb3b82fbe1f21e";
+    const chainId = 31337;
+    const { responseData, expectedFetchResult } = getMockResponseData();
+
+    nock("https://api.ethcomments.xyz")
+      .get(`/api/comments/${commentId}?chainId=${chainId}`)
+      .reply(200, responseData);
+
+    const fetchResult = await fetchComment({
+      commentId,
+      chainId,
+    });
+
+    assert.deepStrictEqual(expectedFetchResult, fetchResult);
+  });
+});
+
+function getMockResponseData() {
+  const date = new Date();
+  const channelId = 0n;
+
+  const responseData = {
+    app: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+    author: {
+      address: "0xc506739d39cbf1d94e2510bfca64cb6015f4bb1b",
+      farcaster: {
+        fid: 856052,
+        pfpUrl:
+          "https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/b1ede387-2c8d-4745-4686-ed9aa005a600/original",
+        displayName: "Norm's test account",
+        username: "normtest",
+      },
+    },
+    id: "0x9e928d74c573428f69aa87aa084cc801c6c9a9c04c0512813abb3b82fbe1f21e",
+    channelId: channelId.toString(),
+    commentType: 0,
+    content: "asdadasas1",
+    chainId: 31337,
+    deletedAt: null,
+    logIndex: 0,
+    metadata: [],
+    hookMetadata: [],
+    parentId: null,
+    targetUri: "http://localhost:3004/quick-start",
+    txHash:
+      "0x7666a46c612a7bec2a5bea129c589d46cb6b17549471f92fbffd2b47f260c81b",
+    cursor:
+      "0x313735333731323531393030303a307839653932386437346335373334323866363961613837616130383463633830316336633961396330346330353132383133616262336238326662653166323165",
+    moderationStatus: "approved",
+    moderationStatusChangedAt: date.toISOString(),
+    moderationClassifierResult: {
+      hate: 0,
+      spam: 0,
+      sexual: 0,
+      violence: 0,
+      self_harm: 0,
+      harassment: 0,
+      llm_generated: 0,
+      sexual_minors: 0,
+      hate_threatening: 0,
+      violence_graphic: 0,
+    },
+    moderationClassifierScore: 0,
+    createdAt: date.toISOString(),
+    updatedAt: date.toISOString(),
+    revision: 0,
+    zeroExSwap: null,
+    references: [],
+    viewerReactions: {},
+    reactionCounts: {},
+    replies: {
+      extra: {
+        moderationEnabled: false,
+        moderationKnownReactions: ["like"],
+      },
+      results: [],
+      pagination: {
+        limit: 2,
+        hasNext: false,
+        hasPrevious: false,
+      },
+    },
+  };
+
+  const expectedFetchResult = {
+    ...responseData,
+    channelId,
+    moderationStatusChangedAt: date,
+    createdAt: date,
+    updatedAt: date,
+  };
+
+  return {
+    responseData,
+    expectedFetchResult,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,7 +251,7 @@ importers:
         version: 2.2.5(patch_hash=de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.15.5(@react-native-async-storage/async-storage@2.1.2(react-native@0.79.5(@babel/core@7.26.10)(@react-native-community/cli@18.0.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@19.1.6)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10)))(@tanstack/query-core@5.80.2)(@tanstack/react-query@5.80.2(react@19.1.0))(@types/react@19.1.6)(@upstash/redis@1.35.0)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@sentry/nextjs':
         specifier: ^9.3.0
-        version: 9.25.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9)
+        version: 9.25.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9(esbuild@0.25.5))
       '@tanstack/react-query':
         specifier: ^5.75.6
         version: 5.80.2(react@19.1.0)
@@ -1032,6 +1032,9 @@ importers:
       eslint:
         specifier: ^9.19.0
         version: 9.28.0(jiti@2.4.2)
+      nock:
+        specifier: ^14.0.5
+        version: 14.0.5
       node-resolve-ts:
         specifier: ^1.0.2
         version: 1.0.2
@@ -11807,7 +11810,7 @@ snapshots:
       '@babel/traverse': 7.27.4
       '@babel/types': 7.27.3
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -11987,7 +11990,7 @@ snapshots:
       '@babel/parser': 7.27.5
       '@babel/template': 7.27.2
       '@babel/types': 7.27.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -12451,7 +12454,7 @@ snapshots:
   '@eslint/config-array@0.20.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12465,7 +12468,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -13034,7 +13037,7 @@ snapshots:
       bufferutil: 4.0.9
       cross-fetch: 4.1.0
       date-fns: 2.30.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       eciesjs: 0.4.15
       eventemitter2: 6.4.9
       readable-stream: 3.6.2
@@ -13058,7 +13061,7 @@ snapshots:
       '@paulmillr/qr': 0.2.1
       bowser: 2.11.0
       cross-fetch: 4.1.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       eciesjs: 0.4.15
       eth-rpc-errors: 4.0.3
       eventemitter2: 6.4.9
@@ -13081,7 +13084,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       semver: 7.7.2
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -13094,7 +13097,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       pony-cause: 2.1.11
       semver: 7.7.2
       uuid: 9.0.1
@@ -13108,7 +13111,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       pony-cause: 2.1.11
       semver: 7.7.2
       uuid: 9.0.1
@@ -15334,7 +15337,7 @@ snapshots:
 
   '@sentry/core@9.25.1': {}
 
-  '@sentry/nextjs@9.25.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9)':
+  '@sentry/nextjs@9.25.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.3(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.34.0
@@ -15345,7 +15348,7 @@ snapshots:
       '@sentry/opentelemetry': 9.25.1(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.34.0)
       '@sentry/react': 9.25.1(react@19.1.0)
       '@sentry/vercel-edge': 9.25.1
-      '@sentry/webpack-plugin': 3.5.0(webpack@5.99.9)
+      '@sentry/webpack-plugin': 3.5.0(webpack@5.99.9(esbuild@0.25.5))
       chalk: 3.0.0
       next: 15.3.3(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       resolve: 1.22.8
@@ -15440,12 +15443,12 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@sentry/core': 9.25.1
 
-  '@sentry/webpack-plugin@3.5.0(webpack@5.99.9)':
+  '@sentry/webpack-plugin@3.5.0(webpack@5.99.9(esbuild@0.25.5))':
     dependencies:
       '@sentry/bundler-plugin-core': 3.5.0
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18611,6 +18614,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -19086,8 +19093,8 @@ snapshots:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.28.0(jiti@2.4.2))
@@ -19106,8 +19113,8 @@ snapshots:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.28.0(jiti@2.4.2))
@@ -19130,7 +19137,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@8.1.1)
@@ -19141,22 +19148,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.7.9
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19167,7 +19174,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19270,7 +19277,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
@@ -20097,7 +20104,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -21262,7 +21269,7 @@ snapshots:
 
   metro-file-map@0.82.4:
     dependencies:
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -21366,7 +21373,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -24269,14 +24276,16 @@ snapshots:
 
   terminal-size@4.0.0: {}
 
-  terser-webpack-plugin@5.3.14(webpack@5.99.9):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.5)(webpack@5.99.9(esbuild@0.25.5)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.40.0
-      webpack: 5.99.9
+      webpack: 5.99.9(esbuild@0.25.5)
+    optionalDependencies:
+      esbuild: 0.25.5
 
   terser@5.40.0:
     dependencies:
@@ -25210,7 +25219,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.99.9:
+  webpack@5.99.9(esbuild@0.25.5):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.7
@@ -25233,7 +25242,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(webpack@5.99.9)
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.5)(webpack@5.99.9(esbuild@0.25.5))
       watchpack: 2.4.4
       webpack-sources: 3.3.2
     transitivePeerDependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to fetch a single comment by ID from the SDK, including support for filtering, nested replies, and viewer context.

* **Documentation**
  * Introduced comprehensive documentation for the new comment-fetching feature, detailing available options and the structure of the returned data.
  * Updated SDK reference documentation with new type aliases and function entries.
  * Corrected and updated source code reference links across multiple SDK documentation pages for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->