### PR TITLE
fix(sdk): export correct addresses in SUPPORTED_CHAINS when in local dev

### DIFF
--- a/.changeset/breezy-kings-kneel.md
+++ b/.changeset/breezy-kings-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+fix(sdk): export correct addresses in SUPPORTED_CHAINS in local dev

--- a/docs/pages/sdk-reference/defaultExports/type-aliases/SupportedChainConfig.mdx
+++ b/docs/pages/sdk-reference/defaultExports/type-aliases/SupportedChainConfig.mdx
@@ -14,7 +14,7 @@ type SupportedChainConfig = {
 };
 ```
 
-Defined in: [packages/sdk/src/constants.ts:27](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L27)
+Defined in: [packages/sdk/src/constants.ts:26](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L26)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/constants.ts:27](https://github.com/ecp-eth/commen
 chain: Chain;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:28](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L28)
+Defined in: [packages/sdk/src/constants.ts:27](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L27)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [packages/sdk/src/constants.ts:28](https://github.com/ecp-eth/commen
 channelManagerAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:30](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L30)
+Defined in: [packages/sdk/src/constants.ts:29](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L29)
 
 ***
 
@@ -44,4 +44,4 @@ Defined in: [packages/sdk/src/constants.ts:30](https://github.com/ecp-eth/commen
 commentManagerAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:29](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L29)
+Defined in: [packages/sdk/src/constants.ts:28](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L28)

--- a/docs/pages/sdk-reference/defaultExports/variables/CHANNEL_MANAGER_ADDRESS.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/CHANNEL_MANAGER_ADDRESS.mdx
@@ -10,6 +10,6 @@
 const CHANNEL_MANAGER_ADDRESS: `0x${string}`;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:21](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L21)
+Defined in: [packages/sdk/src/constants.ts:22](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L22)
 
 The address of the ChannelManager contract.

--- a/docs/pages/sdk-reference/defaultExports/variables/COMMENTS_EMBED_DEFAULT_BY_AUTHOR_URL.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/COMMENTS_EMBED_DEFAULT_BY_AUTHOR_URL.mdx
@@ -10,7 +10,7 @@
 const COMMENTS_EMBED_DEFAULT_BY_AUTHOR_URL: "https://embed.ethcomments.xyz/by-author" = "https://embed.ethcomments.xyz/by-author";
 ```
 
-Defined in: [packages/sdk/src/constants.ts:87](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L87)
+Defined in: [packages/sdk/src/constants.ts:86](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L86)
 
 The default `embedUri` for the CommentsByAuthorEmbed component.
 It runs a service that creates app signatures for requests and

--- a/docs/pages/sdk-reference/defaultExports/variables/COMMENTS_EMBED_DEFAULT_BY_REPLIES_URL.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/COMMENTS_EMBED_DEFAULT_BY_REPLIES_URL.mdx
@@ -10,7 +10,7 @@
 const COMMENTS_EMBED_DEFAULT_BY_REPLIES_URL: "https://embed.ethcomments.xyz/by-replies" = "https://embed.ethcomments.xyz/by-replies";
 ```
 
-Defined in: [packages/sdk/src/constants.ts:95](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L95)
+Defined in: [packages/sdk/src/constants.ts:94](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L94)
 
 The default `embedUri` for the CommentsByRepliesEmbed component.
 It runs a service that creates app signatures for requests and

--- a/docs/pages/sdk-reference/defaultExports/variables/COMMENTS_EMBED_DEFAULT_URL.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/COMMENTS_EMBED_DEFAULT_URL.mdx
@@ -10,7 +10,7 @@
 const COMMENTS_EMBED_DEFAULT_URL: "https://embed.ethcomments.xyz" = "https://embed.ethcomments.xyz";
 ```
 
-Defined in: [packages/sdk/src/constants.ts:80](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L80)
+Defined in: [packages/sdk/src/constants.ts:79](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L79)
 
 The default `embedUri` for the CommentsEmbed component.
 It runs a service that creates app signatures for requests and

--- a/docs/pages/sdk-reference/defaultExports/variables/COMMENT_MANAGER_ADDRESS.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/COMMENT_MANAGER_ADDRESS.mdx
@@ -10,7 +10,7 @@
 const COMMENT_MANAGER_ADDRESS: `0x${string}`;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:12](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L12)
+Defined in: [packages/sdk/src/constants.ts:15](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L15)
 
 The address of the `CommentManager` contract.
 It is created using the CREATE2 opcode so should be identical across chains if no collisions occur.

--- a/docs/pages/sdk-reference/defaultExports/variables/COMMENT_TYPE_COMMENT.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/COMMENT_TYPE_COMMENT.mdx
@@ -10,6 +10,6 @@
 const COMMENT_TYPE_COMMENT: 0 = 0;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:67](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L67)
+Defined in: [packages/sdk/src/constants.ts:66](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L66)
 
 Comment type constants

--- a/docs/pages/sdk-reference/defaultExports/variables/COMMENT_TYPE_REACTION.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/COMMENT_TYPE_REACTION.mdx
@@ -10,4 +10,4 @@
 const COMMENT_TYPE_REACTION: 1 = 1;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:68](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L68)
+Defined in: [packages/sdk/src/constants.ts:67](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L67)

--- a/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_CHAIN_ID.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_CHAIN_ID.mdx
@@ -10,4 +10,4 @@
 const DEFAULT_CHAIN_ID: 8453 = 8453;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:117](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L117)
+Defined in: [packages/sdk/src/constants.ts:116](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L116)

--- a/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_CHAIN_ID_DEV.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_CHAIN_ID_DEV.mdx
@@ -10,4 +10,4 @@
 const DEFAULT_CHAIN_ID_DEV: 31337 = 31337;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:118](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L118)
+Defined in: [packages/sdk/src/constants.ts:117](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L117)

--- a/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_CHANNEL_ID.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_CHANNEL_ID.mdx
@@ -10,6 +10,6 @@
 const DEFAULT_CHANNEL_ID: 0n = 0n;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:62](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L62)
+Defined in: [packages/sdk/src/constants.ts:61](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L61)
 
 The default channel ID for the CommentManager contract.

--- a/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_COMMENT_TYPE.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/DEFAULT_COMMENT_TYPE.mdx
@@ -10,6 +10,6 @@
 const DEFAULT_COMMENT_TYPE: 0 = COMMENT_TYPE_COMMENT;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:73](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L73)
+Defined in: [packages/sdk/src/constants.ts:72](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L72)
 
 The default comment type for the `CommentManager` contract.

--- a/docs/pages/sdk-reference/defaultExports/variables/EMPTY_PARENT_ID.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/EMPTY_PARENT_ID.mdx
@@ -10,7 +10,7 @@
 const EMPTY_PARENT_ID: `0x${string}`;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:110](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L110)
+Defined in: [packages/sdk/src/constants.ts:109](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L109)
 
 The parent ID for comments that are not replies.
 

--- a/docs/pages/sdk-reference/defaultExports/variables/INDEXER_API_URL.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/INDEXER_API_URL.mdx
@@ -10,7 +10,7 @@
 const INDEXER_API_URL: "https://api.ethcomments.xyz" = "https://api.ethcomments.xyz";
 ```
 
-Defined in: [packages/sdk/src/constants.ts:103](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L103)
+Defined in: [packages/sdk/src/constants.ts:102](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L102)
 
 The default URL for the Indexer API.
 

--- a/docs/pages/sdk-reference/defaultExports/variables/MAX_COMMENT_REPORT_MESSAGE_LENGTH.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/MAX_COMMENT_REPORT_MESSAGE_LENGTH.mdx
@@ -10,6 +10,6 @@
 const MAX_COMMENT_REPORT_MESSAGE_LENGTH: 200 = 200;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:115](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L115)
+Defined in: [packages/sdk/src/constants.ts:114](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L114)
 
 The maximum length of a message for comment report.

--- a/docs/pages/sdk-reference/defaultExports/variables/SUPPORTED_CHAINS.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/SUPPORTED_CHAINS.mdx
@@ -14,7 +14,7 @@ const SUPPORTED_CHAINS: {
 };
 ```
 
-Defined in: [packages/sdk/src/constants.ts:36](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L36)
+Defined in: [packages/sdk/src/constants.ts:35](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L35)
 
 The supported chains and their corresponding contract addresses.
 

--- a/docs/pages/sdk-reference/defaultExports/variables/ZERO_ADDRESS.mdx
+++ b/docs/pages/sdk-reference/defaultExports/variables/ZERO_ADDRESS.mdx
@@ -10,6 +10,6 @@
 const ZERO_ADDRESS: `0x${string}`;
 ```
 
-Defined in: [packages/sdk/src/constants.ts:57](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L57)
+Defined in: [packages/sdk/src/constants.ts:56](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/constants.ts#L56)
 
 The zero address.

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -5,23 +5,22 @@ import type { Hex } from "./core/schemas.js";
 const localCommentAddressManager = "0xc9deBB99EA31E376eB78303662B4Ba56b8E808d7";
 const localChannelAddressManager = "0x0a84C0e74A01581e169bDBA0cb5Aa04786f37BA0";
 
+const commentManagerAddress = "0xb262C9278fBcac384Ef59Fc49E24d800152E19b1";
+const channelManagerAddress = "0xa1043eDBE1b0Ffe6C12a2b8ed5AfD7AcB2DEA396";
+
 /**
  * The address of the `CommentManager` contract.
  * It is created using the CREATE2 opcode so should be identical across chains if no collisions occur.
  */
 export const COMMENT_MANAGER_ADDRESS = (
-  __DEV__
-    ? localCommentAddressManager
-    : "0xb262C9278fBcac384Ef59Fc49E24d800152E19b1"
+  __DEV__ ? localCommentAddressManager : commentManagerAddress
 ) as Hex;
 
 /**
  * The address of the ChannelManager contract.
  */
 export const CHANNEL_MANAGER_ADDRESS = (
-  __DEV__
-    ? localChannelAddressManager
-    : "0xa1043eDBE1b0Ffe6C12a2b8ed5AfD7AcB2DEA396"
+  __DEV__ ? localChannelAddressManager : channelManagerAddress
 ) as Hex;
 
 export type SupportedChainConfig = {
@@ -36,13 +35,13 @@ export type SupportedChainConfig = {
 export const SUPPORTED_CHAINS = {
   [base.id]: {
     chain: base,
-    commentManagerAddress: COMMENT_MANAGER_ADDRESS,
-    channelManagerAddress: CHANNEL_MANAGER_ADDRESS,
+    commentManagerAddress: commentManagerAddress,
+    channelManagerAddress: channelManagerAddress,
   } as SupportedChainConfig,
   [baseSepolia.id]: {
     chain: baseSepolia,
-    commentManagerAddress: COMMENT_MANAGER_ADDRESS,
-    channelManagerAddress: CHANNEL_MANAGER_ADDRESS,
+    commentManagerAddress: commentManagerAddress,
+    channelManagerAddress: channelManagerAddress,
   } as SupportedChainConfig,
   [anvil.id]: {
     chain: anvil,


### PR DESCRIPTION
https://linear.app/modprotocol/issue/ECP-1482/export-correct-contract-addresses-in-supported-chains-for-base-and
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the export of chain addresses for the local development environment to ensure accurate values in the SDK.

* **Documentation**
  * Updated documentation to reflect new source code line numbers for various SDK constants and type aliases. No changes to functionality or descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->