### PR TITLE
feat(sdk): add `getCommentCreationFee` and `setCommentCreationFee`

### DIFF
--- a/.changeset/tidy-walls-sink.md
+++ b/.changeset/tidy-walls-sink.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+feat(sdk): add `getCommentCreationFee` and `setCommentCreationFee` to sdk

--- a/docs/pages/sdk-reference/channel-manager/functions/getCommentCreationFee.mdx
+++ b/docs/pages/sdk-reference/channel-manager/functions/getCommentCreationFee.mdx
@@ -1,0 +1,29 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager](/sdk-reference/channel-manager/index.mdx) / getCommentCreationFee
+
+# Function: getCommentCreationFee()
+
+```ts
+function getCommentCreationFee(params): Promise<GetCommentCreationFeeResult>;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:455](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L455)
+
+Get the creation fee from channel manager
+
+## Parameters
+
+### params
+
+[`GetCommentCreationFeeParams`](/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeParams.mdx)
+
+The parameters for getting the creation fee from channel manager
+
+## Returns
+
+`Promise`\<[`GetCommentCreationFeeResult`](/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeResult.mdx)\>
+
+The creation fee from channel manager

--- a/docs/pages/sdk-reference/channel-manager/functions/setBaseURI.mdx
+++ b/docs/pages/sdk-reference/channel-manager/functions/setBaseURI.mdx
@@ -10,7 +10,7 @@
 function setBaseURI(params): Promise<SetBaseURIResult>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:503](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L503)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:590](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L590)
 
 Sets the base URI for NFT metadata
 

--- a/docs/pages/sdk-reference/channel-manager/functions/setCommentCreationFee.mdx
+++ b/docs/pages/sdk-reference/channel-manager/functions/setCommentCreationFee.mdx
@@ -1,0 +1,29 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager](/sdk-reference/channel-manager/index.mdx) / setCommentCreationFee
+
+# Function: setCommentCreationFee()
+
+```ts
+function setCommentCreationFee(params): Promise<SetCommentCreationFeeResult>;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:500](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L500)
+
+Set the fee for creating a new comment
+
+## Parameters
+
+### params
+
+[`SetCommentCreationFeeParams`](/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeParams.mdx)
+
+The parameters for setting the fee for creating a new comment
+
+## Returns
+
+`Promise`\<[`SetCommentCreationFeeResult`](/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeResult.mdx)\>
+
+The transaction hash of the set creation fee

--- a/docs/pages/sdk-reference/channel-manager/functions/withdrawFees.mdx
+++ b/docs/pages/sdk-reference/channel-manager/functions/withdrawFees.mdx
@@ -10,7 +10,7 @@
 function withdrawFees(params): Promise<WithdrawFeesResult>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:458](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L458)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:545](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L545)
 
 Withdraws accumulated fees to a specified address
 

--- a/docs/pages/sdk-reference/channel-manager/index.mdx
+++ b/docs/pages/sdk-reference/channel-manager/index.mdx
@@ -24,6 +24,8 @@ Core functionality for managing comment channels
 | [GetChannelMetadataResult](/sdk-reference/channel-manager/type-aliases/GetChannelMetadataResult.mdx) | - |
 | [GetChannelParams](/sdk-reference/channel-manager/type-aliases/GetChannelParams.mdx) | - |
 | [GetChannelResult](/sdk-reference/channel-manager/type-aliases/GetChannelResult.mdx) | - |
+| [GetCommentCreationFeeParams](/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeParams.mdx) | - |
+| [GetCommentCreationFeeResult](/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeResult.mdx) | - |
 | [GetHookTransactionFeeParams](/sdk-reference/channel-manager/type-aliases/GetHookTransactionFeeParams.mdx) | - |
 | [GetHookTransactionFeeResult](/sdk-reference/channel-manager/type-aliases/GetHookTransactionFeeResult.mdx) | - |
 | [OwnerOfParams](/sdk-reference/channel-manager/type-aliases/OwnerOfParams.mdx) | - |
@@ -32,6 +34,8 @@ Core functionality for managing comment channels
 | [SetBaseURIResult](/sdk-reference/channel-manager/type-aliases/SetBaseURIResult.mdx) | - |
 | [SetChannelCreationFeeParams](/sdk-reference/channel-manager/type-aliases/SetChannelCreationFeeParams.mdx) | - |
 | [SetChannelCreationFeeResult](/sdk-reference/channel-manager/type-aliases/SetChannelCreationFeeResult.mdx) | - |
+| [SetCommentCreationFeeParams](/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeParams.mdx) | - |
+| [SetCommentCreationFeeResult](/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeResult.mdx) | - |
 | [SetHookParams](/sdk-reference/channel-manager/type-aliases/SetHookParams.mdx) | - |
 | [SetHookResult](/sdk-reference/channel-manager/type-aliases/SetHookResult.mdx) | - |
 | [SetHookTransactionFeeParams](/sdk-reference/channel-manager/type-aliases/SetHookTransactionFeeParams.mdx) | - |
@@ -57,10 +61,12 @@ Core functionality for managing comment channels
 | [getChannel](/sdk-reference/channel-manager/functions/getChannel.mdx) | Get a channel |
 | [getChannelCreationFee](/sdk-reference/channel-manager/functions/getChannelCreationFee.mdx) | Get the creation fee from channel manager |
 | [getChannelMetadata](/sdk-reference/channel-manager/functions/getChannelMetadata.mdx) | Get channel metadata |
+| [getCommentCreationFee](/sdk-reference/channel-manager/functions/getCommentCreationFee.mdx) | Get the creation fee from channel manager |
 | [getHookTransactionFee](/sdk-reference/channel-manager/functions/getHookTransactionFee.mdx) | Get the hook transaction fee from channel manager |
 | [ownerOf](/sdk-reference/channel-manager/functions/ownerOf.mdx) | Get the owner of a channel |
 | [setBaseURI](/sdk-reference/channel-manager/functions/setBaseURI.mdx) | Sets the base URI for NFT metadata |
 | [setChannelCreationFee](/sdk-reference/channel-manager/functions/setChannelCreationFee.mdx) | Set the fee for creating a new channel |
+| [setCommentCreationFee](/sdk-reference/channel-manager/functions/setCommentCreationFee.mdx) | Set the fee for creating a new comment |
 | [setHook](/sdk-reference/channel-manager/functions/setHook.mdx) | Set the hook for a channel |
 | [setHookTransactionFee](/sdk-reference/channel-manager/functions/setHookTransactionFee.mdx) | Set the percentage of the fee for the hook transaction |
 | [withdrawFees](/sdk-reference/channel-manager/functions/withdrawFees.mdx) | Withdraws accumulated fees to a specified address |

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useChannelExists.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useChannelExists.mdx
@@ -10,7 +10,7 @@
 function useChannelExists(params, options): UseChannelExistsResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:159](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L159)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:165](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L165)
 
 Check if a channel exists
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useCreateChannel.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useCreateChannel.mdx
@@ -10,7 +10,7 @@
 function useCreateChannel(options): UseCreateChannelResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:56](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L56)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:62](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L62)
 
 Create a new channel
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useGetChannel.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useGetChannel.mdx
@@ -10,7 +10,7 @@
 function useGetChannel(params, options): UseGetChannelResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:119](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L119)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:125](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L125)
 
 Get a channel
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useGetChannelCreationFee.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useGetChannelCreationFee.mdx
@@ -10,7 +10,7 @@
 function useGetChannelCreationFee(params, options): UseGetChannelCreationFeeResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:245](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L245)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:251](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L251)
 
 Get the creation fee from channel manager
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useGetCommentCreationFee.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useGetCommentCreationFee.mdx
@@ -1,0 +1,35 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / useGetCommentCreationFee
+
+# Function: useGetCommentCreationFee()
+
+```ts
+function useGetCommentCreationFee(params, options): UseGetCommentCreationFeeResult;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:337](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L337)
+
+Get the creation fee from channel manager
+
+## Parameters
+
+### params
+
+[`UseGetCommentCreationFeeParams`](/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeParams.mdx) = `{}`
+
+The parameters for getting the creation fee from channel manager
+
+### options
+
+[`UseGetCommentCreationFeeOptions`](/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeOptions.mdx) = `{}`
+
+The options for the query
+
+## Returns
+
+[`UseGetCommentCreationFeeResult`](/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeResult.mdx)
+
+The result of the query

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useOwnerOf.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useOwnerOf.mdx
@@ -10,7 +10,7 @@
 function useOwnerOf(params, options): UseOwnerOfResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:199](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L199)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:205](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L205)
 
 Get the owner of a channel
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useSetBaseURI.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useSetBaseURI.mdx
@@ -10,7 +10,7 @@
 function useSetBaseURI(options): UseSetBaseURIResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:361](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L361)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:453](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L453)
 
 Sets the base URI for NFT metadata
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useSetChannelCreationFee.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useSetChannelCreationFee.mdx
@@ -10,7 +10,7 @@
 function useSetChannelCreationFee(options): UseSetChannelCreationFeeResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:295](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L295)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:301](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L301)
 
 Set the fee for creating a new channel
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useSetCommentCreationFee.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useSetCommentCreationFee.mdx
@@ -1,0 +1,29 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / useSetCommentCreationFee
+
+# Function: useSetCommentCreationFee()
+
+```ts
+function useSetCommentCreationFee(options): UseSetCommentCreationFeeResult;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:387](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L387)
+
+Set the fee for creating a new comment
+
+## Parameters
+
+### options
+
+[`UseSetCommentCreationFeeOptions`](/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeOptions.mdx) = `{}`
+
+The options for the mutation
+
+## Returns
+
+[`UseSetCommentCreationFeeResult`](/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeResult.mdx)
+
+The result of the mutation

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useUpdateChannel.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useUpdateChannel.mdx
@@ -10,7 +10,7 @@
 function useUpdateChannel(options): UseUpdateChannelResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:89](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L89)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:95](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L95)
 
 Update a channel
 

--- a/docs/pages/sdk-reference/channel-manager/react/functions/useWithdrawFees.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/functions/useWithdrawFees.mdx
@@ -10,7 +10,7 @@
 function useWithdrawFees(options): UseWithdrawFeesResult;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:328](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L328)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:420](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L420)
 
 Withdraws accumulated fees to a specified address
 

--- a/docs/pages/sdk-reference/channel-manager/react/index.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/index.mdx
@@ -25,6 +25,9 @@ React hooks for managing comment channels
 | [UseGetChannelOptions](/sdk-reference/channel-manager/react/type-aliases/UseGetChannelOptions.mdx) | - |
 | [UseGetChannelParams](/sdk-reference/channel-manager/react/type-aliases/UseGetChannelParams.mdx) | - |
 | [UseGetChannelResult](/sdk-reference/channel-manager/react/type-aliases/UseGetChannelResult.mdx) | - |
+| [UseGetCommentCreationFeeOptions](/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeOptions.mdx) | - |
+| [UseGetCommentCreationFeeParams](/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeParams.mdx) | - |
+| [UseGetCommentCreationFeeResult](/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeResult.mdx) | - |
 | [UseGetHookTransactionFeeOptions](/sdk-reference/channel-manager/react/type-aliases/UseGetHookTransactionFeeOptions.mdx) | - |
 | [UseGetHookTransactionFeeParams](/sdk-reference/channel-manager/react/type-aliases/UseGetHookTransactionFeeParams.mdx) | - |
 | [UseGetHookTransactionFeeResult](/sdk-reference/channel-manager/react/type-aliases/UseGetHookTransactionFeeResult.mdx) | - |
@@ -37,6 +40,9 @@ React hooks for managing comment channels
 | [UseSetChannelCreationFeeOptions](/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeOptions.mdx) | - |
 | [UseSetChannelCreationFeeParams](/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeParams.mdx) | - |
 | [UseSetChannelCreationFeeResult](/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeResult.mdx) | - |
+| [UseSetCommentCreationFeeOptions](/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeOptions.mdx) | - |
+| [UseSetCommentCreationFeeParams](/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeParams.mdx) | - |
+| [UseSetCommentCreationFeeResult](/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeResult.mdx) | - |
 | [UseSetHookOptions](/sdk-reference/channel-manager/react/type-aliases/UseSetHookOptions.mdx) | - |
 | [UseSetHookParams](/sdk-reference/channel-manager/react/type-aliases/UseSetHookParams.mdx) | - |
 | [UseSetHookResult](/sdk-reference/channel-manager/react/type-aliases/UseSetHookResult.mdx) | - |
@@ -58,10 +64,12 @@ React hooks for managing comment channels
 | [useCreateChannel](/sdk-reference/channel-manager/react/functions/useCreateChannel.mdx) | Create a new channel |
 | [useGetChannel](/sdk-reference/channel-manager/react/functions/useGetChannel.mdx) | Get a channel |
 | [useGetChannelCreationFee](/sdk-reference/channel-manager/react/functions/useGetChannelCreationFee.mdx) | Get the creation fee from channel manager |
+| [useGetCommentCreationFee](/sdk-reference/channel-manager/react/functions/useGetCommentCreationFee.mdx) | Get the creation fee from channel manager |
 | [useGetHookTransactionFee](/sdk-reference/channel-manager/react/functions/useGetHookTransactionFee.mdx) | Get the hook transaction fee from channel manager |
 | [useOwnerOf](/sdk-reference/channel-manager/react/functions/useOwnerOf.mdx) | Get the owner of a channel |
 | [useSetBaseURI](/sdk-reference/channel-manager/react/functions/useSetBaseURI.mdx) | Sets the base URI for NFT metadata |
 | [useSetChannelCreationFee](/sdk-reference/channel-manager/react/functions/useSetChannelCreationFee.mdx) | Set the fee for creating a new channel |
+| [useSetCommentCreationFee](/sdk-reference/channel-manager/react/functions/useSetCommentCreationFee.mdx) | Set the fee for creating a new comment |
 | [useSetHook](/sdk-reference/channel-manager/react/functions/useSetHook.mdx) | Set the hook for a channel |
 | [useSetHookTransactionFee](/sdk-reference/channel-manager/react/functions/useSetHookTransactionFee.mdx) | Set the percentage of the fee for the hook transaction |
 | [useUpdateChannel](/sdk-reference/channel-manager/react/functions/useUpdateChannel.mdx) | Update a channel |

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseChannelExistsOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseChannelExistsOptions.mdx
@@ -10,4 +10,4 @@
 type UseChannelExistsOptions = Omit<UseQueryOptions<boolean, Error>, "queryKey" | "queryFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:146](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L146)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:152](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L152)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseChannelExistsParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseChannelExistsParams.mdx
@@ -10,4 +10,4 @@
 type UseChannelExistsParams = Omit<ChannelExistsParams, "readContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:145](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L145)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:151](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L151)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseChannelExistsResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseChannelExistsResult.mdx
@@ -10,4 +10,4 @@
 type UseChannelExistsResult = UseQueryResult<boolean, Error>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:150](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L150)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:156](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L156)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseCreateChannelOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseCreateChannelOptions.mdx
@@ -10,4 +10,4 @@
 type UseCreateChannelOptions = Omit<UseMutationOptions<CreateChannelResult, Error, UseCreateChannelParams>, "mutationFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:40](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L40)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:46](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L46)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseCreateChannelParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseCreateChannelParams.mdx
@@ -10,4 +10,4 @@
 type UseCreateChannelParams = Omit<CreateChannelParams, "writeContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:39](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L39)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:45](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L45)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseCreateChannelResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseCreateChannelResult.mdx
@@ -10,4 +10,4 @@
 type UseCreateChannelResult = UseMutationResult<CreateChannelResult, Error, UseCreateChannelParams>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:44](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L44)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:50](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L50)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelCreationFeeOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelCreationFeeOptions.mdx
@@ -10,4 +10,4 @@
 type UseGetChannelCreationFeeOptions = Omit<UseQueryOptions<GetChannelCreationFeeResult, Error>, "queryKey" | "queryFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:229](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L229)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:235](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L235)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelCreationFeeParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelCreationFeeParams.mdx
@@ -10,4 +10,4 @@
 type UseGetChannelCreationFeeParams = Omit<GetChannelCreationFeeParams, "readContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:225](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L225)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:231](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L231)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelCreationFeeResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelCreationFeeResult.mdx
@@ -10,4 +10,4 @@
 type UseGetChannelCreationFeeResult = UseQueryResult<GetChannelCreationFeeResult, Error>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:233](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L233)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:239](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L239)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelOptions.mdx
@@ -10,4 +10,4 @@
 type UseGetChannelOptions = Omit<UseQueryOptions<GetChannelResult, Error>, "queryKey" | "queryFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:106](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L106)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:112](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L112)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelParams.mdx
@@ -10,4 +10,4 @@
 type UseGetChannelParams = Omit<GetChannelParams, "readContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:105](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L105)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:111](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L111)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetChannelResult.mdx
@@ -10,4 +10,4 @@
 type UseGetChannelResult = UseQueryResult<GetChannelResult, Error>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:110](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L110)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:116](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L116)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeOptions.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / UseGetCommentCreationFeeOptions
+
+# Type Alias: UseGetCommentCreationFeeOptions
+
+```ts
+type UseGetCommentCreationFeeOptions = Omit<UseQueryOptions<GetCommentCreationFeeResult, Error>, "queryKey" | "queryFn">;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:321](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L321)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeParams.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / UseGetCommentCreationFeeParams
+
+# Type Alias: UseGetCommentCreationFeeParams
+
+```ts
+type UseGetCommentCreationFeeParams = Omit<GetCommentCreationFeeParams, "readContract">;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:317](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L317)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseGetCommentCreationFeeResult.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / UseGetCommentCreationFeeResult
+
+# Type Alias: UseGetCommentCreationFeeResult
+
+```ts
+type UseGetCommentCreationFeeResult = UseQueryResult<GetCommentCreationFeeResult, Error>;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:325](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L325)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseOwnerOfOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseOwnerOfOptions.mdx
@@ -10,4 +10,4 @@
 type UseOwnerOfOptions = Omit<UseQueryOptions<OwnerOfResult, Error>, "queryKey" | "queryFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:186](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L186)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:192](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L192)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseOwnerOfParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseOwnerOfParams.mdx
@@ -10,4 +10,4 @@
 type UseOwnerOfParams = Omit<OwnerOfParams, "readContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:185](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L185)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:191](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L191)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseOwnerOfResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseOwnerOfResult.mdx
@@ -10,4 +10,4 @@
 type UseOwnerOfResult = UseQueryResult<OwnerOfResult, Error>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:190](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L190)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:196](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L196)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetBaseURIOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetBaseURIOptions.mdx
@@ -10,4 +10,4 @@
 type UseSetBaseURIOptions = Omit<UseMutationOptions<SetBaseURIResult, Error, UseSetBaseURIParams>, "mutationFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:345](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L345)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:437](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L437)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetBaseURIParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetBaseURIParams.mdx
@@ -10,4 +10,4 @@
 type UseSetBaseURIParams = Omit<SetBaseURIParams, "writeContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:344](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L344)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:436](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L436)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetBaseURIResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetBaseURIResult.mdx
@@ -10,4 +10,4 @@
 type UseSetBaseURIResult = UseMutationResult<SetBaseURIResult, Error, UseSetBaseURIParams>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:349](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L349)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:441](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L441)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeOptions.mdx
@@ -10,4 +10,4 @@
 type UseSetChannelCreationFeeOptions = Omit<UseMutationOptions<SetChannelCreationFeeResult, Error, UseSetChannelCreationFeeParams>, "mutationFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:275](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L275)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:281](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L281)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeParams.mdx
@@ -10,4 +10,4 @@
 type UseSetChannelCreationFeeParams = Omit<SetChannelCreationFeeParams, "writeContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:271](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L271)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:277](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L277)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetChannelCreationFeeResult.mdx
@@ -10,4 +10,4 @@
 type UseSetChannelCreationFeeResult = UseMutationResult<SetChannelCreationFeeResult, Error, UseSetChannelCreationFeeParams>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:283](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L283)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:289](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L289)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeOptions.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / UseSetCommentCreationFeeOptions
+
+# Type Alias: UseSetCommentCreationFeeOptions
+
+```ts
+type UseSetCommentCreationFeeOptions = Omit<UseMutationOptions<SetCommentCreationFeeResult, Error, UseSetCommentCreationFeeParams>, "mutationFn">;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:367](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L367)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeParams.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / UseSetCommentCreationFeeParams
+
+# Type Alias: UseSetCommentCreationFeeParams
+
+```ts
+type UseSetCommentCreationFeeParams = Omit<SetCommentCreationFeeParams, "writeContract">;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:363](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L363)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseSetCommentCreationFeeResult.mdx
@@ -1,0 +1,13 @@
+[**@ecp.eth/sdk**](../../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager/react](/sdk-reference/channel-manager/react/index.mdx) / UseSetCommentCreationFeeResult
+
+# Type Alias: UseSetCommentCreationFeeResult
+
+```ts
+type UseSetCommentCreationFeeResult = UseMutationResult<SetCommentCreationFeeResult, Error, UseSetCommentCreationFeeParams>;
+```
+
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:375](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L375)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseUpdateChannelOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseUpdateChannelOptions.mdx
@@ -10,4 +10,4 @@
 type UseUpdateChannelOptions = Omit<UseMutationOptions<UpdateChannelResult, Error, UseUpdateChannelParams>, "mutationFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:73](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L73)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:79](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L79)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseUpdateChannelParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseUpdateChannelParams.mdx
@@ -10,4 +10,4 @@
 type UseUpdateChannelParams = Omit<UpdateChannelParams, "writeContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:72](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L72)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:78](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L78)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseUpdateChannelResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseUpdateChannelResult.mdx
@@ -10,4 +10,4 @@
 type UseUpdateChannelResult = UseMutationResult<UpdateChannelResult, Error, UseUpdateChannelParams>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:77](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L77)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:83](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L83)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseWithdrawFeesOptions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseWithdrawFeesOptions.mdx
@@ -10,4 +10,4 @@
 type UseWithdrawFeesOptions = Omit<UseMutationOptions<WithdrawFeesResult, Error, UseWithdrawFeesParams>, "mutationFn">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:312](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L312)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:404](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L404)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseWithdrawFeesParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseWithdrawFeesParams.mdx
@@ -10,4 +10,4 @@
 type UseWithdrawFeesParams = Omit<WithdrawFeesParams, "writeContract">;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:311](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L311)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:403](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L403)

--- a/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseWithdrawFeesResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/react/type-aliases/UseWithdrawFeesResult.mdx
@@ -10,4 +10,4 @@
 type UseWithdrawFeesResult = UseMutationResult<WithdrawFeesResult, Error, UseWithdrawFeesParams>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/react/channel.ts:316](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L316)
+Defined in: [packages/sdk/src/channel-manager/react/channel.ts:408](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/react/channel.ts#L408)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeParams.mdx
@@ -1,0 +1,44 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager](/sdk-reference/channel-manager/index.mdx) / GetCommentCreationFeeParams
+
+# Type Alias: GetCommentCreationFeeParams
+
+```ts
+type GetCommentCreationFeeParams = {
+  channelManagerAddress?: Hex;
+  readContract: ContractReadFunctions["getCommentCreationFee"];
+};
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:431](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L431)
+
+## Properties
+
+### channelManagerAddress?
+
+```ts
+optional channelManagerAddress: Hex;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:437](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L437)
+
+The address of the channel manager
+
+#### Default
+
+```ts
+CHANNEL_MANAGER_ADDRESS
+```
+
+***
+
+### readContract
+
+```ts
+readContract: ContractReadFunctions["getCommentCreationFee"];
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:438](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L438)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeResult.mdx
@@ -1,0 +1,25 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager](/sdk-reference/channel-manager/index.mdx) / GetCommentCreationFeeResult
+
+# Type Alias: GetCommentCreationFeeResult
+
+```ts
+type GetCommentCreationFeeResult = {
+  fee: bigint;
+};
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:441](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L441)
+
+## Properties
+
+### fee
+
+```ts
+fee: bigint;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:442](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L442)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/SetBaseURIParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/SetBaseURIParams.mdx
@@ -14,7 +14,7 @@ type SetBaseURIParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:476](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L476)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:563](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L563)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/channel-manager/channel.ts:476](https://github.com
 baseURI: string;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:480](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L480)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:567](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L567)
 
 The new base URI for NFT metadata
 
@@ -36,7 +36,7 @@ The new base URI for NFT metadata
 optional channelManagerAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:484](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L484)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:571](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L571)
 
 The address of the channel manager
 
@@ -48,4 +48,4 @@ The address of the channel manager
 writeContract: ContractWriteFunctions["setBaseURI"];
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:485](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L485)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:572](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L572)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/SetBaseURIResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/SetBaseURIResult.mdx
@@ -12,7 +12,7 @@ type SetBaseURIResult = {
 };
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:488](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L488)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:575](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L575)
 
 ## Properties
 
@@ -22,4 +22,4 @@ Defined in: [packages/sdk/src/channel-manager/channel.ts:488](https://github.com
 txHash: Hex;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:489](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L489)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:576](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L576)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeParams.mdx
@@ -1,0 +1,57 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager](/sdk-reference/channel-manager/index.mdx) / SetCommentCreationFeeParams
+
+# Type Alias: SetCommentCreationFeeParams
+
+```ts
+type SetCommentCreationFeeParams = {
+  channelManagerAddress?: Hex;
+  fee: bigint;
+  writeContract: ContractWriteFunctions["setCommentCreationFee"];
+};
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:471](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L471)
+
+## Properties
+
+### channelManagerAddress?
+
+```ts
+optional channelManagerAddress: Hex;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:481](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L481)
+
+The address of the channel manager
+
+#### Default
+
+```ts
+CHANNEL_MANAGER_ADDRESS
+```
+
+***
+
+### fee
+
+```ts
+fee: bigint;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:475](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L475)
+
+The fee for creating a comment in wei
+
+***
+
+### writeContract
+
+```ts
+writeContract: ContractWriteFunctions["setCommentCreationFee"];
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:482](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L482)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeResult.mdx
@@ -1,0 +1,25 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [channel-manager](/sdk-reference/channel-manager/index.mdx) / SetCommentCreationFeeResult
+
+# Type Alias: SetCommentCreationFeeResult
+
+```ts
+type SetCommentCreationFeeResult = {
+  txHash: Hex;
+};
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:485](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L485)
+
+## Properties
+
+### txHash
+
+```ts
+txHash: Hex;
+```
+
+Defined in: [packages/sdk/src/channel-manager/channel.ts:486](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L486)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/WithdrawFeesParams.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/WithdrawFeesParams.mdx
@@ -14,7 +14,7 @@ type WithdrawFeesParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:431](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L431)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:518](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L518)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/channel-manager/channel.ts:431](https://github.com
 optional channelManagerAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:439](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L439)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:526](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L526)
 
 The address of the channel manager
 
@@ -36,7 +36,7 @@ The address of the channel manager
 recipient: Hex;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:435](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L435)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:522](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L522)
 
 The address of the recipient
 
@@ -48,4 +48,4 @@ The address of the recipient
 writeContract: ContractWriteFunctions["withdrawFees"];
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:440](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L440)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:527](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L527)

--- a/docs/pages/sdk-reference/channel-manager/type-aliases/WithdrawFeesResult.mdx
+++ b/docs/pages/sdk-reference/channel-manager/type-aliases/WithdrawFeesResult.mdx
@@ -12,7 +12,7 @@ type WithdrawFeesResult = {
 };
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:443](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L443)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:530](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L530)
 
 ## Properties
 
@@ -22,4 +22,4 @@ Defined in: [packages/sdk/src/channel-manager/channel.ts:443](https://github.com
 txHash: Hex;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/channel.ts:444](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L444)
+Defined in: [packages/sdk/src/channel-manager/channel.ts:531](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/channel.ts#L531)

--- a/docs/pages/sdk-reference/channel-manager/types/type-aliases/ContractReadFunctions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/types/type-aliases/ContractReadFunctions.mdx
@@ -13,12 +13,13 @@ type ContractReadFunctions = {
   getChannel: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getChannel">>;
   getChannelCreationFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getChannelCreationFee">>;
   getChannelMetadata: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getChannelMetadata">>;
+  getCommentCreationFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getCommentCreationFee">>;
   getHookTransactionFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getHookTransactionFee">>;
   ownerOf: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "ownerOf">>;
 };
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:90](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L90)
+Defined in: [packages/sdk/src/channel-manager/types.ts:98](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L98)
 
 ## Properties
 
@@ -28,7 +29,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:90](https://github.com/ec
 channelExists: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "channelExists">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:101](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L101)
+Defined in: [packages/sdk/src/channel-manager/types.ts:109](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L109)
 
 #### Parameters
 
@@ -48,7 +49,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:101](https://github.com/e
 deductProtocolHookTransactionFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "deductProtocolHookTransactionFee">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:127](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L127)
+Defined in: [packages/sdk/src/channel-manager/types.ts:144](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L144)
 
 #### Parameters
 
@@ -68,7 +69,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:127](https://github.com/e
 getChannel: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getChannel">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:91](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L91)
+Defined in: [packages/sdk/src/channel-manager/types.ts:99](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L99)
 
 #### Parameters
 
@@ -88,7 +89,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:91](https://github.com/ec
 getChannelCreationFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getChannelCreationFee">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:109](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L109)
+Defined in: [packages/sdk/src/channel-manager/types.ts:117](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L117)
 
 #### Parameters
 
@@ -108,7 +109,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:109](https://github.com/e
 getChannelMetadata: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getChannelMetadata">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:95](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L95)
+Defined in: [packages/sdk/src/channel-manager/types.ts:103](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L103)
 
 #### Parameters
 
@@ -122,13 +123,33 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:95](https://github.com/ec
 
 ***
 
+### getCommentCreationFee()
+
+```ts
+getCommentCreationFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getCommentCreationFee">>;
+```
+
+Defined in: [packages/sdk/src/channel-manager/types.ts:126](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L126)
+
+#### Parameters
+
+##### args
+
+`ReadContractParameters`\<[`ChannelManagerABIType`](/sdk-reference/channel-manager/types/type-aliases/ChannelManagerABIType.mdx), `"getCommentCreationFee"`\>
+
+#### Returns
+
+`Promise`\<`ReadContractReturnType`\<[`ChannelManagerABIType`](/sdk-reference/channel-manager/types/type-aliases/ChannelManagerABIType.mdx), `"getCommentCreationFee"`\>\>
+
+***
+
 ### getHookTransactionFee()
 
 ```ts
 getHookTransactionFee: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "getHookTransactionFee">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:118](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L118)
+Defined in: [packages/sdk/src/channel-manager/types.ts:135](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L135)
 
 #### Parameters
 
@@ -148,7 +169,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:118](https://github.com/e
 ownerOf: (args) => Promise<ReadContractReturnType<ChannelManagerABIType, "ownerOf">>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:105](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L105)
+Defined in: [packages/sdk/src/channel-manager/types.ts:113](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L113)
 
 #### Parameters
 

--- a/docs/pages/sdk-reference/channel-manager/types/type-aliases/ContractWriteFunctions.mdx
+++ b/docs/pages/sdk-reference/channel-manager/types/type-aliases/ContractWriteFunctions.mdx
@@ -11,6 +11,7 @@ type ContractWriteFunctions = {
   createChannel: (args) => Promise<Hex>;
   setBaseURI: (args) => Promise<Hex>;
   setChannelCreationFee: (args) => Promise<Hex>;
+  setCommentCreationFee: (args) => Promise<Hex>;
   setHook: (args) => Promise<Hex>;
   setHookTransactionFee: (args) => Promise<Hex>;
   updateChannel: (args) => Promise<Hex>;
@@ -84,13 +85,33 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:49](https://github.com/ec
 
 ***
 
+### setCommentCreationFee()
+
+```ts
+setCommentCreationFee: (args) => Promise<Hex>;
+```
+
+Defined in: [packages/sdk/src/channel-manager/types.ts:57](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L57)
+
+#### Parameters
+
+##### args
+
+`ContractFunctionParameters`\<[`ChannelManagerABIType`](/sdk-reference/channel-manager/types/type-aliases/ChannelManagerABIType.mdx), `"nonpayable"`, `"setCommentCreationFee"`\>
+
+#### Returns
+
+`Promise`\<[`Hex`](/sdk-reference/core/type-aliases/Hex.mdx)\>
+
+***
+
 ### setHook()
 
 ```ts
 setHook: (args) => Promise<Hex>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:57](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L57)
+Defined in: [packages/sdk/src/channel-manager/types.ts:65](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L65)
 
 #### Parameters
 
@@ -110,7 +131,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:57](https://github.com/ec
 setHookTransactionFee: (args) => Promise<Hex>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:65](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L65)
+Defined in: [packages/sdk/src/channel-manager/types.ts:73](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L73)
 
 #### Parameters
 
@@ -130,7 +151,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:65](https://github.com/ec
 updateChannel: (args) => Promise<Hex>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:73](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L73)
+Defined in: [packages/sdk/src/channel-manager/types.ts:81](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L81)
 
 #### Parameters
 
@@ -150,7 +171,7 @@ Defined in: [packages/sdk/src/channel-manager/types.ts:73](https://github.com/ec
 withdrawFees: (args) => Promise<Hex>;
 ```
 
-Defined in: [packages/sdk/src/channel-manager/types.ts:81](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L81)
+Defined in: [packages/sdk/src/channel-manager/types.ts:89](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/channel-manager/types.ts#L89)
 
 #### Parameters
 

--- a/packages/sdk/src/channel-manager/channel.ts
+++ b/packages/sdk/src/channel-manager/channel.ts
@@ -428,6 +428,93 @@ export async function setChannelCreationFee(
   };
 }
 
+export type GetCommentCreationFeeParams = {
+  /**
+   * The address of the channel manager
+   *
+   * @default CHANNEL_MANAGER_ADDRESS
+   */
+  channelManagerAddress?: Hex;
+  readContract: ContractReadFunctions["getCommentCreationFee"];
+};
+
+export type GetCommentCreationFeeResult = {
+  fee: bigint;
+};
+
+const GetCommentCreationFeeParamsSchema = z.object({
+  channelManagerAddress: HexSchema.default(CHANNEL_MANAGER_ADDRESS),
+});
+
+/**
+ * Get the creation fee from channel manager
+ *
+ * @param params - The parameters for getting the creation fee from channel manager
+ * @returns The creation fee from channel manager
+ */
+export async function getCommentCreationFee(
+  params: GetCommentCreationFeeParams,
+): Promise<GetCommentCreationFeeResult> {
+  const { channelManagerAddress } =
+    GetCommentCreationFeeParamsSchema.parse(params);
+
+  const fee = await params.readContract({
+    address: channelManagerAddress,
+    abi: ChannelManagerABI,
+    functionName: "getCommentCreationFee",
+    args: [],
+  });
+
+  return { fee };
+}
+
+export type SetCommentCreationFeeParams = {
+  /**
+   * The fee for creating a comment in wei
+   */
+  fee: bigint;
+  /**
+   * The address of the channel manager
+   *
+   * @default CHANNEL_MANAGER_ADDRESS
+   */
+  channelManagerAddress?: Hex;
+  writeContract: ContractWriteFunctions["setCommentCreationFee"];
+};
+
+export type SetCommentCreationFeeResult = {
+  txHash: Hex;
+};
+
+const SetCommentCreationFeeParamsSchema = z.object({
+  channelManagerAddress: HexSchema.default(CHANNEL_MANAGER_ADDRESS),
+  fee: z.bigint().min(0n),
+});
+
+/**
+ * Set the fee for creating a new comment
+ *
+ * @param params - The parameters for setting the fee for creating a new comment
+ * @returns The transaction hash of the set creation fee
+ */
+export async function setCommentCreationFee(
+  params: SetCommentCreationFeeParams,
+): Promise<SetCommentCreationFeeResult> {
+  const { channelManagerAddress, fee } =
+    SetCommentCreationFeeParamsSchema.parse(params);
+
+  const txHash = await params.writeContract({
+    address: channelManagerAddress,
+    abi: ChannelManagerABI,
+    functionName: "setCommentCreationFee",
+    args: [fee],
+  });
+
+  return {
+    txHash,
+  };
+}
+
 export type WithdrawFeesParams = {
   /**
    * The address of the recipient

--- a/packages/sdk/src/channel-manager/react/channel.ts
+++ b/packages/sdk/src/channel-manager/react/channel.ts
@@ -34,6 +34,12 @@ import {
   setBaseURI,
   type ChannelExistsParams,
   channelExists,
+  type GetCommentCreationFeeParams,
+  type GetCommentCreationFeeResult,
+  getCommentCreationFee,
+  type SetCommentCreationFeeParams,
+  type SetCommentCreationFeeResult,
+  setCommentCreationFee,
 } from "../channel.js";
 
 export type UseCreateChannelParams = Omit<CreateChannelParams, "writeContract">;
@@ -301,6 +307,92 @@ export function useSetChannelCreationFee(
     ...options,
     mutationFn: (params) => {
       return setChannelCreationFee({
+        ...params,
+        writeContract: writeContractAsync,
+      });
+    },
+  });
+}
+
+export type UseGetCommentCreationFeeParams = Omit<
+  GetCommentCreationFeeParams,
+  "readContract"
+>;
+export type UseGetCommentCreationFeeOptions = Omit<
+  UseQueryOptions<GetCommentCreationFeeResult, Error>,
+  "queryKey" | "queryFn"
+>;
+export type UseGetCommentCreationFeeResult = UseQueryResult<
+  GetCommentCreationFeeResult,
+  Error
+>;
+
+/**
+ * Get the creation fee from channel manager
+ *
+ * @param params - The parameters for getting the creation fee from channel manager
+ * @param options - The options for the query
+ * @returns The result of the query
+ */
+export function useGetCommentCreationFee(
+  params: UseGetCommentCreationFeeParams = {},
+  options: UseGetCommentCreationFeeOptions = {},
+): UseGetCommentCreationFeeResult {
+  const client = usePublicClient();
+
+  return useQuery({
+    ...options,
+    enabled: options.enabled && !!client,
+    queryKey: ["commentCreationFee", params.channelManagerAddress],
+    queryFn: async () => {
+      const result = await getCommentCreationFee({
+        ...params,
+        readContract: async (params) => {
+          if (!client) {
+            throw new Error("Client not found");
+          }
+
+          return client.readContract(params);
+        },
+      });
+      return result;
+    },
+  });
+}
+
+export type UseSetCommentCreationFeeParams = Omit<
+  SetCommentCreationFeeParams,
+  "writeContract"
+>;
+export type UseSetCommentCreationFeeOptions = Omit<
+  UseMutationOptions<
+    SetCommentCreationFeeResult,
+    Error,
+    UseSetCommentCreationFeeParams
+  >,
+  "mutationFn"
+>;
+export type UseSetCommentCreationFeeResult = UseMutationResult<
+  SetCommentCreationFeeResult,
+  Error,
+  UseSetCommentCreationFeeParams
+>;
+
+/**
+ * Set the fee for creating a new comment
+ *
+ * @param options - The options for the mutation
+ * @returns The result of the mutation
+ */
+export function useSetCommentCreationFee(
+  options: UseSetCommentCreationFeeOptions = {},
+): UseSetCommentCreationFeeResult {
+  const { writeContractAsync } = useWriteContract();
+
+  return useMutation({
+    ...options,
+    mutationFn: (params) => {
+      return setCommentCreationFee({
         ...params,
         writeContract: writeContractAsync,
       });

--- a/packages/sdk/src/channel-manager/types.ts
+++ b/packages/sdk/src/channel-manager/types.ts
@@ -54,6 +54,14 @@ export type ContractWriteFunctions = {
     >,
   ) => Promise<Hex>;
 
+  setCommentCreationFee: (
+    args: ContractFunctionParameters<
+      ChannelManagerABIType,
+      "nonpayable",
+      "setCommentCreationFee"
+    >,
+  ) => Promise<Hex>;
+
   setHook: (
     args: ContractFunctionParameters<
       ChannelManagerABIType,
@@ -113,6 +121,15 @@ export type ContractReadFunctions = {
     >,
   ) => Promise<
     ReadContractReturnType<ChannelManagerABIType, "getChannelCreationFee">
+  >;
+
+  getCommentCreationFee: (
+    args: ReadContractParameters<
+      ChannelManagerABIType,
+      "getCommentCreationFee"
+    >,
+  ) => Promise<
+    ReadContractReturnType<ChannelManagerABIType, "getCommentCreationFee">
   >;
 
   getHookTransactionFee: (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing comment creation fees in the channel manager, including the ability to get and set the fee.
  * Introduced new React hooks to query and update the comment creation fee.
* **Tests**
  * Added tests to verify correct behavior when retrieving and updating the comment creation fee, including permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->