### PR TITLE
docs: add content_contains search example to read comments guide

### DIFF
--- a/docs/pages/indexer/read-comments.mdx
+++ b/docs/pages/indexer/read-comments.mdx
@@ -60,6 +60,14 @@ query {
 }
 ```
 
+Search comments by content using `content_contains`:
+
+```bash
+curl -X POST https://api.ethcomments.xyz/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query MyQuery { comments(where: {content_contains: \"build\"}) { items { id content } } }"}'
+```
+
 **Important**: The hosted indexer has moderation enabled by default. If you want comments to appear immediately without waiting for moderation approval, you can filter by moderation status in your GraphQL queries:
 
 ```graphql


### PR DESCRIPTION
## Summary
- Add curl example demonstrating how to search comments by content using the `content_contains` filter in GraphQL queries
- Enhances the read comments documentation with a practical search example

## Test plan
- [x] Verify the example syntax is correct
- [x] Ensure the documentation renders properly
- [x] Check that the curl command follows existing patterns in the docs

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new example for searching comments by content using a content_contains filter (with curl and GraphQL).
  - Introduced guidance on default moderation for the hosted indexer.
  - Provided a GraphQL example to filter comments by moderationStatus (e.g., approved or pending) with a limit, returning id, content, and moderationStatus.
  - Ensured existing examples for querying by comment ID and filtering by targetUri remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->