### PR TITLE
fix(sdk): update schema to correctly handle nested replies and moderation data in comment responses

### DIFF
--- a/.changeset/violet-chefs-tease.md
+++ b/.changeset/violet-chefs-tease.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+fix(sdk): use correct shape for list comments and replies that contains replies even on nested levels

--- a/apps/indexer/src/lib/response-formatters.ts
+++ b/apps/indexer/src/lib/response-formatters.ts
@@ -125,6 +125,10 @@ export const createUserDataAndFormatSingleCommentResponseResolver = (
     const slicedReplies = replies.slice(0, replyLimit);
     const startReply = slicedReplies[0];
     const endReply = slicedReplies[slicedReplies.length - 1];
+    const extra = {
+      moderationEnabled: env.MODERATION_ENABLED,
+      moderationKnownReactions: Array.from(env.MODERATION_KNOWN_REACTIONS),
+    };
 
     return {
       ...formatComment(comment),
@@ -135,10 +139,7 @@ export const createUserDataAndFormatSingleCommentResponseResolver = (
       ),
       viewerReactions: formatViewerReactions(viewerReactions),
       replies: {
-        extra: {
-          moderationEnabled: env.MODERATION_ENABLED,
-          moderationKnownReactions: Array.from(env.MODERATION_KNOWN_REACTIONS),
-        },
+        extra,
         results: slicedReplies.map((reply) => {
           const resolvedAuthorEnsData = resolveUserData(
             resolvedAuthorsEnsData,
@@ -159,6 +160,7 @@ export const createUserDataAndFormatSingleCommentResponseResolver = (
 
             // do not go deeper than first level of replies
             replies: {
+              extra,
               results: [],
               pagination: {
                 limit: 0,

--- a/packages/sdk/src/indexer/schemas.ts
+++ b/packages/sdk/src/indexer/schemas.ts
@@ -369,11 +369,19 @@ export const IndexerAPICommentReactionSchema = IndexerAPICommentSchema.extend({
   reactionCounts: z.record(z.number()),
 });
 
+export type IndexerAPICommentReactionSchemaType = z.infer<
+  typeof IndexerAPICommentReactionSchema
+>;
+
 export const IndexerAPICommentReactionOutputSchema =
   IndexerAPICommentOutputSchema.extend({
     viewerReactions: z.record(z.array(IndexerAPICommentOutputSchema)),
     reactionCounts: z.record(z.number()),
   });
+
+export type IndexerAPICommentReactionOutputSchemaType = z.infer<
+  typeof IndexerAPICommentReactionOutputSchema
+>;
 
 export const IndexerAPIPaginationSchema = z.object({
   limit: z.number().int(),
@@ -392,11 +400,20 @@ export const IndexerAPIExtraSchema = z.object({
 
 export type IndexerAPIExtraSchemaType = z.infer<typeof IndexerAPIExtraSchema>;
 
-export const IndexerAPICommentWithRepliesSchema =
+type IndexerAPICommentWithRepliesSchemaInnerType =
+  IndexerAPICommentReactionSchemaType & {
+    replies: {
+      extra: IndexerAPIExtraSchemaType;
+      results: IndexerAPICommentWithRepliesSchemaInnerType[];
+      pagination: IndexerAPICursorPaginationSchemaType;
+    };
+  };
+
+export const IndexerAPICommentWithRepliesSchema: z.ZodType<IndexerAPICommentWithRepliesSchemaInnerType> =
   IndexerAPICommentReactionSchema.extend({
     replies: z.object({
       extra: IndexerAPIExtraSchema,
-      results: z.array(IndexerAPICommentReactionSchema),
+      results: z.lazy(() => IndexerAPICommentWithRepliesSchema.array()),
       pagination: IndexerAPICursorPaginationSchema,
     }),
   });
@@ -405,14 +422,39 @@ export type IndexerAPICommentWithRepliesSchemaType = z.infer<
   typeof IndexerAPICommentWithRepliesSchema
 >;
 
-export const IndexerAPICommentWithRepliesOutputSchema =
-  IndexerAPICommentReactionOutputSchema.extend({
-    replies: z.object({
-      extra: IndexerAPIExtraSchema,
-      results: z.array(IndexerAPICommentReactionOutputSchema),
-      pagination: IndexerAPICursorPaginationSchema,
-    }),
-  });
+type IndexerAPICommentReactionOutputSchemaInputType = z.input<
+  typeof IndexerAPICommentReactionOutputSchema
+>;
+
+type IndexerAPICommentWithRepliesOutputSchemaInnerType =
+  IndexerAPICommentReactionOutputSchemaType & {
+    replies: {
+      extra: IndexerAPIExtraSchemaType;
+      results: IndexerAPICommentReactionOutputSchemaType[];
+      pagination: IndexerAPICursorPaginationSchemaType;
+    };
+  };
+
+type IndexerAPICommentWithRepliesOutputSchemaInnerInputType =
+  IndexerAPICommentReactionOutputSchemaInputType & {
+    replies: {
+      extra: IndexerAPIExtraSchemaType;
+      results: IndexerAPICommentWithRepliesOutputSchemaInnerInputType[];
+      pagination: IndexerAPICursorPaginationSchemaType;
+    };
+  };
+
+export const IndexerAPICommentWithRepliesOutputSchema: z.ZodType<
+  IndexerAPICommentWithRepliesOutputSchemaInnerType,
+  z.ZodObjectDef,
+  IndexerAPICommentWithRepliesOutputSchemaInnerInputType
+> = IndexerAPICommentReactionOutputSchema.extend({
+  replies: z.object({
+    extra: IndexerAPIExtraSchema,
+    results: z.lazy(() => IndexerAPICommentWithRepliesOutputSchema.array()),
+    pagination: IndexerAPICursorPaginationSchema,
+  }),
+});
 
 export type IndexerAPICommentWithRepliesOutputSchemaType = z.infer<
   typeof IndexerAPICommentWithRepliesOutputSchema


### PR DESCRIPTION
https://linear.app/modprotocol/issue/ECP-1480/fetchcommentreplies-doesnt-use-correct-shape-for-nested-comments-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested comment threads, ensuring replies can contain multiple levels of nested replies for more accurate comment and reply listings.

* **Refactor**
  * Standardized the inclusion of moderation-related metadata across all levels of comment replies, ensuring consistent data structure throughout nested replies.

* **Style**
  * Enhanced type safety and clarity for comment and reply data structures, providing more robust and maintainable type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->