### PR TITLE
feat(indexer): update approvals query schema to allow optional author and app parameters

### DIFF
--- a/apps/indexer/src/api/approvals/get.ts
+++ b/apps/indexer/src/api/approvals/get.ts
@@ -33,8 +33,8 @@ export default (app: OpenAPIHono) => {
 
     const query = db.query.approval.findMany({
       where: and(
-        eq(schema.approval.author, author),
-        eq(schema.approval.app, app),
+        app ? eq(schema.approval.app, app) : undefined,
+        author ? eq(schema.approval.author, author) : undefined,
         chainId.length === 1
           ? eq(schema.approval.chainId, chainId[0]!)
           : inArray(schema.approval.chainId, chainId),

--- a/apps/indexer/src/lib/schemas.ts
+++ b/apps/indexer/src/lib/schemas.ts
@@ -338,21 +338,36 @@ export const GetCommentRepliesParamSchema = z.object({
 /**
  * Query string schema for getting a list of approvals.
  */
-export const GetApprovalsQuerySchema = z.object({
-  author: OpenAPIHexSchema.openapi({
-    description: "The author's address",
-  }),
-  app: OpenAPIHexSchema.openapi({
-    description: "The address of the app signer",
-  }),
-  chainId: ChainIdSchema,
-  limit: z.coerce.number().int().positive().max(100).default(50).openapi({
-    description: "The number of comments to return",
-  }),
-  offset: z.coerce.number().int().min(0).default(0).openapi({
-    description: "The offset of the comments to return",
-  }),
-});
+export const GetApprovalsQuerySchema = z
+  .object({
+    author: OpenAPIHexSchema.openapi({
+      description:
+        "The author's address. Can be used to filter approvals by author. Either `author` or `app` must be provided or both.",
+    }).optional(),
+    app: OpenAPIHexSchema.openapi({
+      description:
+        "The address of the app signer. Can be used to filter approvals by app. Either `author` or `app` must be provided or both.",
+    }).optional(),
+    chainId: ChainIdSchema,
+    limit: z.coerce.number().int().positive().max(100).default(50).openapi({
+      description: "The number of comments to return",
+    }),
+    offset: z.coerce.number().int().min(0).default(0).openapi({
+      description: "The offset of the comments to return",
+    }),
+  })
+  .refine(
+    (val) => {
+      if (val.author || val.app) {
+        return true;
+      }
+
+      return false;
+    },
+    {
+      message: "Either `author` or `app` must be provided or both.",
+    },
+  );
 
 /**
  * Schema for a single approval.

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -6238,16 +6238,20 @@ paths:
       parameters:
         - schema:
             type: string
-            description: The author's address
+            description: >-
+              The author's address. Can be used to filter approvals by author.
+              Either `author` or `app` must be provided or both.
             pattern: ^0x[a-fA-F0-9]+$
-          required: true
+          required: false
           name: author
           in: query
         - schema:
             type: string
-            description: The address of the app signer
+            description: >-
+              The address of the app signer. Can be used to filter approvals by
+              app. Either `author` or `app` must be provided or both.
             pattern: ^0x[a-fA-F0-9]+$
-          required: true
+          required: false
           name: app
           in: query
         - schema:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The approvals API now allows queries with either the `author` or `app` parameter, making both fields optional as long as at least one is provided.

* **Documentation**
  * Updated API documentation to reflect that `author` and `app` are now optional query parameters, with clear guidance that at least one must be included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->