### PR TITLE
fix(indexer): telegram bot issues

### DIFF
--- a/apps/indexer/src/services/admin-telegram-bot-service/commands/moderate-helpers.ts
+++ b/apps/indexer/src/services/admin-telegram-bot-service/commands/moderate-helpers.ts
@@ -193,6 +193,22 @@ export function moderationStatusToString(
   }
 }
 
+export function moderationStatusToActionString(
+  status: CommentModerationStatus,
+): string {
+  switch (status) {
+    case "pending":
+      return "Mark as pending";
+    case "approved":
+      return "Approve";
+    case "rejected":
+      return "Reject";
+    default:
+      status satisfies never;
+      throw new Error(`Unknown moderation status: ${status}`);
+  }
+}
+
 export function renderComment(
   comment: CommentSelectType,
   author: Hex | string,

--- a/apps/indexer/src/services/admin-telegram-bot-service/commands/moderate-menu.ts
+++ b/apps/indexer/src/services/admin-telegram-bot-service/commands/moderate-menu.ts
@@ -3,7 +3,7 @@ import { AdminTelegramBotServiceContext, MenuId } from "../types";
 import {
   commentModerationCommandToPayload,
   moderationCommandParser,
-  moderationStatusToString,
+  moderationStatusToActionString,
   renderComment,
 } from "./moderate-helpers";
 import { CommentModerationStatus } from "../../../management/types";
@@ -108,7 +108,7 @@ const moderateChangeStatusMenu = new Menu<AdminTelegramBotServiceContext>(
 
       range.text(
         {
-          text: moderationStatusToString(status),
+          text: moderationStatusToActionString(status),
           payload() {
             return commentModerationCommandToPayload({
               action: "changeStatus",


### PR DESCRIPTION
TODO:
- [x] - fix labels
- [x] - make moderation bot not returning errors and log them to sentry
- [ ] - investigate why on deploy some comments notify and then edit themselves (0x600f4455a3c9c4aa0c4bf85e135b4748abe8273a38081ee6816f0d1df1f32854, 0x8877633206c5a8b3b07f0a7ff6754c4a12dac7dfcda57cae5c0eb657efab75a5)
- [ ] - fix error handling swallowing the original errors in bot command handlers
- [ ] - fix potential status mismatch because it is not done in transaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated the moderation status menu to display action-oriented labels such as "Mark as pending", "Approve", and "Reject" for each status option. This enhances clarity when changing comment moderation statuses.

* **Bug Fixes**
  * Improved webhook handling by logging outdated or invalid requests instead of returning errors, ensuring smoother and more reliable processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->