### PR TITLE
fix(sdk): inconsistent schema used in fetchCommentReplies()

### DIFF
--- a/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/fetchCommentReplies.mdx
@@ -56,6 +56,7 @@ function fetchCommentReplies(options): Promise<{
      moderationStatus: "approved" | "pending" | "rejected";
      moderationStatusChangedAt: Date;
      parentId: null | `0x${string}`;
+     reactionCounts: Record<string, number>;
      references: (
         | {
         address: `0x${string}`;
@@ -144,10 +145,322 @@ function fetchCommentReplies(options): Promise<{
         type: "video";
         url: string;
      })[];
+     replies: {
+        extra: {
+           moderationEnabled: boolean;
+           moderationKnownReactions: string[];
+        };
+        pagination: {
+           endCursor?: `0x${string}`;
+           hasNext: boolean;
+           hasPrevious: boolean;
+           limit: number;
+           startCursor?: `0x${string}`;
+        };
+        results: {
+           app: `0x${string}`;
+           author: {
+              address: `0x${string}`;
+              ens?: {
+                 avatarUrl: ... | ...;
+                 name: string;
+              };
+              farcaster?: {
+                 displayName?: ... | ...;
+                 fid: number;
+                 pfpUrl?: ... | ...;
+                 username: string;
+              };
+           };
+           chainId: number;
+           channelId: bigint;
+           commentType: number;
+           content: string;
+           createdAt: Date;
+           cursor: `0x${string}`;
+           deletedAt: null | Date;
+           hookMetadata: {
+              key: `0x${string}`;
+              value: `0x${string}`;
+           }[];
+           id: `0x${string}`;
+           logIndex: null | number;
+           metadata: {
+              key: `0x${string}`;
+              value: `0x${string}`;
+           }[];
+           moderationClassifierResult: Record<string, number>;
+           moderationClassifierScore: number;
+           moderationStatus: "approved" | "pending" | "rejected";
+           moderationStatusChangedAt: Date;
+           parentId: null | `0x${string}`;
+           reactionCounts: Record<string, number>;
+           references: (
+              | {
+              address: `0x${(...)}`;
+              avatarUrl: ... | ...;
+              name: string;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              type: "ens";
+              url: string;
+            }
+              | {
+              address: `0x${(...)}`;
+              displayName: ... | ...;
+              fid: number;
+              fname: string;
+              pfpUrl: ... | ...;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              type: "farcaster";
+              url: string;
+              username: string;
+            }
+              | {
+              address: `0x${(...)}`;
+              chainId: ... | ...;
+              chains: ...[];
+              decimals: number;
+              logoURI: ... | ...;
+              name: string;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              symbol: string;
+              type: "erc20";
+            }
+              | {
+              description: ... | ...;
+              favicon: ... | ...;
+              opengraph: ... | ...;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              title: string;
+              type: "webpage";
+              url: string;
+            }
+              | {
+              mediaType: string;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              type: "file";
+              url: string;
+            }
+              | {
+              mediaType: string;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              type: "image";
+              url: string;
+            }
+              | {
+              mediaType: string;
+              position: {
+                 end: ...;
+                 start: ...;
+              };
+              type: "video";
+              url: string;
+           })[];
+           revision: number;
+           targetUri: string;
+           txHash: `0x${string}`;
+           updatedAt: Date;
+           viewerReactions: Record<string, {
+              app: `0x${(...)}`;
+              author: {
+                 address: ...;
+                 ens?: ...;
+                 farcaster?: ...;
+              };
+              chainId: number;
+              channelId: bigint;
+              commentType: number;
+              content: string;
+              createdAt: Date;
+              cursor: `0x${(...)}`;
+              deletedAt: ... | ...;
+              hookMetadata: ...[];
+              id: `0x${(...)}`;
+              logIndex: ... | ...;
+              metadata: ...[];
+              moderationClassifierResult: Record<..., ...>;
+              moderationClassifierScore: number;
+              moderationStatus: ... | ... | ...;
+              moderationStatusChangedAt: Date;
+              parentId: ... | ...;
+              references: ...[];
+              revision: number;
+              targetUri: string;
+              txHash: `0x${(...)}`;
+              updatedAt: Date;
+              zeroExSwap: ... | ...;
+           }[]>;
+           zeroExSwap:   | null
+              | {
+              from: {
+                 address: `0x${(...)}`;
+                 amount: string;
+                 symbol: string;
+              };
+              to: {
+                 address: ... | ...;
+                 amount: string;
+                 symbol: string;
+              };
+            };
+        }[];
+     };
      revision: number;
      targetUri: string;
      txHash: `0x${string}`;
      updatedAt: Date;
+     viewerReactions: Record<string, {
+        app: `0x${string}`;
+        author: {
+           address: `0x${string}`;
+           ens?: {
+              avatarUrl: ... | ...;
+              name: string;
+           };
+           farcaster?: {
+              displayName?: ... | ...;
+              fid: number;
+              pfpUrl?: ... | ...;
+              username: string;
+           };
+        };
+        chainId: number;
+        channelId: bigint;
+        commentType: number;
+        content: string;
+        createdAt: Date;
+        cursor: `0x${string}`;
+        deletedAt: null | Date;
+        hookMetadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        id: `0x${string}`;
+        logIndex: null | number;
+        metadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        moderationClassifierResult: Record<string, number>;
+        moderationClassifierScore: number;
+        moderationStatus: "approved" | "pending" | "rejected";
+        moderationStatusChangedAt: Date;
+        parentId: null | `0x${string}`;
+        references: (
+           | {
+           address: `0x${(...)}`;
+           avatarUrl: ... | ...;
+           name: string;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           type: "ens";
+           url: string;
+         }
+           | {
+           address: `0x${(...)}`;
+           displayName: ... | ...;
+           fid: number;
+           fname: string;
+           pfpUrl: ... | ...;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           type: "farcaster";
+           url: string;
+           username: string;
+         }
+           | {
+           address: `0x${(...)}`;
+           chainId: ... | ...;
+           chains: ...[];
+           decimals: number;
+           logoURI: ... | ...;
+           name: string;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           symbol: string;
+           type: "erc20";
+         }
+           | {
+           description: ... | ...;
+           favicon: ... | ...;
+           opengraph: ... | ...;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           title: string;
+           type: "webpage";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           type: "file";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           type: "image";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: ...;
+              start: ...;
+           };
+           type: "video";
+           url: string;
+        })[];
+        revision: number;
+        targetUri: string;
+        txHash: `0x${string}`;
+        updatedAt: Date;
+        zeroExSwap:   | null
+           | {
+           from: {
+              address: `0x${(...)}`;
+              amount: string;
+              symbol: string;
+           };
+           to: {
+              address: ... | ...;
+              amount: string;
+              symbol: string;
+           };
+         };
+     }[]>;
      zeroExSwap:   | null
         | {
         from: {
@@ -226,6 +539,7 @@ Fetch replies for a comment from the Indexer API
      `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
      `moderationStatusChangedAt`: `Date`;
      `parentId`: `null` \| `` `0x${string}` ``;
+     `reactionCounts`: `Record`\<`string`, `number`\>;
      `references`: (
         \| \{
         `address`: `` `0x${string}` ``;
@@ -314,10 +628,322 @@ Fetch replies for a comment from the Indexer API
         `type`: `"video"`;
         `url`: `string`;
      \})[];
+     `replies`: \{
+        `extra`: \{
+           `moderationEnabled`: `boolean`;
+           `moderationKnownReactions`: `string`[];
+        \};
+        `pagination`: \{
+           `endCursor?`: `` `0x${string}` ``;
+           `hasNext`: `boolean`;
+           `hasPrevious`: `boolean`;
+           `limit`: `number`;
+           `startCursor?`: `` `0x${string}` ``;
+        \};
+        `results`: \{
+           `app`: `` `0x${string}` ``;
+           `author`: \{
+              `address`: `` `0x${string}` ``;
+              `ens?`: \{
+                 `avatarUrl`: ... \| ...;
+                 `name`: `string`;
+              \};
+              `farcaster?`: \{
+                 `displayName?`: ... \| ...;
+                 `fid`: `number`;
+                 `pfpUrl?`: ... \| ...;
+                 `username`: `string`;
+              \};
+           \};
+           `chainId`: `number`;
+           `channelId`: `bigint`;
+           `commentType`: `number`;
+           `content`: `string`;
+           `createdAt`: `Date`;
+           `cursor`: `` `0x${string}` ``;
+           `deletedAt`: `null` \| `Date`;
+           `hookMetadata`: \{
+              `key`: `` `0x${string}` ``;
+              `value`: `` `0x${string}` ``;
+           \}[];
+           `id`: `` `0x${string}` ``;
+           `logIndex`: `null` \| `number`;
+           `metadata`: \{
+              `key`: `` `0x${string}` ``;
+              `value`: `` `0x${string}` ``;
+           \}[];
+           `moderationClassifierResult`: `Record`\<`string`, `number`\>;
+           `moderationClassifierScore`: `number`;
+           `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
+           `moderationStatusChangedAt`: `Date`;
+           `parentId`: `null` \| `` `0x${string}` ``;
+           `reactionCounts`: `Record`\<`string`, `number`\>;
+           `references`: (
+              \| \{
+              `address`: `` `0x${(...)}` ``;
+              `avatarUrl`: ... \| ...;
+              `name`: `string`;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `type`: `"ens"`;
+              `url`: `string`;
+            \}
+              \| \{
+              `address`: `` `0x${(...)}` ``;
+              `displayName`: ... \| ...;
+              `fid`: `number`;
+              `fname`: `string`;
+              `pfpUrl`: ... \| ...;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `type`: `"farcaster"`;
+              `url`: `string`;
+              `username`: `string`;
+            \}
+              \| \{
+              `address`: `` `0x${(...)}` ``;
+              `chainId`: ... \| ...;
+              `chains`: ...[];
+              `decimals`: `number`;
+              `logoURI`: ... \| ...;
+              `name`: `string`;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `symbol`: `string`;
+              `type`: `"erc20"`;
+            \}
+              \| \{
+              `description`: ... \| ...;
+              `favicon`: ... \| ...;
+              `opengraph`: ... \| ...;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `title`: `string`;
+              `type`: `"webpage"`;
+              `url`: `string`;
+            \}
+              \| \{
+              `mediaType`: `string`;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `type`: `"file"`;
+              `url`: `string`;
+            \}
+              \| \{
+              `mediaType`: `string`;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `type`: `"image"`;
+              `url`: `string`;
+            \}
+              \| \{
+              `mediaType`: `string`;
+              `position`: \{
+                 `end`: ...;
+                 `start`: ...;
+              \};
+              `type`: `"video"`;
+              `url`: `string`;
+           \})[];
+           `revision`: `number`;
+           `targetUri`: `string`;
+           `txHash`: `` `0x${string}` ``;
+           `updatedAt`: `Date`;
+           `viewerReactions`: `Record`\<`string`, \{
+              `app`: `` `0x${(...)}` ``;
+              `author`: \{
+                 `address`: ...;
+                 `ens?`: ...;
+                 `farcaster?`: ...;
+              \};
+              `chainId`: `number`;
+              `channelId`: `bigint`;
+              `commentType`: `number`;
+              `content`: `string`;
+              `createdAt`: `Date`;
+              `cursor`: `` `0x${(...)}` ``;
+              `deletedAt`: ... \| ...;
+              `hookMetadata`: ...[];
+              `id`: `` `0x${(...)}` ``;
+              `logIndex`: ... \| ...;
+              `metadata`: ...[];
+              `moderationClassifierResult`: `Record`\<..., ...\>;
+              `moderationClassifierScore`: `number`;
+              `moderationStatus`: ... \| ... \| ...;
+              `moderationStatusChangedAt`: `Date`;
+              `parentId`: ... \| ...;
+              `references`: ...[];
+              `revision`: `number`;
+              `targetUri`: `string`;
+              `txHash`: `` `0x${(...)}` ``;
+              `updatedAt`: `Date`;
+              `zeroExSwap`: ... \| ...;
+           \}[]\>;
+           `zeroExSwap`:   \| `null`
+              \| \{
+              `from`: \{
+                 `address`: `` `0x${(...)}` ``;
+                 `amount`: `string`;
+                 `symbol`: `string`;
+              \};
+              `to`: \{
+                 `address`: ... \| ...;
+                 `amount`: `string`;
+                 `symbol`: `string`;
+              \};
+            \};
+        \}[];
+     \};
      `revision`: `number`;
      `targetUri`: `string`;
      `txHash`: `` `0x${string}` ``;
      `updatedAt`: `Date`;
+     `viewerReactions`: `Record`\<`string`, \{
+        `app`: `` `0x${string}` ``;
+        `author`: \{
+           `address`: `` `0x${string}` ``;
+           `ens?`: \{
+              `avatarUrl`: ... \| ...;
+              `name`: `string`;
+           \};
+           `farcaster?`: \{
+              `displayName?`: ... \| ...;
+              `fid`: `number`;
+              `pfpUrl?`: ... \| ...;
+              `username`: `string`;
+           \};
+        \};
+        `chainId`: `number`;
+        `channelId`: `bigint`;
+        `commentType`: `number`;
+        `content`: `string`;
+        `createdAt`: `Date`;
+        `cursor`: `` `0x${string}` ``;
+        `deletedAt`: `null` \| `Date`;
+        `hookMetadata`: \{
+           `key`: `` `0x${string}` ``;
+           `value`: `` `0x${string}` ``;
+        \}[];
+        `id`: `` `0x${string}` ``;
+        `logIndex`: `null` \| `number`;
+        `metadata`: \{
+           `key`: `` `0x${string}` ``;
+           `value`: `` `0x${string}` ``;
+        \}[];
+        `moderationClassifierResult`: `Record`\<`string`, `number`\>;
+        `moderationClassifierScore`: `number`;
+        `moderationStatus`: `"approved"` \| `"pending"` \| `"rejected"`;
+        `moderationStatusChangedAt`: `Date`;
+        `parentId`: `null` \| `` `0x${string}` ``;
+        `references`: (
+           \| \{
+           `address`: `` `0x${(...)}` ``;
+           `avatarUrl`: ... \| ...;
+           `name`: `string`;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `type`: `"ens"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `address`: `` `0x${(...)}` ``;
+           `displayName`: ... \| ...;
+           `fid`: `number`;
+           `fname`: `string`;
+           `pfpUrl`: ... \| ...;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `type`: `"farcaster"`;
+           `url`: `string`;
+           `username`: `string`;
+         \}
+           \| \{
+           `address`: `` `0x${(...)}` ``;
+           `chainId`: ... \| ...;
+           `chains`: ...[];
+           `decimals`: `number`;
+           `logoURI`: ... \| ...;
+           `name`: `string`;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `symbol`: `string`;
+           `type`: `"erc20"`;
+         \}
+           \| \{
+           `description`: ... \| ...;
+           `favicon`: ... \| ...;
+           `opengraph`: ... \| ...;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `title`: `string`;
+           `type`: `"webpage"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `mediaType`: `string`;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `type`: `"file"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `mediaType`: `string`;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `type`: `"image"`;
+           `url`: `string`;
+         \}
+           \| \{
+           `mediaType`: `string`;
+           `position`: \{
+              `end`: ...;
+              `start`: ...;
+           \};
+           `type`: `"video"`;
+           `url`: `string`;
+        \})[];
+        `revision`: `number`;
+        `targetUri`: `string`;
+        `txHash`: `` `0x${string}` ``;
+        `updatedAt`: `Date`;
+        `zeroExSwap`:   \| `null`
+           \| \{
+           `from`: \{
+              `address`: `` `0x${(...)}` ``;
+              `amount`: `string`;
+              `symbol`: `string`;
+           \};
+           `to`: \{
+              `address`: ... \| ...;
+              `amount`: `string`;
+              `symbol`: `string`;
+           \};
+         \};
+     \}[]\>;
      `zeroExSwap`:   \| `null`
         \| \{
         `from`: \{

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
@@ -56,6 +56,7 @@ type IndexerAPIListCommentRepliesSchemaType = {
      moderationStatus: "approved" | "pending" | "rejected";
      moderationStatusChangedAt: Date;
      parentId: null | `0x${string}`;
+     reactionCounts: Record<string, number>;
      references: (
         | {
         address: `0x${string}`;
@@ -144,10 +145,350 @@ type IndexerAPIListCommentRepliesSchemaType = {
         type: "video";
         url: string;
      })[];
+     replies: {
+        extra: {
+           moderationEnabled: boolean;
+           moderationKnownReactions: string[];
+        };
+        pagination: {
+           endCursor?: `0x${string}`;
+           hasNext: boolean;
+           hasPrevious: boolean;
+           limit: number;
+           startCursor?: `0x${string}`;
+        };
+        results: {
+           app: `0x${string}`;
+           author: {
+              address: `0x${string}`;
+              ens?: {
+                 avatarUrl: null | string;
+                 name: string;
+              };
+              farcaster?: {
+                 displayName?: string;
+                 fid: number;
+                 pfpUrl?: string;
+                 username: string;
+              };
+           };
+           chainId: number;
+           channelId: bigint;
+           commentType: number;
+           content: string;
+           createdAt: Date;
+           cursor: `0x${string}`;
+           deletedAt: null | Date;
+           hookMetadata: {
+              key: `0x${string}`;
+              value: `0x${string}`;
+           }[];
+           id: `0x${string}`;
+           logIndex: null | number;
+           metadata: {
+              key: `0x${string}`;
+              value: `0x${string}`;
+           }[];
+           moderationClassifierResult: Record<string, number>;
+           moderationClassifierScore: number;
+           moderationStatus: "approved" | "pending" | "rejected";
+           moderationStatusChangedAt: Date;
+           parentId: null | `0x${string}`;
+           reactionCounts: Record<string, number>;
+           references: (
+              | {
+              address: `0x${string}`;
+              avatarUrl: null | string;
+              name: string;
+              position: {
+                 end: number;
+                 start: number;
+              };
+              type: "ens";
+              url: string;
+            }
+              | {
+              address: `0x${string}`;
+              displayName: null | string;
+              fid: number;
+              fname: string;
+              pfpUrl: null | string;
+              position: {
+                 end: number;
+                 start: number;
+              };
+              type: "farcaster";
+              url: string;
+              username: string;
+            }
+              | {
+              address: `0x${string}`;
+              chainId: null | number;
+              chains: {
+                 caip: ...;
+                 chainId: ...;
+              }[];
+              decimals: number;
+              logoURI: null | string;
+              name: string;
+              position: {
+                 end: number;
+                 start: number;
+              };
+              symbol: string;
+              type: "erc20";
+            }
+              | {
+              description: null | string;
+              favicon: null | string;
+              opengraph:   | null
+                 | {
+                 description: ...;
+                 image: ...;
+                 title: ...;
+                 url: ...;
+               };
+              position: {
+                 end: number;
+                 start: number;
+              };
+              title: string;
+              type: "webpage";
+              url: string;
+            }
+              | {
+              mediaType: string;
+              position: {
+                 end: number;
+                 start: number;
+              };
+              type: "file";
+              url: string;
+            }
+              | {
+              mediaType: string;
+              position: {
+                 end: number;
+                 start: number;
+              };
+              type: "image";
+              url: string;
+            }
+              | {
+              mediaType: string;
+              position: {
+                 end: number;
+                 start: number;
+              };
+              type: "video";
+              url: string;
+           })[];
+           revision: number;
+           targetUri: string;
+           txHash: `0x${string}`;
+           updatedAt: Date;
+           viewerReactions: Record<string, {
+              app: `0x${string}`;
+              author: {
+                 address: `0x${(...)}`;
+                 ens?: ... | ...;
+                 farcaster?: ... | ...;
+              };
+              chainId: number;
+              channelId: bigint;
+              commentType: number;
+              content: string;
+              createdAt: Date;
+              cursor: `0x${string}`;
+              deletedAt: null | Date;
+              hookMetadata: {
+                 key: ...;
+                 value: ...;
+              }[];
+              id: `0x${string}`;
+              logIndex: null | number;
+              metadata: {
+                 key: ...;
+                 value: ...;
+              }[];
+              moderationClassifierResult: Record<string, number>;
+              moderationClassifierScore: number;
+              moderationStatus: "approved" | "pending" | "rejected";
+              moderationStatusChangedAt: Date;
+              parentId: null | `0x${(...)}`;
+              references: (... | ... | ... | ... | ... | ... | ...)[];
+              revision: number;
+              targetUri: string;
+              txHash: `0x${string}`;
+              updatedAt: Date;
+              zeroExSwap:   | null
+                 | {
+                 from: ...;
+                 to: ...;
+               };
+           }[]>;
+           zeroExSwap:   | null
+              | {
+              from: {
+                 address: `0x${string}`;
+                 amount: string;
+                 symbol: string;
+              };
+              to: {
+                 address: "" | `0x${(...)}`;
+                 amount: string;
+                 symbol: string;
+              };
+            };
+        }[];
+     };
      revision: number;
      targetUri: string;
      txHash: `0x${string}`;
      updatedAt: Date;
+     viewerReactions: Record<string, {
+        app: `0x${string}`;
+        author: {
+           address: `0x${string}`;
+           ens?: {
+              avatarUrl: null | string;
+              name: string;
+           };
+           farcaster?: {
+              displayName?: string;
+              fid: number;
+              pfpUrl?: string;
+              username: string;
+           };
+        };
+        chainId: number;
+        channelId: bigint;
+        commentType: number;
+        content: string;
+        createdAt: Date;
+        cursor: `0x${string}`;
+        deletedAt: null | Date;
+        hookMetadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        id: `0x${string}`;
+        logIndex: null | number;
+        metadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        moderationClassifierResult: Record<string, number>;
+        moderationClassifierScore: number;
+        moderationStatus: "approved" | "pending" | "rejected";
+        moderationStatusChangedAt: Date;
+        parentId: null | `0x${string}`;
+        references: (
+           | {
+           address: `0x${string}`;
+           avatarUrl: null | string;
+           name: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "ens";
+           url: string;
+         }
+           | {
+           address: `0x${string}`;
+           displayName: null | string;
+           fid: number;
+           fname: string;
+           pfpUrl: null | string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "farcaster";
+           url: string;
+           username: string;
+         }
+           | {
+           address: `0x${string}`;
+           chainId: null | number;
+           chains: {
+              caip: ...;
+              chainId: ...;
+           }[];
+           decimals: number;
+           logoURI: null | string;
+           name: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           symbol: string;
+           type: "erc20";
+         }
+           | {
+           description: null | string;
+           favicon: null | string;
+           opengraph:   | null
+              | {
+              description: ...;
+              image: ...;
+              title: ...;
+              url: ...;
+            };
+           position: {
+              end: number;
+              start: number;
+           };
+           title: string;
+           type: "webpage";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "file";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "image";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "video";
+           url: string;
+        })[];
+        revision: number;
+        targetUri: string;
+        txHash: `0x${string}`;
+        updatedAt: Date;
+        zeroExSwap:   | null
+           | {
+           from: {
+              address: `0x${string}`;
+              amount: string;
+              symbol: string;
+           };
+           to: {
+              address: "" | `0x${(...)}`;
+              amount: string;
+              symbol: string;
+           };
+         };
+     }[]>;
      zeroExSwap:   | null
         | {
         from: {
@@ -272,6 +613,7 @@ results: {
   moderationStatus: "approved" | "pending" | "rejected";
   moderationStatusChangedAt: Date;
   parentId: null | `0x${string}`;
+  reactionCounts: Record<string, number>;
   references: (
      | {
      address: `0x${string}`;
@@ -360,10 +702,350 @@ results: {
      type: "video";
      url: string;
   })[];
+  replies: {
+     extra: {
+        moderationEnabled: boolean;
+        moderationKnownReactions: string[];
+     };
+     pagination: {
+        endCursor?: `0x${string}`;
+        hasNext: boolean;
+        hasPrevious: boolean;
+        limit: number;
+        startCursor?: `0x${string}`;
+     };
+     results: {
+        app: `0x${string}`;
+        author: {
+           address: `0x${string}`;
+           ens?: {
+              avatarUrl: null | string;
+              name: string;
+           };
+           farcaster?: {
+              displayName?: string;
+              fid: number;
+              pfpUrl?: string;
+              username: string;
+           };
+        };
+        chainId: number;
+        channelId: bigint;
+        commentType: number;
+        content: string;
+        createdAt: Date;
+        cursor: `0x${string}`;
+        deletedAt: null | Date;
+        hookMetadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        id: `0x${string}`;
+        logIndex: null | number;
+        metadata: {
+           key: `0x${string}`;
+           value: `0x${string}`;
+        }[];
+        moderationClassifierResult: Record<string, number>;
+        moderationClassifierScore: number;
+        moderationStatus: "approved" | "pending" | "rejected";
+        moderationStatusChangedAt: Date;
+        parentId: null | `0x${string}`;
+        reactionCounts: Record<string, number>;
+        references: (
+           | {
+           address: `0x${string}`;
+           avatarUrl: null | string;
+           name: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "ens";
+           url: string;
+         }
+           | {
+           address: `0x${string}`;
+           displayName: null | string;
+           fid: number;
+           fname: string;
+           pfpUrl: null | string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "farcaster";
+           url: string;
+           username: string;
+         }
+           | {
+           address: `0x${string}`;
+           chainId: null | number;
+           chains: {
+              caip: ...;
+              chainId: ...;
+           }[];
+           decimals: number;
+           logoURI: null | string;
+           name: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           symbol: string;
+           type: "erc20";
+         }
+           | {
+           description: null | string;
+           favicon: null | string;
+           opengraph:   | null
+              | {
+              description: ...;
+              image: ...;
+              title: ...;
+              url: ...;
+            };
+           position: {
+              end: number;
+              start: number;
+           };
+           title: string;
+           type: "webpage";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "file";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "image";
+           url: string;
+         }
+           | {
+           mediaType: string;
+           position: {
+              end: number;
+              start: number;
+           };
+           type: "video";
+           url: string;
+        })[];
+        revision: number;
+        targetUri: string;
+        txHash: `0x${string}`;
+        updatedAt: Date;
+        viewerReactions: Record<string, {
+           app: `0x${string}`;
+           author: {
+              address: `0x${(...)}`;
+              ens?: ... | ...;
+              farcaster?: ... | ...;
+           };
+           chainId: number;
+           channelId: bigint;
+           commentType: number;
+           content: string;
+           createdAt: Date;
+           cursor: `0x${string}`;
+           deletedAt: null | Date;
+           hookMetadata: {
+              key: ...;
+              value: ...;
+           }[];
+           id: `0x${string}`;
+           logIndex: null | number;
+           metadata: {
+              key: ...;
+              value: ...;
+           }[];
+           moderationClassifierResult: Record<string, number>;
+           moderationClassifierScore: number;
+           moderationStatus: "approved" | "pending" | "rejected";
+           moderationStatusChangedAt: Date;
+           parentId: null | `0x${(...)}`;
+           references: (... | ... | ... | ... | ... | ... | ...)[];
+           revision: number;
+           targetUri: string;
+           txHash: `0x${string}`;
+           updatedAt: Date;
+           zeroExSwap:   | null
+              | {
+              from: ...;
+              to: ...;
+            };
+        }[]>;
+        zeroExSwap:   | null
+           | {
+           from: {
+              address: `0x${string}`;
+              amount: string;
+              symbol: string;
+           };
+           to: {
+              address: "" | `0x${(...)}`;
+              amount: string;
+              symbol: string;
+           };
+         };
+     }[];
+  };
   revision: number;
   targetUri: string;
   txHash: `0x${string}`;
   updatedAt: Date;
+  viewerReactions: Record<string, {
+     app: `0x${string}`;
+     author: {
+        address: `0x${string}`;
+        ens?: {
+           avatarUrl: null | string;
+           name: string;
+        };
+        farcaster?: {
+           displayName?: string;
+           fid: number;
+           pfpUrl?: string;
+           username: string;
+        };
+     };
+     chainId: number;
+     channelId: bigint;
+     commentType: number;
+     content: string;
+     createdAt: Date;
+     cursor: `0x${string}`;
+     deletedAt: null | Date;
+     hookMetadata: {
+        key: `0x${string}`;
+        value: `0x${string}`;
+     }[];
+     id: `0x${string}`;
+     logIndex: null | number;
+     metadata: {
+        key: `0x${string}`;
+        value: `0x${string}`;
+     }[];
+     moderationClassifierResult: Record<string, number>;
+     moderationClassifierScore: number;
+     moderationStatus: "approved" | "pending" | "rejected";
+     moderationStatusChangedAt: Date;
+     parentId: null | `0x${string}`;
+     references: (
+        | {
+        address: `0x${string}`;
+        avatarUrl: null | string;
+        name: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "ens";
+        url: string;
+      }
+        | {
+        address: `0x${string}`;
+        displayName: null | string;
+        fid: number;
+        fname: string;
+        pfpUrl: null | string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "farcaster";
+        url: string;
+        username: string;
+      }
+        | {
+        address: `0x${string}`;
+        chainId: null | number;
+        chains: {
+           caip: ...;
+           chainId: ...;
+        }[];
+        decimals: number;
+        logoURI: null | string;
+        name: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        symbol: string;
+        type: "erc20";
+      }
+        | {
+        description: null | string;
+        favicon: null | string;
+        opengraph:   | null
+           | {
+           description: ...;
+           image: ...;
+           title: ...;
+           url: ...;
+         };
+        position: {
+           end: number;
+           start: number;
+        };
+        title: string;
+        type: "webpage";
+        url: string;
+      }
+        | {
+        mediaType: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "file";
+        url: string;
+      }
+        | {
+        mediaType: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "image";
+        url: string;
+      }
+        | {
+        mediaType: string;
+        position: {
+           end: number;
+           start: number;
+        };
+        type: "video";
+        url: string;
+     })[];
+     revision: number;
+     targetUri: string;
+     txHash: `0x${string}`;
+     updatedAt: Date;
+     zeroExSwap:   | null
+        | {
+        from: {
+           address: `0x${string}`;
+           amount: string;
+           symbol: string;
+        };
+        to: {
+           address: "" | `0x${(...)}`;
+           amount: string;
+           symbol: string;
+        };
+      };
+  }[]>;
   zeroExSwap:   | null
      | {
      from: {

--- a/packages/sdk/src/indexer/api.ts
+++ b/packages/sdk/src/indexer/api.ts
@@ -90,7 +90,7 @@ export async function fetchComment(
     retries,
   } = FetchCommentOptionsSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL(`/api/comments/${commentId}`, apiUrl);
 
@@ -126,12 +126,12 @@ export async function fetchComment(
         throw new Error(`Failed to fetch comments: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPICommentWithRepliesSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPICommentWithRepliesSchema.parse(responseData);
 }
 
 /**
@@ -283,7 +283,7 @@ export async function fetchComments(
     excludeByModerationLabels,
   } = FetchCommentsOptionsSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL("/api/comments", apiUrl);
 
@@ -363,12 +363,12 @@ export async function fetchComments(
         throw new Error(`Failed to fetch comments: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPIListCommentsSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPIListCommentsSchema.parse(responseData);
 }
 
 /**
@@ -510,7 +510,7 @@ export async function fetchCommentReplies(
     excludeByModerationLabels,
   } = FetchCommentRepliesOptionSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL(`/api/comments/${commentId}/replies`, apiUrl);
 
@@ -582,12 +582,12 @@ export async function fetchCommentReplies(
         throw new Error(`Failed to fetch replies: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPIListCommentRepliesSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPIListCommentRepliesSchema.parse(responseData);
 }
 
 /**
@@ -631,7 +631,7 @@ export async function fetchAuthorData(
   const { address, retries, apiUrl, signal } =
     FetchAuthorDataOptionsSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL(`/api/authors/${address}`, apiUrl);
 
@@ -648,12 +648,12 @@ export async function fetchAuthorData(
         throw new Error(`Failed to fetch author data: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPIAuthorDataSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPIAuthorDataSchema.parse(responseData);
 }
 
 /**
@@ -788,7 +788,7 @@ export async function fetchChannels(
   const { apiUrl, limit, cursor, retries, sort, signal, owner, chainId } =
     FetchChannelsOptionsSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL("/api/channels", apiUrl);
 
@@ -822,12 +822,12 @@ export async function fetchChannels(
         throw new Error(`Failed to fetch channels: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPIListChannelsSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPIListChannelsSchema.parse(responseData);
 }
 
 /**
@@ -871,7 +871,7 @@ export async function fetchChannel(
   const { channelId, apiUrl, retries, signal } =
     FetchChannelOptionsSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL(`/api/channels/${channelId}`, apiUrl);
 
@@ -888,12 +888,12 @@ export async function fetchChannel(
         throw new Error(`Failed to fetch channel: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPIChannelOutputSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPIChannelOutputSchema.parse(responseData);
 }
 
 /**
@@ -943,7 +943,7 @@ export async function fetchAutocomplete(
   const { query, char, apiUrl, retries, signal } =
     FetchAutocompleteOptionsSchema.parse(options);
 
-  return runAsync(
+  const responseData = await runAsync(
     async (signal) => {
       const url = new URL("/api/autocomplete", apiUrl);
 
@@ -963,12 +963,12 @@ export async function fetchAutocomplete(
         throw new Error(`Failed to fetch autocomplete: ${response.statusText}`);
       }
 
-      const responseData = await response.json();
-
-      return IndexerAPIGetAutocompleteOutputSchema.parse(responseData);
+      return await response.json();
     },
     { signal, retries },
   );
+
+  return IndexerAPIGetAutocompleteOutputSchema.parse(responseData);
 }
 
 /**

--- a/packages/sdk/src/indexer/schemas.ts
+++ b/packages/sdk/src/indexer/schemas.ts
@@ -440,7 +440,7 @@ export type IndexerAPIListCommentsOutputSchemaType = z.infer<
 >;
 
 export const IndexerAPIListCommentRepliesSchema = z.object({
-  results: z.array(IndexerAPICommentSchema),
+  results: z.array(IndexerAPICommentWithRepliesSchema),
   pagination: IndexerAPICursorPaginationSchema,
   extra: IndexerAPIExtraSchema,
 });

--- a/packages/sdk/src/indexer/test/api.ts
+++ b/packages/sdk/src/indexer/test/api.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import nock from "nock";
-import { fetchComment } from "../api.js";
+import { fetchComment, fetchCommentReplies } from "../api.js";
 import type { Hex } from "../../core/schemas.js";
 
 describe("fetchComment", () => {
@@ -9,7 +9,8 @@ describe("fetchComment", () => {
     const commentId: Hex =
       "0x9e928d74c573428f69aa87aa084cc801c6c9a9c04c0512813abb3b82fbe1f21e";
     const chainId = 31337;
-    const { responseData, expectedFetchResult } = getMockResponseData();
+    const { responseData, expectedFetchResult } =
+      getMockFetchCommentResponseData();
 
     nock("https://api.ethcomments.xyz")
       .get(`/api/comments/${commentId}?chainId=${chainId}`)
@@ -24,11 +25,56 @@ describe("fetchComment", () => {
   });
 });
 
-function getMockResponseData() {
-  const date = new Date();
-  const channelId = 0n;
+describe("fetchCommentReplies", () => {
+  it("should fetch replies for a comment", async () => {
+    const commentId: Hex =
+      "0x9e928d74c573428f69aa87aa084cc801c6c9a9c04c0512813abb3b82fbe1f21e";
+    const chainId = 31337;
+    const { responseData, expectedFetchResult } =
+      getMockFetchCommentRepliesResponseData();
 
-  const responseData = {
+    nock("https://api.ethcomments.xyz")
+      .get(
+        `/api/comments/${commentId}/replies?chainId=${chainId}&limit=50&sort=desc`,
+      )
+      .reply(200, responseData);
+
+    const fetchResult = await fetchCommentReplies({
+      commentId,
+      chainId,
+    });
+
+    assert.deepStrictEqual(expectedFetchResult, fetchResult);
+  });
+});
+
+const responseDataJSONReplacer = (_: unknown, v: unknown) => {
+  if (typeof v === "bigint") {
+    return v.toString();
+  }
+
+  // JSON.stringify always attempt to call value.toJSON on the value and then passing the result to the replacer function
+  // so in order to catch Date object in raw form, we need to handle it on its parent level.
+  if (v !== null && typeof v === "object") {
+    if (Array.isArray(v)) {
+      return v;
+    }
+
+    return Object.fromEntries(
+      Object.entries(v).map(([key, value]) => {
+        if (value instanceof Date) {
+          return [key, value.toISOString()];
+        }
+        return [key, value];
+      }),
+    );
+  }
+
+  return v;
+};
+
+function getMockFetchCommentResponseData() {
+  const expectedFetchResult = {
     app: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
     author: {
       address: "0xc506739d39cbf1d94e2510bfca64cb6015f4bb1b",
@@ -41,7 +87,7 @@ function getMockResponseData() {
       },
     },
     id: "0x9e928d74c573428f69aa87aa084cc801c6c9a9c04c0512813abb3b82fbe1f21e",
-    channelId: channelId.toString(),
+    channelId: 0n,
     commentType: 0,
     content: "asdadasas1",
     chainId: 31337,
@@ -56,7 +102,7 @@ function getMockResponseData() {
     cursor:
       "0x313735333731323531393030303a307839653932386437346335373334323866363961613837616130383463633830316336633961396330346330353132383133616262336238326662653166323165",
     moderationStatus: "approved",
-    moderationStatusChangedAt: date.toISOString(),
+    moderationStatusChangedAt: new Date(),
     moderationClassifierResult: {
       hate: 0,
       spam: 0,
@@ -70,8 +116,8 @@ function getMockResponseData() {
       violence_graphic: 0,
     },
     moderationClassifierScore: 0,
-    createdAt: date.toISOString(),
-    updatedAt: date.toISOString(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
     revision: 0,
     zeroExSwap: null,
     references: [],
@@ -91,16 +137,147 @@ function getMockResponseData() {
     },
   };
 
+  return {
+    expectedFetchResult,
+    responseData: JSON.stringify(expectedFetchResult, responseDataJSONReplacer),
+  };
+}
+
+function getMockFetchCommentRepliesResponseData() {
   const expectedFetchResult = {
-    ...responseData,
-    channelId,
-    moderationStatusChangedAt: date,
-    createdAt: date,
-    updatedAt: date,
+    results: [
+      {
+        app: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+        author: {
+          address: "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
+        },
+        id: "0x4639fe3e5aa762ed850143819b5022ab59e67713ce1561cf4f012f9f5246ec1a",
+        channelId: 0n,
+        commentType: 0,
+        content: "reply 7",
+        chainId: 31337,
+        deletedAt: null,
+        logIndex: 0,
+        metadata: [],
+        hookMetadata: [],
+        parentId:
+          "0x7d4ceac9744f15fa8e544612dbdb3d34498761ef7437bf198f58037a37fa169f",
+        targetUri: "",
+        txHash:
+          "0x8185e0d1c11e515c28cd6b8ef13925cb4bf0dcfe5bb4005b7a301edc56e78496",
+        cursor:
+          "0x313735333830343031303030303a307834363339666533653561613736326564383530313433383139623530323261623539653637373133636531353631636634663031326639663532343665633161",
+        moderationStatus: "approved",
+        moderationStatusChangedAt: new Date("2025-07-29T18:24:25.258Z"),
+        moderationClassifierResult: {
+          hate: 0,
+          spam: 0,
+          sexual: 0,
+          violence: 0,
+          self_harm: 0,
+          harassment: 0,
+          llm_generated: 0,
+          sexual_minors: 0,
+          hate_threatening: 0,
+          violence_graphic: 0,
+        },
+        moderationClassifierScore: 0,
+        createdAt: new Date("2025-07-29T15:46:50.000Z"),
+        updatedAt: new Date("2025-07-29T15:46:50.000Z"),
+        revision: 0,
+        zeroExSwap: null,
+        references: [],
+        viewerReactions: {},
+        reactionCounts: {},
+        replies: {
+          extra: {
+            moderationEnabled: false,
+            moderationKnownReactions: ["like"],
+          },
+          results: [],
+          pagination: {
+            limit: 2,
+            hasNext: false,
+            hasPrevious: false,
+          },
+        },
+      },
+      {
+        app: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+        author: {
+          address: "0xa0ee7a142d267c1f36714e4a8f75612f20a79720",
+        },
+        id: "0x733462c8fae87358165c88b84f6dc213333e0480a8607cf26c33ce53206beda4",
+        channelId: 0n,
+        commentType: 0,
+        content: "reply 6",
+        chainId: 31337,
+        deletedAt: null,
+        logIndex: 0,
+        metadata: [],
+        hookMetadata: [],
+        parentId:
+          "0x7d4ceac9744f15fa8e544612dbdb3d34498761ef7437bf198f58037a37fa169f",
+        targetUri: "",
+        txHash:
+          "0x8ecb2727559e83040eb0711d74755005ad3e8b145178e6bbf093dbe49901b4d2",
+        cursor:
+          "0x313735333830333937333030303a307837333334363263386661653837333538313635633838623834663664633231333333336530343830613836303763663236633333636535333230366265646134",
+        moderationStatus: "approved",
+        moderationStatusChangedAt: new Date("2025-07-29T18:24:25.236Z"),
+        moderationClassifierResult: {
+          hate: 0,
+          spam: 0,
+          sexual: 0,
+          violence: 0,
+          self_harm: 0,
+          harassment: 0,
+          llm_generated: 0,
+          sexual_minors: 0,
+          hate_threatening: 0,
+          violence_graphic: 0,
+        },
+        moderationClassifierScore: 0,
+        createdAt: new Date("2025-07-29T15:46:13.000Z"),
+        updatedAt: new Date("2025-07-29T15:46:13.000Z"),
+        revision: 0,
+        zeroExSwap: null,
+        references: [],
+        viewerReactions: {},
+        reactionCounts: {
+          like: 1,
+        },
+        replies: {
+          extra: {
+            moderationEnabled: false,
+            moderationKnownReactions: ["like"],
+          },
+          results: [],
+          pagination: {
+            limit: 2,
+            hasNext: false,
+            hasPrevious: false,
+          },
+        },
+      },
+    ],
+    pagination: {
+      limit: 50,
+      hasNext: false,
+      hasPrevious: false,
+      startCursor:
+        "0x313735333830343031303030303a307834363339666533653561613736326564383530313433383139623530323261623539653637373133636531353631636634663031326639663532343665633161",
+      endCursor:
+        "0x313735333739353839393030303a307861313565353862366334373062333933373833666366386363636530616561636232623331393962623735663137613865663939326534663761646265396234",
+    },
+    extra: {
+      moderationEnabled: false,
+      moderationKnownReactions: ["like"],
+    },
   };
 
   return {
-    responseData,
     expectedFetchResult,
+    responseData: JSON.stringify(expectedFetchResult, responseDataJSONReplacer),
   };
 }


### PR DESCRIPTION
### 1. fix: `fetchCommentReplies()` does not return reaction related props

https://linear.app/modprotocol/issue/ECP-1478/fetchcommentreplies-should-return-similar-shape-as-fetchcomments-there

The reason is inconsistent schema used in indexer and in SDK, the indexer uses `IndexerAPIListCommentRepliesOutputSchema` for parsing while sdk uses the base comment schema `IndexerAPIListCommentsSchema`

```typescript
...
    return c.json(
      IndexerAPIListCommentRepliesOutputSchema.parse(formattedComments),
      200,
    );
...
```

### 2. fix: `runAsync()` in sdk should avoid retry error due to schema parsing

It is unnecessary to wrap `schema.parse()` inside `runAsync()`, parsing error should be exposed immediately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced comment replies to include detailed nested reply structures, allowing multi-level replies with full metadata, moderation info, and reaction tracking.
  * Added reaction counts and viewer reactions for both comments and replies, providing greater insight into engagement.

* **Tests**
  * Expanded test coverage to include comprehensive cases for fetching comment replies and improved mock data handling for complex data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->