### PR TITLE
feat: avoid manual moderate for comments below threshold

### DIFF
--- a/apps/demo/src/components/comments/standard/CommentSection.tsx
+++ b/apps/demo/src/components/comments/standard/CommentSection.tsx
@@ -99,7 +99,7 @@ export function CommentSection() {
         signal,
         viewer,
         mode: "flat",
-        commentType: 0,
+        commentType: COMMENT_TYPE_COMMENT,
       });
     },
     refetchInterval: NEW_COMMENTS_CHECK_INTERVAL,

--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -49,7 +49,7 @@ MODERATION_NOTIFICATION_TRIGGERING_CLASSIFICATION_THRESHOLD=90
 MODERATION_TELEGRAM_API_ROOT_URL=
 
 # (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) Telegram bot token to send notifications about comments pending moderation.
-# To create a telegram bot, talk to @BotFather in telegram
+# To create a telegram bot, talk to @BotFather in telegram, remember to send a message to the bot to activate it and add it into the channel
 MODERATION_TELEGRAM_BOT_TOKEN=
 
 # (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) Telegram channel ID to send notifications about comments pending moderation.

--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -38,7 +38,7 @@ MODERATION_ENABLE_NOTIFICATIONS=0
 
 # (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) classification score threshold (in percentage),
 # only comments with one of its classification go beyound this threshold will be manually moderated
-MODERATION_CLASSIFICATION_THRESHOLD=90
+MODERATION_NOTIFICATION_TRIGGERING_CLASSIFICATION_THRESHOLD=90
 
 # (Optional) Use if you want to test notifications locally. 
 # If you want to use notifications locally:

--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -43,7 +43,7 @@ MODERATION_NOTIFICATION_TRIGGERING_CLASSIFICATION_THRESHOLD=90
 # (Optional) Use if you want to test notifications locally. 
 # If you want to use notifications locally:
 # 1. Obtain TELEGRAM_API_ID and TELEGRAM_API_HASH and set them in env variables. See https://github.com/aiogram/telegram-bot-api?tab=readme-ov-file#quick-reference
-# 2. Start docker services using docker-compose up -d -f docker-compose.local.yml
+# 2. Start docker services using docker-compose -f docker-compose.local.yml up -d 
 # 3. Set this value to http://localhost:8081
 # 4. Set MODERATION_TELEGRAM_WEBHOOK_URL to a url returned by `ngrok http 42069`. Like https://{someid}.ngrok-free.app/api/webhook
 MODERATION_TELEGRAM_API_ROOT_URL=

--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -36,6 +36,10 @@ MODERATION_KNOWN_REACTIONS=like,dislike
 # If enabled MODERATION_TELEGRAM_BOT_TOKEN and MODERATION_TELEGRAM_CHANNEL_ID must be set.
 MODERATION_ENABLE_NOTIFICATIONS=0
 
+# (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) classification score threshold (in percentage),
+# only comments with one of its classification go beyound this threshold will be manually moderated
+MODERATION_CLASSIFICATION_THRESHOLD=90
+
 # (Optional) Use if you want to test notifications locally. 
 # If you want to use notifications locally:
 # 1. Obtain TELEGRAM_API_ID and TELEGRAM_API_HASH and set them in env variables. See https://github.com/aiogram/telegram-bot-api?tab=readme-ov-file#quick-reference

--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -49,9 +49,11 @@ MODERATION_CLASSIFICATION_THRESHOLD=90
 MODERATION_TELEGRAM_API_ROOT_URL=
 
 # (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) Telegram bot token to send notifications about comments pending moderation.
+# To create a telegram bot, talk to @BotFather in telegram
 MODERATION_TELEGRAM_BOT_TOKEN=
 
 # (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) Telegram channel ID to send notifications about comments pending moderation.
+# To obtain the channel id, use @userinfobot in telegram
 MODERATION_TELEGRAM_CHANNEL_ID=
 
 # (Required if MODERATION_ENABLE_NOTIFICATIONS is 1) Webhook url that telegram will call

--- a/apps/indexer/src/env.ts
+++ b/apps/indexer/src/env.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const moderationNotificationsEnabledSchema = z.object({
+  MODERATION_CLASSIFICATION_THRESHOLD: z.coerce.number().min(0).max(100),
   MODERATION_TELEGRAM_BOT_TOKEN: z.string().nonempty(),
   MODERATION_TELEGRAM_CHANNEL_ID: z.string().nonempty(),
   MODERATION_TELEGRAM_WEBHOOK_URL: z.string().url(),
@@ -58,6 +59,11 @@ const EnvSchema = z
       .enum(["0", "1"])
       .default("0")
       .transform((val) => val === "1"),
+    MODERATION_CLASSIFICATION_THRESHOLD: z.coerce
+      .number()
+      .min(0)
+      .max(100)
+      .default(0),
     MODERATION_ENABLE_NOTIFICATIONS: z
       .enum(["0", "1"])
       .default("0")

--- a/apps/indexer/src/env.ts
+++ b/apps/indexer/src/env.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 const moderationNotificationsEnabledSchema = z.object({
-  MODERATION_CLASSIFICATION_THRESHOLD: z.coerce.number().min(0).max(100),
+  MODERATION_NOTIFICATION_TRIGGERING_CLASSIFICATION_THRESHOLD: z.coerce
+    .number()
+    .min(0)
+    .max(100),
   MODERATION_TELEGRAM_BOT_TOKEN: z.string().nonempty(),
   MODERATION_TELEGRAM_CHANNEL_ID: z.string().nonempty(),
   MODERATION_TELEGRAM_WEBHOOK_URL: z.string().url(),
@@ -59,7 +62,7 @@ const EnvSchema = z
       .enum(["0", "1"])
       .default("0")
       .transform((val) => val === "1"),
-    MODERATION_CLASSIFICATION_THRESHOLD: z.coerce
+    MODERATION_NOTIFICATION_TRIGGERING_CLASSIFICATION_THRESHOLD: z.coerce
       .number()
       .min(0)
       .max(100)

--- a/apps/indexer/src/management/services/comment-moderation-service.ts
+++ b/apps/indexer/src/management/services/comment-moderation-service.ts
@@ -86,21 +86,25 @@ export class CommentModerationService {
         },
       },
       saveAndNotify: async () => {
-        let messageId: number | undefined;
-
         await Promise.all([
           premoderationResult.save(),
           classifierResult.save(),
         ]);
 
-        if (premoderationResult.action !== "skipped") {
-          messageId = await this.sendNewNotification({
-            comment,
-            commentRevision: DEFAULT_REVISION_ON_ADD,
-            references,
-            classifierResult,
-          });
+        const skipNotification =
+          premoderationResult.status === "approved" ||
+          premoderationResult.action === "skipped";
+
+        if (skipNotification) {
+          return;
         }
+
+        const messageId = await this.sendNewNotification({
+          comment,
+          commentRevision: DEFAULT_REVISION_ON_ADD,
+          references,
+          classifierResult,
+        });
 
         if (classifierResult.action !== "skipped") {
           await this.sendNewAutomaticClassification({
@@ -186,20 +190,25 @@ export class CommentModerationService {
         changedAt: premoderationResult.changedAt,
       },
       saveAndNotify: async () => {
-        let messageId: number | undefined;
         await Promise.all([
           premoderationResult.save(),
           classifierResult.save(),
         ]);
 
-        if (premoderationResult.action !== "skipped") {
-          messageId = await this.sendUpdateNotification({
-            comment,
-            commentRevision,
-            references,
-            classifierResult,
-          });
+        const skipNotification =
+          premoderationResult.status === "approved" ||
+          premoderationResult.action === "skipped";
+
+        if (skipNotification) {
+          return;
         }
+
+        const messageId = await this.sendUpdateNotification({
+          comment,
+          commentRevision,
+          references,
+          classifierResult,
+        });
 
         if (classifierResult.action !== "skipped") {
           await this.sendUpdateAutomaticClassification({

--- a/apps/indexer/src/management/services/comment-moderation-service.ts
+++ b/apps/indexer/src/management/services/comment-moderation-service.ts
@@ -68,10 +68,13 @@ export class CommentModerationService {
       revision: DEFAULT_REVISION_ON_ADD,
     };
 
-    const [premoderationResult, classifierResult] = await Promise.all([
-      this.premoderationService.moderate(formattedComment),
-      this.classifierService.classify(formattedComment),
-    ]);
+    const classifierResult =
+      await this.classifierService.classify(formattedComment);
+
+    const premoderationResult = await this.premoderationService.moderate(
+      formattedComment,
+      classifierResult,
+    );
 
     return {
       result: {
@@ -162,13 +165,16 @@ export class CommentModerationService {
       revision: commentRevision,
     };
 
-    const [premoderationResult, classifierResult] = await Promise.all([
-      this.premoderationService.moderateUpdate(
-        formattedComment,
-        existingComment,
-      ),
-      this.classifierService.classifyUpdate(formattedComment, existingComment),
-    ]);
+    const classifierResult = await this.classifierService.classifyUpdate(
+      formattedComment,
+      existingComment,
+    );
+
+    const premoderationResult = await this.premoderationService.moderateUpdate(
+      formattedComment,
+      existingComment,
+      classifierResult,
+    );
 
     return {
       result: {

--- a/apps/indexer/src/services/index.ts
+++ b/apps/indexer/src/services/index.ts
@@ -88,7 +88,8 @@ export const commentReportsService = new CommentReportsService({
 
 export const premoderationService = env.MODERATION_ENABLED
   ? new PremoderationService({
-      classificationThreshold: env.MODERATION_CLASSIFICATION_THRESHOLD,
+      classificationThreshold:
+        env.MODERATION_NOTIFICATION_TRIGGERING_CLASSIFICATION_THRESHOLD,
       db,
     })
   : new NoopPremoderationService();

--- a/apps/indexer/src/services/index.ts
+++ b/apps/indexer/src/services/index.ts
@@ -88,7 +88,7 @@ export const commentReportsService = new CommentReportsService({
 
 export const premoderationService = env.MODERATION_ENABLED
   ? new PremoderationService({
-      defaultModerationStatus: "pending",
+      classificationThreshold: env.MODERATION_CLASSIFICATION_THRESHOLD,
       db,
     })
   : new NoopPremoderationService();

--- a/apps/indexer/src/services/types.ts
+++ b/apps/indexer/src/services/types.ts
@@ -180,11 +180,13 @@ export type CommentPremoderationServiceModerateParams =
 export interface ICommentPremoderationService {
   moderate: (
     comment: ModerationNotificationServicePendingComment,
+    classifierResult: CommentModerationClassfierResult,
   ) => Promise<CommentPremoderationServiceModerateResult>;
 
   moderateUpdate: (
     comment: ModerationNotificationServicePendingComment,
     existingComment: CommentSelectType,
+    classifierResult: CommentModerationClassfierResult,
   ) => Promise<CommentPremoderationServiceModerateResult>;
 
   updateStatus: (params: {

--- a/apps/indexer/tests/management/services/comment-moderation-service.test.ts
+++ b/apps/indexer/tests/management/services/comment-moderation-service.test.ts
@@ -131,16 +131,19 @@ describe("CommentModerationService", () => {
 
       await result.saveAndNotify();
 
-      expect(mockPremoderationService.moderate).toHaveBeenCalledWith({
-        author: mockComment.author,
-        channelId: mockComment.channelId,
-        content: mockComment.content,
-        id: mockComment.commentId,
-        parentId: mockComment.parentId,
-        references: mockReferences,
-        targetUri: mockComment.targetUri,
-        revision: 0,
-      });
+      expect(mockPremoderationService.moderate).toHaveBeenCalledWith(
+        {
+          author: mockComment.author,
+          channelId: mockComment.channelId,
+          content: mockComment.content,
+          id: mockComment.commentId,
+          parentId: mockComment.parentId,
+          references: mockReferences,
+          targetUri: mockComment.targetUri,
+          revision: 0,
+        },
+        mockClassifierResult,
+      );
 
       expect(mockClassifierService.classify).toHaveBeenCalledWith({
         author: mockComment.author,
@@ -197,16 +200,19 @@ describe("CommentModerationService", () => {
 
       await result.saveAndNotify();
 
-      expect(mockPremoderationService.moderate).toHaveBeenCalledWith({
-        author: mockComment.author,
-        channelId: mockComment.channelId,
-        content: mockComment.content,
-        id: mockComment.commentId,
-        parentId: mockComment.parentId,
-        references: mockReferences,
-        targetUri: mockComment.targetUri,
-        revision: 0,
-      });
+      expect(mockPremoderationService.moderate).toHaveBeenCalledWith(
+        {
+          author: mockComment.author,
+          channelId: mockComment.channelId,
+          content: mockComment.content,
+          id: mockComment.commentId,
+          parentId: mockComment.parentId,
+          references: mockReferences,
+          targetUri: mockComment.targetUri,
+          revision: 0,
+        },
+        mockClassifierResult,
+      );
 
       expect(mockClassifierService.classify).toHaveBeenCalledWith({
         author: mockComment.author,
@@ -268,16 +274,19 @@ describe("CommentModerationService", () => {
 
       await result.saveAndNotify();
 
-      expect(mockPremoderationService.moderate).toHaveBeenCalledWith({
-        author: mockComment.author,
-        channelId: mockComment.channelId,
-        content: mockComment.content,
-        id: mockComment.commentId,
-        parentId: mockComment.parentId,
-        references: mockReferences,
-        targetUri: mockComment.targetUri,
-        revision: 0,
-      });
+      expect(mockPremoderationService.moderate).toHaveBeenCalledWith(
+        {
+          author: mockComment.author,
+          channelId: mockComment.channelId,
+          content: mockComment.content,
+          id: mockComment.commentId,
+          parentId: mockComment.parentId,
+          references: mockReferences,
+          targetUri: mockComment.targetUri,
+          revision: 0,
+        },
+        mockClassifierResult,
+      );
 
       expect(mockClassifierService.classify).toHaveBeenCalledWith({
         author: mockComment.author,
@@ -334,16 +343,19 @@ describe("CommentModerationService", () => {
 
       await result.saveAndNotify();
 
-      expect(mockPremoderationService.moderate).toHaveBeenCalledWith({
-        author: mockComment.author,
-        channelId: mockComment.channelId,
-        content: mockComment.content,
-        id: mockComment.commentId,
-        parentId: mockComment.parentId,
-        references: mockReferences,
-        targetUri: mockComment.targetUri,
-        revision: 0,
-      });
+      expect(mockPremoderationService.moderate).toHaveBeenCalledWith(
+        {
+          author: mockComment.author,
+          channelId: mockComment.channelId,
+          content: mockComment.content,
+          id: mockComment.commentId,
+          parentId: mockComment.parentId,
+          references: mockReferences,
+          targetUri: mockComment.targetUri,
+          revision: 0,
+        },
+        mockClassifierResult,
+      );
 
       expect(mockClassifierService.classify).toHaveBeenCalledWith({
         author: mockComment.author,
@@ -502,6 +514,7 @@ describe("CommentModerationService", () => {
           revision: 0,
         },
         mockExistingComment,
+        mockClassifierResult,
       );
 
       expect(mockClassifierService.classifyUpdate).toHaveBeenCalledWith(
@@ -579,6 +592,7 @@ describe("CommentModerationService", () => {
           revision: 0,
         },
         mockExistingComment,
+        mockClassifierResult,
       );
 
       expect(mockClassifierService.classifyUpdate).toHaveBeenCalledWith(
@@ -661,6 +675,7 @@ describe("CommentModerationService", () => {
           revision: 0,
         },
         mockExistingComment,
+        mockClassifierResult,
       );
 
       expect(mockClassifierService.classifyUpdate).toHaveBeenCalledWith(
@@ -738,6 +753,7 @@ describe("CommentModerationService", () => {
           revision: 0,
         },
         mockExistingComment,
+        mockClassifierResult,
       );
 
       expect(mockClassifierService.classifyUpdate).toHaveBeenCalledWith(

--- a/apps/indexer/tests/management/services/comment-moderation-service.test.ts
+++ b/apps/indexer/tests/management/services/comment-moderation-service.test.ts
@@ -231,7 +231,7 @@ describe("CommentModerationService", () => {
       ).not.toHaveBeenCalled();
       expect(
         mockNotificationService.notifyAutomaticallyClassified,
-      ).toHaveBeenCalled();
+      ).not.toHaveBeenCalled();
     });
 
     it("should not send notifications when classification is skipped", async () => {
@@ -615,7 +615,7 @@ describe("CommentModerationService", () => {
       ).not.toHaveBeenCalled();
       expect(
         mockNotificationService.notifyAutomaticallyClassified,
-      ).toHaveBeenCalled();
+      ).not.toHaveBeenCalled();
     });
 
     it("should not send notifications when classification is skipped for updates", async () => {

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: 0.0.20
+  version: 0.0.21
   title: Indexer Restful API
 servers:
   - url: https://api.ethcomments.xyz

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -2558,85 +2558,85 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigFontSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigSchemaInputType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigSchemaOutputType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigSupportedChainIdsSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigThemeColorsSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigThemeOtherSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigThemePaletteSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedConfigThemeSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedGetDimensionsEventSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/type-aliases/EmbedResizedEventSchemaType</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigFontSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigFontSizeSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigSupportedChainIdsSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -2648,37 +2648,37 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigThemeColorsSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigThemeOtherSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigThemePaletteSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedConfigThemeSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedGetDimensionsEventSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/embed/variables/EmbedResizedEventSchema</loc>
-    <lastmod>2025-07-18T09:46:11.000Z</lastmod>
+    <lastmod>2025-08-13T13:53:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>


### PR DESCRIPTION
fix https://linear.app/modprotocol/issue/ECP-1535/featindexer-auto-approved-comments-if-theyve-got-a-low-score-less

- [x] add tests
- [x] manual testing
- [ ] add env var to vercel 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configurable moderation notification threshold (0–100). Classifier now runs first, driving premoderation outcomes and skipping notifications for approved/skipped cases.

- **Documentation**
  - Added threshold env example, Telegram setup hints, and corrected local docker-compose usage. OpenAPI version bumped and sitemap timestamps updated.

- **Tests**
  - Expanded tests for threshold-driven outcomes, skipped/classified paths, sequential classifier flow, and persistence/save behavior.

- **Bug Fix**
  - Aligned new-comments fetch to use the COMMENT_TYPE_COMMENT constant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->