### PR TITLE
chore: bump privy lib to latest

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -17,7 +17,7 @@
     "@hpke/chacha20poly1305": "^1.6.2",
     "@hpke/core": "^1.7.2",
     "@neynar/nodejs-sdk": "^2.13.1",
-    "@privy-io/server-auth": "1.26.0",
+    "@privy-io/server-auth": "1.30.0",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.5",

--- a/apps/signer/package.json
+++ b/apps/signer/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@ecp.eth/sdk": "workspace:*",
     "@ecp.eth/shared": "workspace:*",
-    "@privy-io/server-auth": "1.26.0",
+    "@privy-io/server-auth": "^1.30.0",
     "@types/node": "^20",
     "@types/react": "~19.1.0",
     "@types/react-dom": "~19.1.0",

--- a/patches/@privy-io__server-auth.patch
+++ b/patches/@privy-io__server-auth.patch
@@ -1,26 +1,13 @@
 diff --git a/dist/dts/viem.d.mts b/dist/dts/viem.d.mts
-index 6ffed073a4ddcc69ce67648a69176e5550b7b456..42bea92d9a90aeea00fb06e4e939b5900aaa3ebc 100644
+index 2d6ee0e0175e05b26e32190dd05775d5d08a3abd..027549d94658f08d7dac5c7bc90d6ce96642c73b 100644
 --- a/dist/dts/viem.d.mts
 +++ b/dist/dts/viem.d.mts
 @@ -1,6 +1,6 @@
  import { LocalAccount } from 'viem/accounts';
 -import { PrivyClient } from './index.js';
--import { H as Hex } from './public-BAGJecXe.js';
+-import { H as Hex } from './public-DQ5eO1J3.js';
 +import { PrivyClient } from './index.mts';
-+import { H as Hex } from './public-BAGJecXe.mts';
++import { H as Hex } from './public-DQ5eO1J3.mts';
  import '@solana/web3.js';
  import 'redaxios';
  import '@privy-io/public-api';
-diff --git a/package.json b/package.json
-index f07f9de48462d12c1584d029c09fb625b9c8708c..8538c355226f6fdb40ffd2eb24cf57b45cb93026 100644
---- a/package.json
-+++ b/package.json
-@@ -88,6 +88,8 @@
-     "@noble/hashes": "^1.5.0",
-     "@privy-io/public-api": "2.32.0",
-     "@solana/web3.js": "^1.95.8",
-+    "@hpke/chacha20poly1305": "^1.6.2",
-+    "@hpke/core": "^1.7.2",
-     "canonicalize": "^2.0.0",
-     "dotenv": "^16.0.3",
-     "jose": "^4.10.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
 
 patchedDependencies:
   '@privy-io/server-auth':
-    hash: 78088c76aea7ad10983f0789b33590118cecdd976346ac52e3b965b6bed7202a
+    hash: 3261a77169140110e743634bd597f6f14d53817310de531811ffee9d2940c88c
     path: patches/@privy-io__server-auth.patch
   '@rainbow-me/rainbowkit':
     hash: de27859521ffa1f2f5bc03d5400233e30552e5f51b766007d69da9b01003d1c8
@@ -90,8 +90,8 @@ importers:
         specifier: ^2.13.1
         version: 2.44.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@privy-io/server-auth':
-        specifier: 1.26.0
-        version: 1.26.0(patch_hash=78088c76aea7ad10983f0789b33590118cecdd976346ac52e3b965b6bed7202a)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: 1.30.0
+        version: 1.30.0(patch_hash=3261a77169140110e743634bd597f6f14d53817310de531811ffee9d2940c88c)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@radix-ui/react-avatar':
         specifier: ^1.1.3
         version: 1.1.10(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -658,8 +658,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       '@privy-io/server-auth':
-        specifier: 1.26.0
-        version: 1.26.0(patch_hash=78088c76aea7ad10983f0789b33590118cecdd976346ac52e3b965b6bed7202a)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        specifier: ^1.30.0
+        version: 1.30.0(patch_hash=3261a77169140110e743634bd597f6f14d53817310de531811ffee9d2940c88c)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@types/node':
         specifier: ^20
         version: 20.11.17
@@ -2861,16 +2861,15 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
-  '@privy-io/api-base@1.5.1':
-    resolution: {integrity: sha512-UokueOxl2hoW+kfFTzwV8uqwCNajSaJJEGSWHpsuKvdDQ8ePwXe53Gr5ptnKznaZlMLivc25mrv92bVEJbclfQ==}
+  '@privy-io/api-base@1.5.2':
+    resolution: {integrity: sha512-0eJBoQNmCSsWSWhzEVSU8WqPm7bgeN6VaAmqeXvjk8Ni0jM8nyTYjmRAqiCSs3mRzsnlQVchkGR6lsMTHkHKbw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
 
-  '@privy-io/public-api@2.32.0':
-    resolution: {integrity: sha512-zbqU7+mWSFLyurr0JVrpoRsMEtFp4VLXcqesrh60ZfPbYuUN+ULoY/mNrHFrvtSQCB0wq+sU3b679kS36g88XA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+  '@privy-io/public-api@2.42.0':
+    resolution: {integrity: sha512-cmo4Bx85f6zdxojjTmc9z+bxaoINGP8HzsMTor7e8olQcHvVxnol0otcMs1haG+6wrvZL7zn6+SBlQtK0bQmJg==}
 
-  '@privy-io/server-auth@1.26.0':
-    resolution: {integrity: sha512-E6pbxgx01RfB4BQ4c1JhrAOSPXqR9/c/GEJBq5iF+/CKrRdRXUMH1Q7OEPnjHCIEcYNErLwkydaql/QH5NNz0A==}
+  '@privy-io/server-auth@1.30.0':
+    resolution: {integrity: sha512-3pBKB4836P2qrein9a1mnWLwskuJWI5fvc7rykwBNkRwC9suFPpjozJkGmI1gour5AsEs2klDsg2fZZPzLM8uA==}
     peerDependencies:
       ethers: ^6
       viem: ~2.29.2
@@ -13885,13 +13884,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@privy-io/api-base@1.5.1':
+  '@privy-io/api-base@1.5.2':
     dependencies:
       zod: 3.25.76
 
-  '@privy-io/public-api@2.32.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@privy-io/public-api@2.42.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@privy-io/api-base': 1.5.1
+      '@privy-io/api-base': 1.5.2
       bs58: 5.0.0
       libphonenumber-js: 1.12.8
       viem: 2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -13901,11 +13900,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@privy-io/server-auth@1.26.0(patch_hash=78088c76aea7ad10983f0789b33590118cecdd976346ac52e3b965b6bed7202a)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@privy-io/server-auth@1.30.0(patch_hash=3261a77169140110e743634bd597f6f14d53817310de531811ffee9d2940c88c)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
+      '@hpke/chacha20poly1305': 1.6.2
+      '@hpke/core': 1.7.2
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
-      '@privy-io/public-api': 2.32.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@privy-io/public-api': 2.42.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       canonicalize: 2.1.0
       dotenv: 16.5.0


### PR DESCRIPTION
also reapply privy patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the dependency version of @privy-io/server-auth to 1.30.0 in relevant applications.
  * Added new underlying dependencies to support package compatibility and functionality improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->