### PR TITLE
feat(sdk,embed,docs): make `app` an option for embed and iframe configurator

### DIFF
--- a/.changeset/sweet-snails-look.md
+++ b/.changeset/sweet-snails-look.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+Add `app` as configurable option to iframe embed config

--- a/apps/embed/src/app/by-author/page.tsx
+++ b/apps/embed/src/app/by-author/page.tsx
@@ -11,6 +11,7 @@ import { EmbedConfigFromSearchParamsSchema } from "@/lib/schemas";
 import { MainWrapper } from "@/components/MainWrapper";
 import { cookies } from "next/headers";
 import { COMMENT_TYPE_COMMENT } from "@ecp.eth/sdk";
+import { getAppSignerAddress } from "@/lib/utils";
 
 const SearchParamsSchema = z.object({
   author: HexSchema,
@@ -53,7 +54,7 @@ export default async function EmbedCommentsByAuthorPage({
   try {
     const fetchCommentParams: FetchCommentsOptions = {
       chainId: config.chainId,
-      app: env.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+      app: getAppSignerAddress(config.app),
       apiUrl: env.NEXT_PUBLIC_COMMENTS_INDEXER_URL,
       commentType: COMMENT_TYPE_COMMENT,
       limit: COMMENTS_PER_PAGE,

--- a/apps/embed/src/app/by-replies/page.tsx
+++ b/apps/embed/src/app/by-replies/page.tsx
@@ -14,6 +14,7 @@ import { EmbedConfigFromSearchParamsSchema } from "@/lib/schemas";
 import { MainWrapper } from "@/components/MainWrapper";
 import { cookies } from "next/headers";
 import { COMMENT_TYPE_COMMENT } from "@ecp.eth/sdk";
+import { getAppSignerAddress } from "@/lib/utils";
 
 const SearchParamsSchema = z.object({
   commentId: HexSchema,
@@ -56,7 +57,7 @@ export default async function EmbedCommentsByRepliesPage({
   try {
     const fetchCommentRepliesParams: FetchCommentRepliesOptions = {
       chainId: config.chainId,
-      app: env.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+      app: getAppSignerAddress(config.app),
       apiUrl: env.NEXT_PUBLIC_COMMENTS_INDEXER_URL,
       commentType: COMMENT_TYPE_COMMENT,
       limit: COMMENTS_PER_PAGE,

--- a/apps/embed/src/app/page.tsx
+++ b/apps/embed/src/app/page.tsx
@@ -11,6 +11,7 @@ import { COMMENTS_PER_PAGE } from "@/lib/constants";
 import { cookies } from "next/headers";
 import { Hex } from "@ecp.eth/sdk/core/schemas";
 import { COMMENT_TYPE_COMMENT } from "@ecp.eth/sdk";
+import { getAppSignerAddress } from "@/lib/utils";
 
 const SearchParamsSchema = z.object({
   targetUri: z.string().url(),
@@ -51,7 +52,7 @@ export default async function EmbedPage({ searchParams }: EmbedPageProps) {
   try {
     const fetchCommentParams: FetchCommentsOptions = {
       chainId: config.chainId,
-      app: env.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+      app: getAppSignerAddress(config.app),
       apiUrl: env.NEXT_PUBLIC_COMMENTS_INDEXER_URL,
       limit: COMMENTS_PER_PAGE,
       commentType: COMMENT_TYPE_COMMENT,

--- a/apps/embed/src/components/comments/CommentItem.tsx
+++ b/apps/embed/src/components/comments/CommentItem.tsx
@@ -33,6 +33,7 @@ import { CommentActionButton } from "@ecp.eth/shared/components";
 import { COMMENT_TYPE_COMMENT } from "@ecp.eth/sdk";
 import { Loader2Icon } from "lucide-react";
 import { useSetupPendingAction } from "./hooks/useSetupPendingAction";
+import { getAppSignerAddress } from "@/lib/utils";
 
 type CommentItemProps = {
   comment: CommentType;
@@ -40,7 +41,7 @@ type CommentItemProps = {
 
 export function CommentItem({ comment }: CommentItemProps) {
   const { address: connectedAddress } = useAccount();
-  const source = useEmbedConfig<
+  const config = useEmbedConfig<
     | EmbedConfigProviderByTargetURIConfig
     | EmbedConfigProviderByRepliesConfig
     | EmbedConfigProviderByAuthorConfig
@@ -64,13 +65,13 @@ export function CommentItem({ comment }: CommentItemProps) {
       createCommentItemsQueryKey(
         connectedAddress,
         chainId,
-        "targetUri" in source
-          ? source.targetUri
-          : "commentId" in source
-            ? source.commentId
-            : source.author,
+        "targetUri" in config
+          ? config.targetUri
+          : "commentId" in config
+            ? config.commentId
+            : config.author,
       ),
-    [source, connectedAddress, chainId],
+    [config, connectedAddress, chainId],
   );
 
   const firstPageParamOfReplies: ListCommentsQueryPageParamsSchemaType =
@@ -99,7 +100,7 @@ export function CommentItem({ comment }: CommentItemProps) {
       const response = await fetchCommentReplies({
         chainId,
         apiUrl: publicEnv.NEXT_PUBLIC_COMMENTS_INDEXER_URL,
-        app: publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+        app: getAppSignerAddress(config.app),
         cursor: pageParam.cursor,
         limit: pageParam.limit,
         commentId: comment.id,
@@ -131,7 +132,7 @@ export function CommentItem({ comment }: CommentItemProps) {
       return fetchCommentReplies({
         chainId,
         apiUrl: publicEnv.NEXT_PUBLIC_COMMENTS_INDEXER_URL,
-        app: publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS,
+        app: getAppSignerAddress(config.app),
         commentId: comment.id,
         cursor,
         limit: 10,

--- a/apps/embed/src/lib/utils.ts
+++ b/apps/embed/src/lib/utils.ts
@@ -3,7 +3,8 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { formatAuthorLinkWithTemplate } from "@ecp.eth/shared/helpers";
 import { AuthorType } from "@ecp.eth/shared/types";
-import { EmbedConfigSchemaInputType } from "@ecp.eth/sdk/embed/schemas";
+import { EmbedConfigSchema } from "@ecp.eth/sdk/embed/schemas";
+import z from "zod";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -16,7 +17,9 @@ export function formatAuthorLink(author: AuthorType): string | null {
   );
 }
 
-export function getAppSignerAddress(app: EmbedConfigSchemaInputType["app"]) {
+export function getAppSignerAddress(
+  app: z.output<typeof EmbedConfigSchema>["app"],
+) {
   return app === "embed"
     ? publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS
     : app === "all"

--- a/apps/embed/src/lib/utils.ts
+++ b/apps/embed/src/lib/utils.ts
@@ -3,6 +3,7 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { formatAuthorLinkWithTemplate } from "@ecp.eth/shared/helpers";
 import { AuthorType } from "@ecp.eth/shared/types";
+import { EmbedConfigSchemaInputType } from "@ecp.eth/sdk/embed/schemas";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -13,4 +14,12 @@ export function formatAuthorLink(author: AuthorType): string | null {
     author,
     publicEnv.NEXT_PUBLIC_COMMENT_AUTHOR_URL,
   );
+}
+
+export function getAppSignerAddress(app: EmbedConfigSchemaInputType["app"]) {
+  return app === "embed"
+    ? publicEnv.NEXT_PUBLIC_APP_SIGNER_ADDRESS
+    : app === "all"
+      ? undefined
+      : app;
 }

--- a/docs/components/IframeConfigurator/index.tsx
+++ b/docs/components/IframeConfigurator/index.tsx
@@ -59,6 +59,9 @@ const formSchema = z.object({
 
 export default function IframeConfigurator() {
   const [showAdvanced, setShowAdvanced] = React.useState(false);
+  const [appSigner, setAppSigner] = React.useState<"embed" | "custom" | "all">(
+    "embed",
+  );
 
   const form = useForm<z.input<typeof formSchema>>({
     mode: "all",
@@ -280,6 +283,59 @@ export default function IframeConfigurator() {
                   </FormItem>
                 )}
               />
+
+              <FormItem>
+                <FormLabel>App Signer Address</FormLabel>
+                <FormControl>
+                  <Select
+                    onValueChange={(value) => {
+                      setAppSigner(value as "embed" | "custom" | "all");
+
+                      if (value === "embed" || value === "all") {
+                        form.setValue("config.app", value);
+                      }
+                    }}
+                    value={appSigner}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Theme Mode" />
+                    </SelectTrigger>
+                    <SelectContent id="theme-mode-select">
+                      <SelectItem value="embed" defaultChecked>
+                        Default (embed app signer)
+                      </SelectItem>
+                      <SelectItem value="custom">Custom app signer</SelectItem>
+                      <SelectItem value="all">All apps</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+
+              {appSigner === "custom" && (
+                <FormField
+                  control={form.control}
+                  name="config.app"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Custom App Signer Address</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="text"
+                          {...field}
+                          value={
+                            field.value === "embed" || field.value === "all"
+                              ? ""
+                              : field.value
+                          }
+                          placeholder="0x..."
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
 
               <FormField
                 control={form.control}

--- a/docs/components/IframeConfigurator/index.tsx
+++ b/docs/components/IframeConfigurator/index.tsx
@@ -32,12 +32,13 @@ import { z } from "zod";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "../ui/form";
-import { ChevronsDown } from "lucide-react";
+import { ChevronsDown, Info } from "lucide-react";
 
 const formSchema = z.object({
   mode: z.enum(["post", "author", "replies"]),
@@ -318,7 +319,19 @@ export default function IframeConfigurator() {
                   name="config.app"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Custom App Signer Address</FormLabel>
+                      <FormLabel>
+                        Custom App Signer Address (for retrieving comments)
+                      </FormLabel>
+                      <FormDescription className="text-yellow-400">
+                        <span className="align-middle">
+                          <Info className="w-3 h-3 stroke-yellow-400 inline-block" />
+                          &nbsp; This option specifies the app signer address
+                          used to retrieve comments. However the embed app will
+                          always use the embed signer for posting comments. If
+                          the signer addresses do not match, newly posted
+                          comments may not appear.
+                        </span>
+                      </FormDescription>
                       <FormControl>
                         <Input
                           type="text"

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigFontSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigFontSchemaType.mdx
@@ -1777,7 +1777,7 @@ type EmbedConfigFontSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:140](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L140)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:141](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L141)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigSchemaInputType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigSchemaInputType.mdx
@@ -8,6 +8,7 @@
 
 ```ts
 type EmbedConfigSchemaInputType = {
+  app?: `0x${string}` | "all" | "embed";
   chainId?: 8453 | 31337;
   disablePromotion?: boolean;
   restrictMaximumContainerWidth?: boolean;
@@ -1826,11 +1827,29 @@ type EmbedConfigSchemaInputType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:209](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L209)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:222](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L222)
 
 Custom configuration for `<CommentEmbed />` component.
 
 ## Type declaration
+
+### app?
+
+```ts
+optional app: `0x${string}` | "all" | "embed";
+```
+
+Specify the app signer address the comments associated with.
+
+- Set it to "embed" will cause the embed to retrieve all comments posted by the embed app.
+- Set it to "all" will cause the embed to retrieve all comments from all apps.
+- Set it to a valid hex address will cause the embed to retrieve all comments posted by the specified app.
+
+#### Default
+
+```ts
+"embed"
+```
 
 ### chainId?
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigSchemaOutputType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigSchemaOutputType.mdx
@@ -10,4 +10,4 @@
 type EmbedConfigSchemaOutputType = z.output<typeof EmbedConfigSchema>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:210](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L210)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:223](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L223)

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigSupportedChainIdsSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigSupportedChainIdsSchemaType.mdx
@@ -10,6 +10,6 @@
 type EmbedConfigSupportedChainIdsSchemaType = 8453 | 31337;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:173](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L173)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:174](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L174)
 
 The type for supported chain ids

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemeColorsSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemeColorsSchemaType.mdx
@@ -45,7 +45,7 @@ type EmbedConfigThemeColorsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:94](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L94)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:95](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L95)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemeOtherSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemeOtherSchemaType.mdx
@@ -14,7 +14,7 @@ type EmbedConfigThemeOtherSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:104](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L104)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:105](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L105)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemePaletteSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemePaletteSchemaType.mdx
@@ -26,7 +26,7 @@ type EmbedConfigThemePaletteSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:85](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L85)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:86](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L86)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemeSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedConfigThemeSchemaType.mdx
@@ -1821,7 +1821,7 @@ type EmbedConfigThemeSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:160](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L160)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:161](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L161)
 
 The type for embed theme configuration
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedGetDimensionsEventSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedGetDimensionsEventSchemaType.mdx
@@ -12,7 +12,7 @@ type EmbedGetDimensionsEventSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:225](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L225)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:238](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L238)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/embed/type-aliases/EmbedResizedEventSchemaType.mdx
+++ b/docs/pages/sdk-reference/embed/type-aliases/EmbedResizedEventSchemaType.mdx
@@ -13,7 +13,7 @@ type EmbedResizedEventSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:217](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L217)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:230](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L230)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigFontSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigFontSchema.mdx
@@ -10,4 +10,4 @@
 const EmbedConfigFontSchema: ZodObject<EmbedConfigFontSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:115](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L115)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:116](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L116)

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigFontSizeSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigFontSizeSchema.mdx
@@ -19,4 +19,4 @@ const EmbedConfigFontSizeSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:108](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L108)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:109](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L109)

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigSchema.mdx
@@ -10,6 +10,6 @@
 const EmbedConfigSchema: ZodObject<EmbedConfigSchemaInputType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:180](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L180)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:181](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L181)
 
 The zod schema for `EmbedConfigSchemaType`

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigSupportedChainIdsSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigSupportedChainIdsSchema.mdx
@@ -10,6 +10,6 @@
 const EmbedConfigSupportedChainIdsSchema: ZodDefault<EmbedConfigSupportedChainIdsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:165](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L165)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:166](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L166)
 
 The zod schema for supported chain ids

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigThemeColorsSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigThemeColorsSchema.mdx
@@ -10,4 +10,4 @@
 const EmbedConfigThemeColorsSchema: ZodObject<EmbedConfigThemeColorsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:89](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L89)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:90](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L90)

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigThemeOtherSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigThemeOtherSchema.mdx
@@ -10,4 +10,4 @@
 const EmbedConfigThemeOtherSchema: ZodObject<EmbedConfigThemeOtherSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:98](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L98)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:99](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L99)

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigThemePaletteSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigThemePaletteSchema.mdx
@@ -10,4 +10,4 @@
 const EmbedConfigThemePaletteSchema: ZodObject<EmbedConfigThemePaletteSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:53](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L53)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:54](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L54)

--- a/docs/pages/sdk-reference/embed/variables/EmbedConfigThemeSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedConfigThemeSchema.mdx
@@ -10,6 +10,6 @@
 const EmbedConfigThemeSchema: ZodObject<EmbedConfigThemeSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:145](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L145)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:146](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L146)
 
 The zod schema for embed theme configuration

--- a/docs/pages/sdk-reference/embed/variables/EmbedGetDimensionsEventSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedGetDimensionsEventSchema.mdx
@@ -10,4 +10,4 @@
 const EmbedGetDimensionsEventSchema: ZodObject<EmbedGetDimensionsEventSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:221](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L221)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:234](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L234)

--- a/docs/pages/sdk-reference/embed/variables/EmbedResizedEventSchema.mdx
+++ b/docs/pages/sdk-reference/embed/variables/EmbedResizedEventSchema.mdx
@@ -10,4 +10,4 @@
 const EmbedResizedEventSchema: ZodObject<EmbedResizedEventSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/embed/schemas/index.ts:212](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L212)
+Defined in: [packages/sdk/src/embed/schemas/index.ts:225](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/embed/schemas/index.ts#L225)

--- a/packages/sdk/src/embed/schemas/index.ts
+++ b/packages/sdk/src/embed/schemas/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { EmbedConfigSupportedFont } from "./fonts.js";
 import { DEFAULT_CHAIN_ID, DEFAULT_CHAIN_ID_DEV } from "../../constants.js";
+import { HexSchema } from "../../core/schemas.js";
 
 export { EmbedConfigSupportedFont };
 
@@ -201,6 +202,18 @@ export const EmbedConfigSchema = z.object({
    * @default true
    */
   restrictMaximumContainerWidth: z.boolean().default(true),
+  /**
+   * Specify the app signer address the comments associated with.
+   *
+   * - Set it to "embed" will cause the embed to retrieve all comments posted by the embed app.
+   * - Set it to "all" will cause the embed to retrieve all comments from all apps.
+   * - Set it to a valid hex address will cause the embed to retrieve all comments posted by the specified app.
+   *
+   * @default "embed"
+   */
+  app: z
+    .union([HexSchema, z.literal("embed"), z.literal("all")])
+    .default("embed"),
 });
 
 /**


### PR DESCRIPTION
https://linear.app/modprotocol/issue/ECP-1466/fixembed-by-author-is-not-showing-all-the-comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Embed now lets you choose the app signer for comment queries: default (embed), all apps, or a custom address; applied across comments and replies and respected by the embed UI.

- **Documentation**
  - SDK reference updated to document the new app option and fixed cross-reference line pointers.

- **Chores**
  - Added a changeset for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->