### PR TITLE
fix(docs): the recommanded caip format should be without chain://

### DIFF
--- a/docs/pages/comment-data-props.mdx
+++ b/docs/pages/comment-data-props.mdx
@@ -126,8 +126,8 @@ This ensures the reference is consistent and maximal compatibility across differ
 Example (NFT and collection):
 
 ```
-chain://eip155:1/erc721:0xa723a8a69d9b8cf0bc93b92f9cb41532c1a27f8f/11
-chain://eip155:1/erc721:0xa723a8a69d9b8cf0bc93b92f9cb41532c1a27f8f
+eip155:1/erc721:0xa723a8a69d9b8cf0bc93b92f9cb41532c1a27f8f/11
+eip155:1/erc721:0xa723a8a69d9b8cf0bc93b92f9cb41532c1a27f8f
 ```
 
 ## `parentId`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples for app/chain agnostic URIs by removing the `chain://` prefix from CAIP-19 formatted strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->