### PR TITLE
fix(indexer): ens resolution of primary name

### DIFF
--- a/apps/indexer/src/resolvers/ens-by-address-resolver.ts
+++ b/apps/indexer/src/resolvers/ens-by-address-resolver.ts
@@ -1,5 +1,11 @@
 import DataLoader from "dataloader";
-import { createPublicClient, http, type PublicClient, type Hex } from "viem";
+import {
+  createPublicClient,
+  http,
+  type PublicClient,
+  type Hex,
+  getAddress,
+} from "viem";
 import { mainnet } from "viem/chains";
 import { normalize } from "viem/ens";
 import type { ResolvedENSData } from "./ens.types";
@@ -12,23 +18,37 @@ async function resolveEnsData(
   address: Hex,
   ensByQueryResolver: ENSByQueryResolver,
 ): Promise<ResolvedENSData | null> {
-  // `client.getEnsName` is a reverse lookup, it doesn't return ens names supported by custom resolvers,
-  // such as .base.eth or .uni.eth, so try subgraph first as it covers all edge cases and support bundling
-  // it will be faster.
-  const results = await ensByQueryResolver.load(address);
+  // `client.getEnsName` is a reverse lookup using oficial ENS reverse registrar, it returns user set "primary" ENS name
+  // this is useful for users who has many ENS names and allow us to use the primary one.
+  let name: string | undefined =
+    (await client.getEnsName({ address })) ?? undefined;
+  let avatarUrl: string | undefined;
+  let url: string | undefined;
 
-  if (results && results.length > 0 && results[0]) {
-    const result = results[0];
+  if (name) {
+    // since `getEnsName` returns a name from reverse registrar, which is configured by user manually,
+    // there is a chance of misconfiguration and spoof, so we need to do a forward check
+    const normalizedName = normalize(name);
+    const ensAddress = await client.getEnsAddress({ name: normalizedName });
 
-    return {
-      address: result.address,
-      avatarUrl: result.avatarUrl,
-      name: result.name,
-      url: result.url,
-    };
+    if (!ensAddress || getAddress(ensAddress) !== getAddress(address)) {
+      name = undefined;
+    }
   }
 
-  const name = await client.getEnsName({ address });
+  // oficial ENS reverse registrar might return undefined or due to misconfiguration.
+  // so in this case we will use ensnode subgraph to cover the rest of the cases.
+  if (!name) {
+    const results = await ensByQueryResolver.load(address);
+
+    if (results && results.length > 0 && results[0]) {
+      const result = results[0];
+
+      name = result.name;
+      avatarUrl = result.avatarUrl ?? undefined;
+      url = result.url;
+    }
+  }
 
   if (!name) {
     return null;
@@ -36,13 +56,12 @@ async function resolveEnsData(
 
   const normalizedName = normalize(name);
 
-  const avatarUrl = await client.getEnsAvatar({ name: normalizedName });
-
   return {
     address,
     name: normalizedName,
-    avatarUrl,
-    url: `https://app.ens.domains/${address}`,
+    avatarUrl:
+      avatarUrl ?? (await client.getEnsAvatar({ name: normalizedName })),
+    url: url ?? `https://app.ens.domains/${address}`,
   };
 }
 

--- a/apps/indexer/tests/resolvers/ens-by-address-resolver.test.ts
+++ b/apps/indexer/tests/resolvers/ens-by-address-resolver.test.ts
@@ -17,7 +17,7 @@ describe("ENSByAddressResolver", () => {
 
     expect(result).toEqual({
       address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
-      name: "davidf.eth",
+      name: "furlong.eth",
       avatarUrl: expect.toBeOneOf([null, expect.any(String)]),
       url: expect.stringMatching(
         /^https:\/\/app\.ens\.domains\/0x[0-9a-fA-F]{40}$/,
@@ -49,7 +49,7 @@ describe("ENSByAddressResolver", () => {
 
     expect(byAddr0).toEqual({
       address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
-      name: "davidf.eth",
+      name: "furlong.eth",
       avatarUrl: expect.toBeOneOf([null, expect.any(String)]),
       url: expect.stringMatching(
         /^https:\/\/app\.ens\.domains\/0x[0-9a-fA-F]{40}$/,

--- a/apps/indexer/vitest.config.ts
+++ b/apps/indexer/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  // @ts-expect-error - ponder has outdated vite + vitest so we have conflicts
-  plugins: [tsconfigPaths()],
+  plugins: [
+    // @ts-expect-error - ponder has outdated vite + vitest so we have conflicts
+    tsconfigPaths({
+      skip: (dir) => dir.includes("demo-rn-expo"),
+    }),
+  ],
 });


### PR DESCRIPTION
@michalkvasnicak i had to fallback using pretty much old method because:

1. official subgraph doesn't provide an easy way to filter name and text changes for the record, resulting multiple requests needed, which defeats the purpose 
2. ensnode subgraph doesn't provide up to date primary name data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ENS name resolution accuracy by prioritizing official ENS reverse registrar lookup and validating results to prevent incorrect or spoofed ENS data.
  * Enhanced reliability of avatar and URL retrieval for ENS records.
  * Updated ENS name expectations in address resolution to reflect current data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->