### PR TITLE
fix(indexer): start block should allow zero

### DIFF
--- a/apps/indexer/src/env.ts
+++ b/apps/indexer/src/env.ts
@@ -120,7 +120,7 @@ const EnvSchema = z
     MODERATION_TELEGRAM_WEBHOOK_URL: z.string().url().optional(),
     MODERATION_TELEGRAM_WEBHOOK_SECRET: z.string().optional(),
     PONDER_RPC_URL_8453: z.string().url().optional(),
-    PONDER_START_BLOCK_8453: z.coerce.number().min(0).optional(),
+    PONDER_START_BLOCK_8453: z.coerce.number().int().min(0).optional(),
     ENS_RPC_URL: z.string().url(),
     ENSNODE_SUBGRAPH_URL: z.string().url().optional(),
     SIM_API_KEY: z.string().nonempty(),
@@ -233,6 +233,7 @@ const _env = EnvSchema.safeParse({
       const startBlock = z.coerce
         .number()
         .int()
+        .min(0)
         .optional()
         .parse(process.env[`PONDER_START_BLOCK_${chainId}`], {
           path: [`PONDER_START_BLOCK_${chainId}`],

--- a/apps/indexer/src/env.ts
+++ b/apps/indexer/src/env.ts
@@ -69,7 +69,7 @@ const ChainConfigs = z.record(
       },
     ),
     rpcUrl: z.string().url(),
-    startBlock: z.coerce.number().int().positive().optional(),
+    startBlock: z.coerce.number().int().min(0).optional(),
   }),
 );
 
@@ -120,7 +120,7 @@ const EnvSchema = z
     MODERATION_TELEGRAM_WEBHOOK_URL: z.string().url().optional(),
     MODERATION_TELEGRAM_WEBHOOK_SECRET: z.string().optional(),
     PONDER_RPC_URL_8453: z.string().url().optional(),
-    PONDER_START_BLOCK_8453: z.coerce.number().optional(),
+    PONDER_START_BLOCK_8453: z.coerce.number().min(0).optional(),
     ENS_RPC_URL: z.string().url(),
     ENSNODE_SUBGRAPH_URL: z.string().url().optional(),
     SIM_API_KEY: z.string().nonempty(),
@@ -167,7 +167,7 @@ const EnvSchema = z
     ADMIN_TELEGRAM_BOT_API_ROOT_URL: z.string().url().optional(),
 
     CHAIN_CONFIGS: ChainConfigs,
-    CHAIN_ANVIL_START_BLOCK: z.coerce.number().int().positive().optional(),
+    CHAIN_ANVIL_START_BLOCK: z.coerce.number().int().min(0).optional(),
     CHAIN_ANVIL_ECP_CHANNEL_MANAGER_ADDRESS_OVERRIDE: HexSchema.optional(),
     CHAIN_ANVIL_ECP_COMMENT_MANAGER_ADDRESS_OVERRIDE: HexSchema.optional(),
   })
@@ -233,7 +233,6 @@ const _env = EnvSchema.safeParse({
       const startBlock = z.coerce
         .number()
         .int()
-        .positive()
         .optional()
         .parse(process.env[`PONDER_START_BLOCK_${chainId}`], {
           path: [`PONDER_START_BLOCK_${chainId}`],

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  version: 0.0.21
+  version: 0.0.22
   title: Indexer Restful API
 servers:
   - url: https://api.ethcomments.xyz

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -194,7 +194,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/protocol-fee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -218,13 +218,13 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/channelExists</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -236,49 +236,49 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/estimateChannelEditCommentFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/estimateChannelPostCommentFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/getChannel</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/getChannelCreationFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/getChannelMetadata</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/getCommentCreationFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/getEstimatedChannelEditCommentHookFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/getEstimatedChannelPostCommentHookFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -290,25 +290,25 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/ownerOf</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/setBaseURI</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/setChannelCreationFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/setCommentCreationFee</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -326,7 +326,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/functions/withdrawFees</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -674,19 +674,19 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/ChannelExistsParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/CreateChannelParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/CreateChannelResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -704,49 +704,49 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetChannelCreationFeeParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetChannelCreationFeeResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetChannelMetadataParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetChannelMetadataResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetChannelParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetChannelResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/GetCommentCreationFeeResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -764,49 +764,49 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/OwnerOfParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/OwnerOfResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/SetBaseURIParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/SetBaseURIResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/SetChannelCreationFeeParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/SetChannelCreationFeeResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/SetCommentCreationFeeResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -836,43 +836,43 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/UpdateChannelParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/UpdateChannelResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/WithdrawFeesParams</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/type-aliases/WithdrawFeesResult</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/BaseHookABIType</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/Channel</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -884,61 +884,61 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/ChannelPermissions</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/ContractBasedAssetERCType</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/ContractBasedAssetType</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/ContractReadFunctions</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/ContractWriteFunctions</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/HookContractReadFunctions</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/HookFeeEstimation</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/types/type-aliases/TotalFeeEstimation</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/variables/createChannel</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/channel-manager/variables/updateChannel</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -1274,7 +1274,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/comments/react/functions/useGaslessTransaction</loc>
-    <lastmod>2025-09-08T23:49:04.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -2450,7 +2450,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/defaultExports</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -2462,7 +2462,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/defaultExports/variables/BaseHookABI</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -2558,19 +2558,19 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/defaultExports/variables/INTERFACE_ID_ERC1155</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/defaultExports/variables/INTERFACE_ID_ERC165</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/defaultExports/variables/INTERFACE_ID_ERC721</loc>
-    <lastmod>2025-09-08T23:49:02.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>
@@ -2582,7 +2582,7 @@
   </url>
   <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/defaultExports/variables/NATIVE_ASSET_ADDRESS</loc>
-    <lastmod>2025-09-08T23:49:00.000Z</lastmod>
+    <lastmod>2025-09-09T01:16:21.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.4</priority>
   </url>


### PR DESCRIPTION
for  brand new chain the start block is zero not 1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Start block configuration now accepts 0, enabling indexing from genesis and preventing setup failures from overly strict validation.
  - Validation standardized across start-block settings so existing positive values remain compatible.

- Documentation
  - Public API version bumped to 0.0.22.
  - Public sitemap timestamps refreshed to reflect recent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->