### PR TITLE
docs: update indexer URL to api.ethcomments.xyz

### DIFF
--- a/docs/pages/react-editor/index.mdx
+++ b/docs/pages/react-editor/index.mdx
@@ -1,9 +1,10 @@
-{/*
-  !!DO NOT EDIT!!
-  Automatically generated doc.
-  run `pnpm run ref:gen:react-editor` to update
-  !!DO NOT EDIT!!
-*/}
+{/_
+!!DO NOT EDIT!!
+Automatically generated doc.
+run `pnpm run ref:gen:react-editor` to update
+!!DO NOT EDIT!!
+_/}
+
 # `@ecp.eth/react-editor`
 
 A React-based rich text editor for the Ethereum Comments Protocol.
@@ -113,7 +114,7 @@ Provides suggestions for ENS, Farcaster, and ERC-20 mentions using the ECP Index
 import { useIndexerSuggestions } from "@ecp.eth/react-editor/hooks";
 
 const suggestions = useIndexerSuggestions({
-  indexerUrl: "https://indexer.ethcomments.xyz",
+  indexerUrl: "https://api.ethcomments.xyz",
 });
 ```
 

--- a/docs/pages/react-editor/index.mdx
+++ b/docs/pages/react-editor/index.mdx
@@ -1,10 +1,9 @@
-{/_
-!!DO NOT EDIT!!
-Automatically generated doc.
-run `pnpm run ref:gen:react-editor` to update
-!!DO NOT EDIT!!
-_/}
-
+{/*
+  !!DO NOT EDIT!!
+  Automatically generated doc.
+  run `pnpm run ref:gen:react-editor` to update
+  !!DO NOT EDIT!!
+*/}
 # `@ecp.eth/react-editor`
 
 A React-based rich text editor for the Ethereum Comments Protocol.

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://docs.ethcomments.xyz</loc>
-    <lastmod>2025-08-12T12:26:00.000Z</lastmod>
+    <lastmod>2025-09-02T08:32:06.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -152,7 +152,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/integration-options/share-to-ecp</loc>
-    <lastmod>2025-09-01T13:20:52.162Z</lastmod>
+    <lastmod>2025-09-02T08:32:06.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -206,7 +206,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/react-editor</loc>
-    <lastmod>2025-07-18T10:18:08.000Z</lastmod>
+    <lastmod>2025-09-03T09:59:17.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/packages/react-editor/README.md
+++ b/packages/react-editor/README.md
@@ -107,7 +107,7 @@ Provides suggestions for ENS, Farcaster, and ERC-20 mentions using the ECP Index
 import { useIndexerSuggestions } from "@ecp.eth/react-editor/hooks";
 
 const suggestions = useIndexerSuggestions({
-  indexerUrl: "https://indexer.ethcomments.xyz",
+  indexerUrl: "https://api.ethcomments.xyz",
 });
 ```
 


### PR DESCRIPTION
## Summary
- Updated indexer URL in react-editor documentation from `indexer.ethcomments.xyz` to `api.ethcomments.xyz`
- Changes affect both the main README and documentation pages

## Test plan
- [x] Verify documentation builds correctly
- [ ] Confirm new API endpoint is accessible and functional

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated example endpoints from https://indexer.ethcomments.xyz to https://api.ethcomments.xyz in React Editor docs and Hooks README.
  * Updated lastmod timestamps in the public sitemap to reflect current publish dates.
  * No functional or API changes; examples and metadata updated for accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->