### PR TITLE
fix(indexer): url schema validation before insertion

### DIFF
--- a/docs/pages/sdk-reference/indexer/functions/convertIndexerMetadataToRecord.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/convertIndexerMetadataToRecord.mdx
@@ -10,7 +10,7 @@
 function convertIndexerMetadataToRecord(metadataEntries, keyTypeMap?): MetadataRecord;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:525](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L525)
+Defined in: [packages/sdk/src/indexer/schemas.ts:545](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L545)
 
 Converts IndexerAPI MetadataEntry array to Record format for easier manipulation
 

--- a/docs/pages/sdk-reference/indexer/functions/convertRecordToIndexerMetadata.mdx
+++ b/docs/pages/sdk-reference/indexer/functions/convertRecordToIndexerMetadata.mdx
@@ -13,7 +13,7 @@ function convertRecordToIndexerMetadata(metadataRecord): {
 }[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:538](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L538)
+Defined in: [packages/sdk/src/indexer/schemas.ts:558](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L558)
 
 Converts Record format metadata to IndexerAPI MetadataEntry array format
 

--- a/docs/pages/sdk-reference/indexer/index.mdx
+++ b/docs/pages/sdk-reference/indexer/index.mdx
@@ -36,6 +36,7 @@ Functionality for indexing and querying comments data
 | [IndexerAPICommentReferenceERC20SchemaType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceERC20SchemaType.mdx) | - |
 | [IndexerAPICommentReferenceFarcasterSchemaType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceFarcasterSchemaType.mdx) | - |
 | [IndexerAPICommentReferenceSchemaType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceSchemaType.mdx) | - |
+| [IndexerAPICommentReferencesSchemaInputType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaInputType.mdx) | - |
 | [IndexerAPICommentReferencesSchemaType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx) | - |
 | [IndexerAPICommentReferenceURLFileSchemaType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx) | - |
 | [IndexerAPICommentReferenceURLImageSchemaType](/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx) | - |

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteENSSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteENSSchemaType.mdx
@@ -17,7 +17,7 @@ type IndexerAPIAutocompleteENSSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:555](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L555)
+Defined in: [packages/sdk/src/indexer/schemas.ts:575](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L575)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteERC20SchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteERC20SchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPIAutocompleteERC20SchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:575](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L575)
+Defined in: [packages/sdk/src/indexer/schemas.ts:595](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L595)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteFarcasterSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteFarcasterSchemaType.mdx
@@ -20,7 +20,7 @@ type IndexerAPIAutocompleteFarcasterSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:593](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L593)
+Defined in: [packages/sdk/src/indexer/schemas.ts:613](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L613)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIAutocompleteSchemaType.mdx
@@ -40,4 +40,4 @@ type IndexerAPIAutocompleteSchemaType =
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:603](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L603)
+Defined in: [packages/sdk/src/indexer/schemas.ts:623](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L623)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentOutputSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPICommentOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:368](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L368)
+Defined in: [packages/sdk/src/indexer/schemas.ts:388](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L388)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReactionSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReactionSchemaType.mdx
@@ -296,7 +296,7 @@ type IndexerAPICommentReactionSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:377](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L377)
+Defined in: [packages/sdk/src/indexer/schemas.ts:397](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L397)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLFileSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLFileSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:278](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L278)
+Defined in: [packages/sdk/src/indexer/schemas.ts:273](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L273)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLImageSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLImageSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:289](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L289)
+Defined in: [packages/sdk/src/indexer/schemas.ts:284](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L284)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLVideoSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLVideoSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPICommentReferenceURLVideoSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:300](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L300)
+Defined in: [packages/sdk/src/indexer/schemas.ts:295](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L295)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLWebPageSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferenceURLWebPageSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPICommentReferenceURLWebPageSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:267](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L267)
+Defined in: [packages/sdk/src/indexer/schemas.ts:262](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L262)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaInputType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaInputType.mdx
@@ -2,12 +2,12 @@
 
 ***
 
-[@ecp.eth/sdk](/sdk-reference/index.mdx) / [indexer](/sdk-reference/indexer/index.mdx) / IndexerAPICommentReferenceSchemaType
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [indexer](/sdk-reference/indexer/index.mdx) / IndexerAPICommentReferencesSchemaInputType
 
-# Type Alias: IndexerAPICommentReferenceSchemaType
+# Type Alias: IndexerAPICommentReferencesSchemaInputType
 
 ```ts
-type IndexerAPICommentReferenceSchemaType = 
+type IndexerAPICommentReferencesSchemaInputType = (
   | {
   address: `0x${string}`;
   avatarUrl: null | string;
@@ -94,7 +94,7 @@ type IndexerAPICommentReferenceSchemaType =
   };
   type: "video";
   url: string;
-};
+})[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:309](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L309)
+Defined in: [packages/sdk/src/indexer/schemas.ts:342](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L342)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType.mdx
@@ -97,4 +97,4 @@ type IndexerAPICommentReferencesSchemaType = (
 })[];
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:322](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L322)
+Defined in: [packages/sdk/src/indexer/schemas.ts:338](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L338)

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPICommentSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:356](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L356)
+Defined in: [packages/sdk/src/indexer/schemas.ts:376](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L376)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesOutputSchemaType.mdx
@@ -587,7 +587,7 @@ type IndexerAPICommentWithRepliesOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:426](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L426)
+Defined in: [packages/sdk/src/indexer/schemas.ts:446](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L446)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPICommentWithRepliesSchemaType.mdx
@@ -587,7 +587,7 @@ type IndexerAPICommentWithRepliesSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:413](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L413)
+Defined in: [packages/sdk/src/indexer/schemas.ts:433](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L433)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIExtraSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIExtraSchemaType.mdx
@@ -13,7 +13,7 @@ type IndexerAPIExtraSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:402](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L402)
+Defined in: [packages/sdk/src/indexer/schemas.ts:422](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L422)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIGetAutocompleteOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIGetAutocompleteOutputSchemaType.mdx
@@ -42,7 +42,7 @@ type IndexerAPIGetAutocompleteOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:611](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L611)
+Defined in: [packages/sdk/src/indexer/schemas.ts:631](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L631)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesOutputSchemaType.mdx
@@ -506,7 +506,7 @@ type IndexerAPIListCommentRepliesOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:468](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L468)
+Defined in: [packages/sdk/src/indexer/schemas.ts:488](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L488)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentRepliesSchemaType.mdx
@@ -506,7 +506,7 @@ type IndexerAPIListCommentRepliesSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:457](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L457)
+Defined in: [packages/sdk/src/indexer/schemas.ts:477](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L477)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsOutputSchemaType.mdx
@@ -506,7 +506,7 @@ type IndexerAPIListCommentsOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:447](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L447)
+Defined in: [packages/sdk/src/indexer/schemas.ts:467](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L467)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIListCommentsSchemaType.mdx
@@ -506,7 +506,7 @@ type IndexerAPIListCommentsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:436](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L436)
+Defined in: [packages/sdk/src/indexer/schemas.ts:456](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L456)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:502](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L502)
+Defined in: [packages/sdk/src/indexer/schemas.ts:522](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L522)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationChangeModerationStatusOnCommentSchemaType.mdx
@@ -152,7 +152,7 @@ type IndexerAPIModerationChangeModerationStatusOnCommentSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:494](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L494)
+Defined in: [packages/sdk/src/indexer/schemas.ts:514](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L514)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsOutputSchemaType.mdx
@@ -161,7 +161,7 @@ type IndexerAPIModerationGetPendingCommentsOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:487](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L487)
+Defined in: [packages/sdk/src/indexer/schemas.ts:507](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L507)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIModerationGetPendingCommentsSchemaType.mdx
@@ -161,7 +161,7 @@ type IndexerAPIModerationGetPendingCommentsSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:477](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L477)
+Defined in: [packages/sdk/src/indexer/schemas.ts:497](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L497)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIPaginationSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIPaginationSchemaType.mdx
@@ -14,7 +14,7 @@ type IndexerAPIPaginationSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:393](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L393)
+Defined in: [packages/sdk/src/indexer/schemas.ts:413](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L413)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportOutputSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPIReportOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:639](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L639)
+Defined in: [packages/sdk/src/indexer/schemas.ts:659](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L659)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportSchemaType.mdx
@@ -18,7 +18,7 @@ type IndexerAPIReportSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:631](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L631)
+Defined in: [packages/sdk/src/indexer/schemas.ts:651](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L651)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingOutputSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingOutputSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPIReportsListPendingOutputSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:658](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L658)
+Defined in: [packages/sdk/src/indexer/schemas.ts:678](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L678)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingSchemaType.mdx
+++ b/docs/pages/sdk-reference/indexer/type-aliases/IndexerAPIReportsListPendingSchemaType.mdx
@@ -27,7 +27,7 @@ type IndexerAPIReportsListPendingSchemaType = {
 };
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:648](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L648)
+Defined in: [packages/sdk/src/indexer/schemas.ts:668](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L668)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteENSSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteENSSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteENSSchema: ZodObject<IndexerAPIAutocompleteENSSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:544](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L544)
+Defined in: [packages/sdk/src/indexer/schemas.ts:564](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L564)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteERC20Schema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteERC20Schema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteERC20Schema: ZodObject<IndexerAPIAutocompleteERC20SchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:559](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L559)
+Defined in: [packages/sdk/src/indexer/schemas.ts:579](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L579)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteFarcasterSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteFarcasterSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteFarcasterSchema: ZodObject<IndexerAPIAutocompleteFarcasterSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:579](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L579)
+Defined in: [packages/sdk/src/indexer/schemas.ts:599](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L599)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIAutocompleteSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIAutocompleteSchema: ZodDiscriminatedUnion<IndexerAPIAutocompleteSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:597](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L597)
+Defined in: [packages/sdk/src/indexer/schemas.ts:617](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L617)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentOutputSchema: ZodObject<IndexerAPICommentOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:360](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L360)
+Defined in: [packages/sdk/src/indexer/schemas.ts:380](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L380)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionOutputSchema.mdx
@@ -92,23 +92,8 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
   moderationClassifierScore: ZodNumber;
   moderationStatus: ZodEnum<["approved", "rejected", "pending"]>;
   parentId: ZodNullable<ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>>;
-  references: ZodArray<ZodUnion<[ZodObject<{
-     address: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
-     avatarUrl: ZodNullable<ZodString>;
-     name: ZodString;
-     position: ZodObject<{
-        end: ZodNumber;
-        start: ZodNumber;
-      }, "strip", ZodTypeAny, {
-        end: number;
-        start: number;
-      }, {
-        end: number;
-        start: number;
-     }>;
-     type: ZodLiteral<"ens">;
-     url: ZodString;
-   }, "strip", ZodTypeAny, {
+  references: ZodType<(
+     | {
      address: `0x${string}`;
      avatarUrl: null | string;
      name: string;
@@ -118,45 +103,22 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
      };
      type: "ens";
      url: string;
-   }, {
+   }
+     | {
      address: `0x${string}`;
-     avatarUrl: null | string;
-     name: string;
+     displayName: null | string;
+     fid: number;
+     fname: string;
+     pfpUrl: null | string;
      position: {
         end: number;
         start: number;
      };
-     type: "ens";
+     type: "farcaster";
      url: string;
-   }>, ZodObject<{
-     address: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
-     chainId: ZodNullable<ZodNumber>;
-     chains: ZodArray<ZodObject<{
-        caip: ...;
-        chainId: ...;
-      }, "strip", ZodTypeAny, {
-        caip: ...;
-        chainId: ...;
-      }, {
-        caip: ...;
-        chainId: ...;
-     }>, "many">;
-     decimals: ZodNumber;
-     logoURI: ZodNullable<ZodString>;
-     name: ZodString;
-     position: ZodObject<{
-        end: ZodNumber;
-        start: ZodNumber;
-      }, "strip", ZodTypeAny, {
-        end: number;
-        start: number;
-      }, {
-        end: number;
-        start: number;
-     }>;
-     symbol: ZodString;
-     type: ZodLiteral<"erc20">;
-   }, "strip", ZodTypeAny, {
+     username: string;
+   }
+     | {
      address: `0x${string}`;
      chainId: null | number;
      chains: {
@@ -172,7 +134,78 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
      };
      symbol: string;
      type: "erc20";
-   }, {
+   }
+     | {
+     description: null | string;
+     favicon: null | string;
+     opengraph:   | null
+        | {
+        description: null | string;
+        image: string;
+        title: string;
+        url: string;
+      };
+     position: {
+        end: number;
+        start: number;
+     };
+     title: string;
+     type: "webpage";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "file";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "image";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "video";
+     url: string;
+   })[], ZodTypeDef, (
+     | {
+     address: `0x${string}`;
+     avatarUrl: null | string;
+     name: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "ens";
+     url: string;
+   }
+     | {
+     address: `0x${string}`;
+     displayName: null | string;
+     fid: number;
+     fname: string;
+     pfpUrl: null | string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "farcaster";
+     url: string;
+     username: string;
+   }
+     | {
      address: `0x${string}`;
      chainId: null | number;
      chains: {
@@ -188,52 +221,52 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
      };
      symbol: string;
      type: "erc20";
-   }>, ZodObject<{
-     address: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
-     displayName: ZodNullable<ZodString>;
-     fid: ZodNumber;
-     fname: ZodString;
-     pfpUrl: ZodNullable<ZodString>;
-     position: ZodObject<{
-        end: ZodNumber;
-        start: ZodNumber;
-      }, "strip", ZodTypeAny, {
-        end: number;
-        start: number;
-      }, {
-        end: number;
-        start: number;
-     }>;
-     type: ZodLiteral<"farcaster">;
-     url: ZodString;
-     username: ZodString;
-   }, "strip", ZodTypeAny, {
-     address: `0x${string}`;
-     displayName: null | string;
-     fid: number;
-     fname: string;
-     pfpUrl: null | string;
+   }
+     | {
+     description: null | string;
+     favicon: null | string;
+     opengraph:   | null
+        | {
+        description: null | string;
+        image: string;
+        title: string;
+        url: string;
+      };
      position: {
         end: number;
         start: number;
      };
-     type: "farcaster";
+     title: string;
+     type: "webpage";
      url: string;
-     username: string;
-   }, {
-     address: `0x${string}`;
-     displayName: null | string;
-     fid: number;
-     fname: string;
-     pfpUrl: null | string;
+   }
+     | {
+     mediaType: string;
      position: {
         end: number;
         start: number;
      };
-     type: "farcaster";
+     type: "file";
      url: string;
-     username: string;
-  }>]>, "many">;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "image";
+     url: string;
+   }
+     | {
+     mediaType: string;
+     position: {
+        end: number;
+        start: number;
+     };
+     type: "video";
+     url: string;
+  })[]>;
   revision: ZodNumber;
   targetUri: ZodString;
   txHash: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
@@ -340,7 +373,7 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
      moderationClassifierScore: ZodNumber;
      moderationStatus: ZodEnum<["approved", "rejected", "pending"]>;
      parentId: ZodNullable<ZodType<`0x${(...)}`, ZodTypeDef, `0x${(...)}`>>;
-     references: ZodArray<ZodUnion<[..., ..., ...]>, "many">;
+     references: ZodType<(... | ... | ... | ... | ... | ... | ...)[], ZodTypeDef, (... | ... | ... | ... | ... | ... | ...)[]>;
      revision: ZodNumber;
      targetUri: ZodString;
      txHash: ZodType<`0x${string}`, ZodTypeDef, `0x${string}`>;
@@ -1202,4 +1235,4 @@ const IndexerAPICommentReactionOutputSchema: ZodObject<{
 }>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:381](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L381)
+Defined in: [packages/sdk/src/indexer/schemas.ts:401](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L401)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReactionSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReactionSchema: ZodObject<IndexerAPICommentReactionSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:372](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L372)
+Defined in: [packages/sdk/src/indexer/schemas.ts:392](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L392)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceSchema: ZodUnion<IndexerAPICommentReferenceSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:304](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L304)
+Defined in: [packages/sdk/src/indexer/schemas.ts:299](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L299)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLFileSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLFileSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLFileSchema: ZodObject<IndexerAPICommentReferenceURLFileSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:271](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L271)
+Defined in: [packages/sdk/src/indexer/schemas.ts:266](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L266)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLImageSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLImageSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLImageSchema: ZodObject<IndexerAPICommentReferenceURLImageSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:282](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L282)
+Defined in: [packages/sdk/src/indexer/schemas.ts:277](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L277)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLVideoSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferenceURLVideoSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentReferenceURLVideoSchema: ZodObject<IndexerAPICommentReferenceURLVideoSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:293](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L293)
+Defined in: [packages/sdk/src/indexer/schemas.ts:288](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L288)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentReferencesSchema.mdx
@@ -7,7 +7,7 @@
 # Variable: IndexerAPICommentReferencesSchema
 
 ```ts
-const IndexerAPICommentReferencesSchema: ZodArray<IndexerAPICommentReferencesSchemaType>;
+const IndexerAPICommentReferencesSchema: ZodType<IndexerAPICommentReferencesSchemaInputType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:318](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L318)
+Defined in: [packages/sdk/src/indexer/schemas.ts:313](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L313)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentSchema: ZodObject<IndexerAPICommentSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:326](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L326)
+Defined in: [packages/sdk/src/indexer/schemas.ts:346](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L346)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentWithRepliesOutputSchema: ZodObject<IndexerAPICommentWithRepliesOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:417](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L417)
+Defined in: [packages/sdk/src/indexer/schemas.ts:437](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L437)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPICommentWithRepliesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPICommentWithRepliesSchema: ZodObject<IndexerAPICommentWithRepliesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:404](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L404)
+Defined in: [packages/sdk/src/indexer/schemas.ts:424](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L424)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIExtraSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIExtraSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIExtraSchema: ZodObject<IndexerAPIExtraSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:397](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L397)
+Defined in: [packages/sdk/src/indexer/schemas.ts:417](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L417)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIGetAutocompleteOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIGetAutocompleteOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIGetAutocompleteOutputSchema: ZodObject<IndexerAPIGetAutocompleteOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:607](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L607)
+Defined in: [packages/sdk/src/indexer/schemas.ts:627](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L627)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentRepliesOutputSchema: ZodObject<IndexerAPIListCommentRepliesOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:461](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L461)
+Defined in: [packages/sdk/src/indexer/schemas.ts:481](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L481)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentRepliesSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentRepliesSchema: ZodObject<IndexerAPIListCommentRepliesSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:451](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L451)
+Defined in: [packages/sdk/src/indexer/schemas.ts:471](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L471)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentsOutputSchema: ZodObject<IndexerAPIListCommentsOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:440](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L440)
+Defined in: [packages/sdk/src/indexer/schemas.ts:460](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L460)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIListCommentsSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIListCommentsSchema: ZodObject<IndexerAPIListCommentsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:430](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L430)
+Defined in: [packages/sdk/src/indexer/schemas.ts:450](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L450)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationChangeModerationStatusOnCommentOutputSchema: ZodObject<IndexerAPIModerationChangeModerationStatusOnCommentOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:497](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L497)
+Defined in: [packages/sdk/src/indexer/schemas.ts:517](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L517)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationChangeModerationStatusOnCommentSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationChangeModerationStatusOnCommentSchema: ZodObject<IndexerAPIModerationChangeModerationStatusOnCommentSchemaType> = IndexerAPICommentSchema;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:491](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L491)
+Defined in: [packages/sdk/src/indexer/schemas.ts:511](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L511)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationGetPendingCommentsOutputSchema: ZodObject<IndexerAPIModerationGetPendingCommentsOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:481](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L481)
+Defined in: [packages/sdk/src/indexer/schemas.ts:501](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L501)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIModerationGetPendingCommentsSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIModerationGetPendingCommentsSchema: ZodObject<IndexerAPIModerationGetPendingCommentsSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:472](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L472)
+Defined in: [packages/sdk/src/indexer/schemas.ts:492](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L492)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIPaginationSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIPaginationSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIPaginationSchema: ZodObject<IndexerAPIPaginationSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:387](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L387)
+Defined in: [packages/sdk/src/indexer/schemas.ts:407](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L407)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportOutputSchema: ZodObject<IndexerAPIReportOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:633](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L633)
+Defined in: [packages/sdk/src/indexer/schemas.ts:653](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L653)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportSchema: ZodObject<IndexerAPIReportSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:621](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L621)
+Defined in: [packages/sdk/src/indexer/schemas.ts:641](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L641)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportStatusSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportStatusSchema: ZodEnum<["pending", "resolved", "closed"]>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:615](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L615)
+Defined in: [packages/sdk/src/indexer/schemas.ts:635](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L635)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingOutputSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingOutputSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportsListPendingOutputSchema: ZodObject<IndexerAPIReportsListPendingOutputSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:652](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L652)
+Defined in: [packages/sdk/src/indexer/schemas.ts:672](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L672)

--- a/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx
+++ b/docs/pages/sdk-reference/indexer/variables/IndexerAPIReportsListPendingSchema.mdx
@@ -10,4 +10,4 @@
 const IndexerAPIReportsListPendingSchema: ZodObject<IndexerAPIReportsListPendingSchemaType>;
 ```
 
-Defined in: [packages/sdk/src/indexer/schemas.ts:643](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L643)
+Defined in: [packages/sdk/src/indexer/schemas.ts:663](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/indexer/schemas.ts#L663)

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -422,279 +422,282 @@ paths:
                     type: array
                     items:
                       anyOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - ens
-                            avatarUrl:
-                              type:
-                                - string
-                                - 'null'
-                            name:
-                              type: string
-                            address: {}
-                            position:
-                              type: object
+                        - anyOf:
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - ens
+                                avatarUrl:
+                                  type:
+                                    - string
+                                    - 'null'
+                                name:
+                                  type: string
+                                address: {}
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - start
-                                - end
-                            url:
-                              type: string
-                              format: uri
-                          required:
-                            - type
-                            - avatarUrl
-                            - name
-                            - address
-                            - position
-                            - url
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - erc20
-                            symbol:
-                              type: string
-                            logoURI:
-                              type:
-                                - string
-                                - 'null'
-                            name:
-                              type: string
-                            address: {}
-                            decimals:
-                              type: integer
-                            position:
-                              type: object
+                                - type
+                                - avatarUrl
+                                - name
+                                - address
+                                - position
+                                - url
+                            - type: object
                               properties:
-                                start:
+                                type:
+                                  type: string
+                                  enum:
+                                    - erc20
+                                symbol:
+                                  type: string
+                                logoURI:
+                                  type:
+                                    - string
+                                    - 'null'
+                                name:
+                                  type: string
+                                address: {}
+                                decimals:
                                   type: integer
-                                end:
-                                  type: integer
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                chainId:
+                                  type:
+                                    - integer
+                                    - 'null'
+                                  exclusiveMinimum: 0
+                                chains:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      caip:
+                                        type: string
+                                      chainId:
+                                        type: integer
+                                        exclusiveMinimum: 0
+                                    required:
+                                      - caip
+                                      - chainId
                               required:
-                                - start
-                                - end
-                            chainId:
-                              type:
-                                - integer
-                                - 'null'
-                              exclusiveMinimum: 0
-                            chains:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  caip:
-                                    type: string
-                                  chainId:
-                                    type: integer
-                                    exclusiveMinimum: 0
-                                required:
-                                  - caip
-                                  - chainId
-                          required:
-                            - type
-                            - symbol
-                            - logoURI
-                            - name
-                            - address
-                            - decimals
-                            - position
-                            - chainId
-                            - chains
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - farcaster
-                            address: {}
-                            fid:
-                              type: integer
-                            fname:
-                              type: string
-                            username:
-                              type: string
-                            displayName:
-                              type:
-                                - string
-                                - 'null'
-                            pfpUrl:
-                              type:
-                                - string
-                                - 'null'
-                            position:
-                              type: object
+                                - type
+                                - symbol
+                                - logoURI
+                                - name
+                                - address
+                                - decimals
+                                - position
+                                - chainId
+                                - chains
+                            - type: object
                               properties:
-                                start:
+                                type:
+                                  type: string
+                                  enum:
+                                    - farcaster
+                                address: {}
+                                fid:
                                   type: integer
-                                end:
-                                  type: integer
+                                fname:
+                                  type: string
+                                username:
+                                  type: string
+                                displayName:
+                                  type:
+                                    - string
+                                    - 'null'
+                                pfpUrl:
+                                  type:
+                                    - string
+                                    - 'null'
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - start
-                                - end
-                            url:
-                              type: string
-                              format: uri
-                          required:
-                            - type
-                            - address
-                            - fid
-                            - fname
-                            - username
-                            - displayName
-                            - pfpUrl
-                            - position
-                            - url
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - webpage
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - type
+                                - address
+                                - fid
+                                - fname
+                                - username
+                                - displayName
+                                - pfpUrl
+                                - position
+                                - url
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
-                              required:
-                                - start
-                                - end
-                            title:
-                              type: string
-                            description:
-                              type:
-                                - string
-                                - 'null'
-                            favicon:
-                              type:
-                                - string
-                                - 'null'
-                              format: uri
-                            opengraph:
-                              type:
-                                - object
-                                - 'null'
-                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - webpage
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
                                 title:
                                   type: string
                                 description:
                                   type:
                                     - string
                                     - 'null'
-                                image:
-                                  anyOf:
-                                    - type: string
+                                favicon:
+                                  type:
+                                    - string
+                                    - 'null'
+                                  format: uri
+                                opengraph:
+                                  type:
+                                    - object
+                                    - 'null'
+                                  properties:
+                                    title:
+                                      type: string
+                                    description:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    image:
+                                      anyOf:
+                                        - type: string
+                                          format: uri
+                                        - type: string
+                                          pattern: ^\/[^\s]+$
+                                    url:
+                                      type: string
                                       format: uri
-                                    - type: string
-                                      pattern: ^\/[^\s]+$
+                                  required:
+                                    - title
+                                    - description
+                                    - image
+                                    - url
+                              required:
+                                - type
+                                - url
+                                - position
+                                - title
+                                - description
+                                - favicon
+                                - opengraph
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - file
                                 url:
                                   type: string
                                   format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - title
-                                - description
-                                - image
+                                - type
                                 - url
-                          required:
-                            - type
-                            - url
-                            - position
-                            - title
-                            - description
-                            - favicon
-                            - opengraph
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - file
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - position
+                                - mediaType
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - image
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - image
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - type
+                                - url
+                                - position
+                                - mediaType
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - video
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - video
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
-                              properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
-                              required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
+                                - type
+                                - url
+                                - position
+                                - mediaType
+                        - type: 'null'
+                        - type: 'null'
                   viewerReactions:
                     type: object
                     additionalProperties:
@@ -854,279 +857,282 @@ paths:
                             type: array
                             items:
                               anyOf:
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - ens
-                                    avatarUrl:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    name:
-                                      type: string
-                                    address: {}
-                                    position:
-                                      type: object
+                                - anyOf:
+                                    - type: object
                                       properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
+                                        type:
+                                          type: string
+                                          enum:
+                                            - ens
+                                        avatarUrl:
+                                          type:
+                                            - string
+                                            - 'null'
+                                        name:
+                                          type: string
+                                        address: {}
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
+                                        url:
+                                          type: string
+                                          format: uri
                                       required:
-                                        - start
-                                        - end
-                                    url:
-                                      type: string
-                                      format: uri
-                                  required:
-                                    - type
-                                    - avatarUrl
-                                    - name
-                                    - address
-                                    - position
-                                    - url
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - erc20
-                                    symbol:
-                                      type: string
-                                    logoURI:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    name:
-                                      type: string
-                                    address: {}
-                                    decimals:
-                                      type: integer
-                                    position:
-                                      type: object
+                                        - type
+                                        - avatarUrl
+                                        - name
+                                        - address
+                                        - position
+                                        - url
+                                    - type: object
                                       properties:
-                                        start:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - erc20
+                                        symbol:
+                                          type: string
+                                        logoURI:
+                                          type:
+                                            - string
+                                            - 'null'
+                                        name:
+                                          type: string
+                                        address: {}
+                                        decimals:
                                           type: integer
-                                        end:
-                                          type: integer
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
+                                        chainId:
+                                          type:
+                                            - integer
+                                            - 'null'
+                                          exclusiveMinimum: 0
+                                        chains:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              caip:
+                                                type: string
+                                              chainId:
+                                                type: integer
+                                                exclusiveMinimum: 0
+                                            required:
+                                              - caip
+                                              - chainId
                                       required:
-                                        - start
-                                        - end
-                                    chainId:
-                                      type:
-                                        - integer
-                                        - 'null'
-                                      exclusiveMinimum: 0
-                                    chains:
-                                      type: array
-                                      items:
-                                        type: object
-                                        properties:
-                                          caip:
-                                            type: string
-                                          chainId:
-                                            type: integer
-                                            exclusiveMinimum: 0
-                                        required:
-                                          - caip
-                                          - chainId
-                                  required:
-                                    - type
-                                    - symbol
-                                    - logoURI
-                                    - name
-                                    - address
-                                    - decimals
-                                    - position
-                                    - chainId
-                                    - chains
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - farcaster
-                                    address: {}
-                                    fid:
-                                      type: integer
-                                    fname:
-                                      type: string
-                                    username:
-                                      type: string
-                                    displayName:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    pfpUrl:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    position:
-                                      type: object
+                                        - type
+                                        - symbol
+                                        - logoURI
+                                        - name
+                                        - address
+                                        - decimals
+                                        - position
+                                        - chainId
+                                        - chains
+                                    - type: object
                                       properties:
-                                        start:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - farcaster
+                                        address: {}
+                                        fid:
                                           type: integer
-                                        end:
-                                          type: integer
+                                        fname:
+                                          type: string
+                                        username:
+                                          type: string
+                                        displayName:
+                                          type:
+                                            - string
+                                            - 'null'
+                                        pfpUrl:
+                                          type:
+                                            - string
+                                            - 'null'
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
+                                        url:
+                                          type: string
+                                          format: uri
                                       required:
-                                        - start
-                                        - end
-                                    url:
-                                      type: string
-                                      format: uri
-                                  required:
-                                    - type
-                                    - address
-                                    - fid
-                                    - fname
-                                    - username
-                                    - displayName
-                                    - pfpUrl
-                                    - position
-                                    - url
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - webpage
-                                    url:
-                                      type: string
-                                      format: uri
-                                    position:
-                                      type: object
+                                        - type
+                                        - address
+                                        - fid
+                                        - fname
+                                        - username
+                                        - displayName
+                                        - pfpUrl
+                                        - position
+                                        - url
+                                    - type: object
                                       properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
-                                      required:
-                                        - start
-                                        - end
-                                    title:
-                                      type: string
-                                    description:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    favicon:
-                                      type:
-                                        - string
-                                        - 'null'
-                                      format: uri
-                                    opengraph:
-                                      type:
-                                        - object
-                                        - 'null'
-                                      properties:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - webpage
+                                        url:
+                                          type: string
+                                          format: uri
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
                                         title:
                                           type: string
                                         description:
                                           type:
                                             - string
                                             - 'null'
-                                        image:
-                                          anyOf:
-                                            - type: string
+                                        favicon:
+                                          type:
+                                            - string
+                                            - 'null'
+                                          format: uri
+                                        opengraph:
+                                          type:
+                                            - object
+                                            - 'null'
+                                          properties:
+                                            title:
+                                              type: string
+                                            description:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            image:
+                                              anyOf:
+                                                - type: string
+                                                  format: uri
+                                                - type: string
+                                                  pattern: ^\/[^\s]+$
+                                            url:
+                                              type: string
                                               format: uri
-                                            - type: string
-                                              pattern: ^\/[^\s]+$
+                                          required:
+                                            - title
+                                            - description
+                                            - image
+                                            - url
+                                      required:
+                                        - type
+                                        - url
+                                        - position
+                                        - title
+                                        - description
+                                        - favicon
+                                        - opengraph
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          enum:
+                                            - file
                                         url:
                                           type: string
                                           format: uri
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
+                                        mediaType:
+                                          type: string
                                       required:
-                                        - title
-                                        - description
-                                        - image
+                                        - type
                                         - url
-                                  required:
-                                    - type
-                                    - url
-                                    - position
-                                    - title
-                                    - description
-                                    - favicon
-                                    - opengraph
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - file
-                                    url:
-                                      type: string
-                                      format: uri
-                                    position:
-                                      type: object
+                                        - position
+                                        - mediaType
+                                    - type: object
                                       properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
+                                        type:
+                                          type: string
+                                          enum:
+                                            - image
+                                        url:
+                                          type: string
+                                          format: uri
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
+                                        mediaType:
+                                          type: string
                                       required:
-                                        - start
-                                        - end
-                                    mediaType:
-                                      type: string
-                                  required:
-                                    - type
-                                    - url
-                                    - position
-                                    - mediaType
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - image
-                                    url:
-                                      type: string
-                                      format: uri
-                                    position:
-                                      type: object
+                                        - type
+                                        - url
+                                        - position
+                                        - mediaType
+                                    - type: object
                                       properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
+                                        type:
+                                          type: string
+                                          enum:
+                                            - video
+                                        url:
+                                          type: string
+                                          format: uri
+                                        position:
+                                          type: object
+                                          properties:
+                                            start:
+                                              type: integer
+                                            end:
+                                              type: integer
+                                          required:
+                                            - start
+                                            - end
+                                        mediaType:
+                                          type: string
                                       required:
-                                        - start
-                                        - end
-                                    mediaType:
-                                      type: string
-                                  required:
-                                    - type
-                                    - url
-                                    - position
-                                    - mediaType
-                                - type: object
-                                  properties:
-                                    type:
-                                      type: string
-                                      enum:
-                                        - video
-                                    url:
-                                      type: string
-                                      format: uri
-                                    position:
-                                      type: object
-                                      properties:
-                                        start:
-                                          type: integer
-                                        end:
-                                          type: integer
-                                      required:
-                                        - start
-                                        - end
-                                    mediaType:
-                                      type: string
-                                  required:
-                                    - type
-                                    - url
-                                    - position
-                                    - mediaType
+                                        - type
+                                        - url
+                                        - position
+                                        - mediaType
+                                - type: 'null'
+                                - type: 'null'
                         required:
                           - app
                           - author
@@ -1328,279 +1334,282 @@ paths:
                               type: array
                               items:
                                 anyOf:
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - ens
-                                      avatarUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      position:
-                                        type: object
+                                  - anyOf:
+                                      - type: object
                                         properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
+                                          type:
+                                            type: string
+                                            enum:
+                                              - ens
+                                          avatarUrl:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          name:
+                                            type: string
+                                          address: {}
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          url:
+                                            type: string
+                                            format: uri
                                         required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
-                                    required:
-                                      - type
-                                      - avatarUrl
-                                      - name
-                                      - address
-                                      - position
-                                      - url
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - erc20
-                                      symbol:
-                                        type: string
-                                      logoURI:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      decimals:
-                                        type: integer
-                                      position:
-                                        type: object
+                                          - type
+                                          - avatarUrl
+                                          - name
+                                          - address
+                                          - position
+                                          - url
+                                      - type: object
                                         properties:
-                                          start:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - erc20
+                                          symbol:
+                                            type: string
+                                          logoURI:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          name:
+                                            type: string
+                                          address: {}
+                                          decimals:
                                             type: integer
-                                          end:
-                                            type: integer
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          chainId:
+                                            type:
+                                              - integer
+                                              - 'null'
+                                            exclusiveMinimum: 0
+                                          chains:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                caip:
+                                                  type: string
+                                                chainId:
+                                                  type: integer
+                                                  exclusiveMinimum: 0
+                                              required:
+                                                - caip
+                                                - chainId
                                         required:
-                                          - start
-                                          - end
-                                      chainId:
-                                        type:
-                                          - integer
-                                          - 'null'
-                                        exclusiveMinimum: 0
-                                      chains:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            caip:
-                                              type: string
-                                            chainId:
-                                              type: integer
-                                              exclusiveMinimum: 0
-                                          required:
-                                            - caip
-                                            - chainId
-                                    required:
-                                      - type
-                                      - symbol
-                                      - logoURI
-                                      - name
-                                      - address
-                                      - decimals
-                                      - position
-                                      - chainId
-                                      - chains
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - farcaster
-                                      address: {}
-                                      fid:
-                                        type: integer
-                                      fname:
-                                        type: string
-                                      username:
-                                        type: string
-                                      displayName:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      pfpUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      position:
-                                        type: object
+                                          - type
+                                          - symbol
+                                          - logoURI
+                                          - name
+                                          - address
+                                          - decimals
+                                          - position
+                                          - chainId
+                                          - chains
+                                      - type: object
                                         properties:
-                                          start:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - farcaster
+                                          address: {}
+                                          fid:
                                             type: integer
-                                          end:
-                                            type: integer
+                                          fname:
+                                            type: string
+                                          username:
+                                            type: string
+                                          displayName:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          pfpUrl:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          url:
+                                            type: string
+                                            format: uri
                                         required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
-                                    required:
-                                      - type
-                                      - address
-                                      - fid
-                                      - fname
-                                      - username
-                                      - displayName
-                                      - pfpUrl
-                                      - position
-                                      - url
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - webpage
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
+                                          - type
+                                          - address
+                                          - fid
+                                          - fname
+                                          - username
+                                          - displayName
+                                          - pfpUrl
+                                          - position
+                                          - url
+                                      - type: object
                                         properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      title:
-                                        type: string
-                                      description:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      favicon:
-                                        type:
-                                          - string
-                                          - 'null'
-                                        format: uri
-                                      opengraph:
-                                        type:
-                                          - object
-                                          - 'null'
-                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - webpage
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
                                           title:
                                             type: string
                                           description:
                                             type:
                                               - string
                                               - 'null'
-                                          image:
-                                            anyOf:
-                                              - type: string
+                                          favicon:
+                                            type:
+                                              - string
+                                              - 'null'
+                                            format: uri
+                                          opengraph:
+                                            type:
+                                              - object
+                                              - 'null'
+                                            properties:
+                                              title:
+                                                type: string
+                                              description:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              image:
+                                                anyOf:
+                                                  - type: string
+                                                    format: uri
+                                                  - type: string
+                                                    pattern: ^\/[^\s]+$
+                                              url:
+                                                type: string
                                                 format: uri
-                                              - type: string
-                                                pattern: ^\/[^\s]+$
+                                            required:
+                                              - title
+                                              - description
+                                              - image
+                                              - url
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - title
+                                          - description
+                                          - favicon
+                                          - opengraph
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - file
                                           url:
                                             type: string
                                             format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
                                         required:
-                                          - title
-                                          - description
-                                          - image
+                                          - type
                                           - url
-                                    required:
-                                      - type
-                                      - url
-                                      - position
-                                      - title
-                                      - description
-                                      - favicon
-                                      - opengraph
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - file
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
+                                          - position
+                                          - mediaType
+                                      - type: object
                                         properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
+                                          type:
+                                            type: string
+                                            enum:
+                                              - image
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
                                         required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
-                                    required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - image
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - type: object
                                         properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
+                                          type:
+                                            type: string
+                                            enum:
+                                              - video
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
                                         required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
-                                    required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - video
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
-                                    required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                  - type: 'null'
+                                  - type: 'null'
                             viewerReactions:
                               type: object
                               additionalProperties:
@@ -1760,279 +1769,282 @@ paths:
                                       type: array
                                       items:
                                         anyOf:
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - ens
-                                              avatarUrl:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              name:
-                                                type: string
-                                              address: {}
-                                              position:
-                                                type: object
+                                          - anyOf:
+                                              - type: object
                                                 properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - ens
+                                                  avatarUrl:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                  name:
+                                                    type: string
+                                                  address: {}
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
+                                                  url:
+                                                    type: string
+                                                    format: uri
                                                 required:
-                                                  - start
-                                                  - end
-                                              url:
-                                                type: string
-                                                format: uri
-                                            required:
-                                              - type
-                                              - avatarUrl
-                                              - name
-                                              - address
-                                              - position
-                                              - url
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - erc20
-                                              symbol:
-                                                type: string
-                                              logoURI:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              name:
-                                                type: string
-                                              address: {}
-                                              decimals:
-                                                type: integer
-                                              position:
-                                                type: object
+                                                  - type
+                                                  - avatarUrl
+                                                  - name
+                                                  - address
+                                                  - position
+                                                  - url
+                                              - type: object
                                                 properties:
-                                                  start:
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - erc20
+                                                  symbol:
+                                                    type: string
+                                                  logoURI:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                  name:
+                                                    type: string
+                                                  address: {}
+                                                  decimals:
                                                     type: integer
-                                                  end:
-                                                    type: integer
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
+                                                  chainId:
+                                                    type:
+                                                      - integer
+                                                      - 'null'
+                                                    exclusiveMinimum: 0
+                                                  chains:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                      properties:
+                                                        caip:
+                                                          type: string
+                                                        chainId:
+                                                          type: integer
+                                                          exclusiveMinimum: 0
+                                                      required:
+                                                        - caip
+                                                        - chainId
                                                 required:
-                                                  - start
-                                                  - end
-                                              chainId:
-                                                type:
-                                                  - integer
-                                                  - 'null'
-                                                exclusiveMinimum: 0
-                                              chains:
-                                                type: array
-                                                items:
-                                                  type: object
-                                                  properties:
-                                                    caip:
-                                                      type: string
-                                                    chainId:
-                                                      type: integer
-                                                      exclusiveMinimum: 0
-                                                  required:
-                                                    - caip
-                                                    - chainId
-                                            required:
-                                              - type
-                                              - symbol
-                                              - logoURI
-                                              - name
-                                              - address
-                                              - decimals
-                                              - position
-                                              - chainId
-                                              - chains
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - farcaster
-                                              address: {}
-                                              fid:
-                                                type: integer
-                                              fname:
-                                                type: string
-                                              username:
-                                                type: string
-                                              displayName:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              pfpUrl:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              position:
-                                                type: object
+                                                  - type
+                                                  - symbol
+                                                  - logoURI
+                                                  - name
+                                                  - address
+                                                  - decimals
+                                                  - position
+                                                  - chainId
+                                                  - chains
+                                              - type: object
                                                 properties:
-                                                  start:
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - farcaster
+                                                  address: {}
+                                                  fid:
                                                     type: integer
-                                                  end:
-                                                    type: integer
+                                                  fname:
+                                                    type: string
+                                                  username:
+                                                    type: string
+                                                  displayName:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                  pfpUrl:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
+                                                  url:
+                                                    type: string
+                                                    format: uri
                                                 required:
-                                                  - start
-                                                  - end
-                                              url:
-                                                type: string
-                                                format: uri
-                                            required:
-                                              - type
-                                              - address
-                                              - fid
-                                              - fname
-                                              - username
-                                              - displayName
-                                              - pfpUrl
-                                              - position
-                                              - url
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - webpage
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
+                                                  - type
+                                                  - address
+                                                  - fid
+                                                  - fname
+                                                  - username
+                                                  - displayName
+                                                  - pfpUrl
+                                                  - position
+                                                  - url
+                                              - type: object
                                                 properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              title:
-                                                type: string
-                                              description:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              favicon:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                                format: uri
-                                              opengraph:
-                                                type:
-                                                  - object
-                                                  - 'null'
-                                                properties:
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - webpage
+                                                  url:
+                                                    type: string
+                                                    format: uri
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
                                                   title:
                                                     type: string
                                                   description:
                                                     type:
                                                       - string
                                                       - 'null'
-                                                  image:
-                                                    anyOf:
-                                                      - type: string
+                                                  favicon:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                    format: uri
+                                                  opengraph:
+                                                    type:
+                                                      - object
+                                                      - 'null'
+                                                    properties:
+                                                      title:
+                                                        type: string
+                                                      description:
+                                                        type:
+                                                          - string
+                                                          - 'null'
+                                                      image:
+                                                        anyOf:
+                                                          - type: string
+                                                            format: uri
+                                                          - type: string
+                                                            pattern: ^\/[^\s]+$
+                                                      url:
+                                                        type: string
                                                         format: uri
-                                                      - type: string
-                                                        pattern: ^\/[^\s]+$
+                                                    required:
+                                                      - title
+                                                      - description
+                                                      - image
+                                                      - url
+                                                required:
+                                                  - type
+                                                  - url
+                                                  - position
+                                                  - title
+                                                  - description
+                                                  - favicon
+                                                  - opengraph
+                                              - type: object
+                                                properties:
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - file
                                                   url:
                                                     type: string
                                                     format: uri
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
+                                                  mediaType:
+                                                    type: string
                                                 required:
-                                                  - title
-                                                  - description
-                                                  - image
+                                                  - type
                                                   - url
-                                            required:
-                                              - type
-                                              - url
-                                              - position
-                                              - title
-                                              - description
-                                              - favicon
-                                              - opengraph
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - file
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
+                                                  - position
+                                                  - mediaType
+                                              - type: object
                                                 properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - image
+                                                  url:
+                                                    type: string
+                                                    format: uri
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
+                                                  mediaType:
+                                                    type: string
                                                 required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
-                                            required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - image
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
+                                                  - type
+                                                  - url
+                                                  - position
+                                                  - mediaType
+                                              - type: object
                                                 properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
+                                                  type:
+                                                    type: string
+                                                    enum:
+                                                      - video
+                                                  url:
+                                                    type: string
+                                                    format: uri
+                                                  position:
+                                                    type: object
+                                                    properties:
+                                                      start:
+                                                        type: integer
+                                                      end:
+                                                        type: integer
+                                                    required:
+                                                      - start
+                                                      - end
+                                                  mediaType:
+                                                    type: string
                                                 required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
-                                            required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - video
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
-                                            required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
+                                                  - type
+                                                  - url
+                                                  - position
+                                                  - mediaType
+                                          - type: 'null'
+                                          - type: 'null'
                                   required:
                                     - app
                                     - author
@@ -2458,279 +2470,282 @@ paths:
                           type: array
                           items:
                             anyOf:
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - ens
-                                  avatarUrl:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  name:
-                                    type: string
-                                  address: {}
-                                  position:
-                                    type: object
+                              - anyOf:
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - ens
+                                      avatarUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - start
-                                      - end
-                                  url:
-                                    type: string
-                                    format: uri
-                                required:
-                                  - type
-                                  - avatarUrl
-                                  - name
-                                  - address
-                                  - position
-                                  - url
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - erc20
-                                  symbol:
-                                    type: string
-                                  logoURI:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  name:
-                                    type: string
-                                  address: {}
-                                  decimals:
-                                    type: integer
-                                  position:
-                                    type: object
+                                      - type
+                                      - avatarUrl
+                                      - name
+                                      - address
+                                      - position
+                                      - url
+                                  - type: object
                                     properties:
-                                      start:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - erc20
+                                      symbol:
+                                        type: string
+                                      logoURI:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      decimals:
                                         type: integer
-                                      end:
-                                        type: integer
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      chainId:
+                                        type:
+                                          - integer
+                                          - 'null'
+                                        exclusiveMinimum: 0
+                                      chains:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            caip:
+                                              type: string
+                                            chainId:
+                                              type: integer
+                                              exclusiveMinimum: 0
+                                          required:
+                                            - caip
+                                            - chainId
                                     required:
-                                      - start
-                                      - end
-                                  chainId:
-                                    type:
-                                      - integer
-                                      - 'null'
-                                    exclusiveMinimum: 0
-                                  chains:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        caip:
-                                          type: string
-                                        chainId:
-                                          type: integer
-                                          exclusiveMinimum: 0
-                                      required:
-                                        - caip
-                                        - chainId
-                                required:
-                                  - type
-                                  - symbol
-                                  - logoURI
-                                  - name
-                                  - address
-                                  - decimals
-                                  - position
-                                  - chainId
-                                  - chains
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - farcaster
-                                  address: {}
-                                  fid:
-                                    type: integer
-                                  fname:
-                                    type: string
-                                  username:
-                                    type: string
-                                  displayName:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  pfpUrl:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  position:
-                                    type: object
+                                      - type
+                                      - symbol
+                                      - logoURI
+                                      - name
+                                      - address
+                                      - decimals
+                                      - position
+                                      - chainId
+                                      - chains
+                                  - type: object
                                     properties:
-                                      start:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - farcaster
+                                      address: {}
+                                      fid:
                                         type: integer
-                                      end:
-                                        type: integer
+                                      fname:
+                                        type: string
+                                      username:
+                                        type: string
+                                      displayName:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      pfpUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - start
-                                      - end
-                                  url:
-                                    type: string
-                                    format: uri
-                                required:
-                                  - type
-                                  - address
-                                  - fid
-                                  - fname
-                                  - username
-                                  - displayName
-                                  - pfpUrl
-                                  - position
-                                  - url
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - webpage
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - type
+                                      - address
+                                      - fid
+                                      - fname
+                                      - username
+                                      - displayName
+                                      - pfpUrl
+                                      - position
+                                      - url
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
-                                    required:
-                                      - start
-                                      - end
-                                  title:
-                                    type: string
-                                  description:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  favicon:
-                                    type:
-                                      - string
-                                      - 'null'
-                                    format: uri
-                                  opengraph:
-                                    type:
-                                      - object
-                                      - 'null'
-                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - webpage
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
                                       title:
                                         type: string
                                       description:
                                         type:
                                           - string
                                           - 'null'
-                                      image:
-                                        anyOf:
-                                          - type: string
+                                      favicon:
+                                        type:
+                                          - string
+                                          - 'null'
+                                        format: uri
+                                      opengraph:
+                                        type:
+                                          - object
+                                          - 'null'
+                                        properties:
+                                          title:
+                                            type: string
+                                          description:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          image:
+                                            anyOf:
+                                              - type: string
+                                                format: uri
+                                              - type: string
+                                                pattern: ^\/[^\s]+$
+                                          url:
+                                            type: string
                                             format: uri
-                                          - type: string
-                                            pattern: ^\/[^\s]+$
+                                        required:
+                                          - title
+                                          - description
+                                          - image
+                                          - url
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - title
+                                      - description
+                                      - favicon
+                                      - opengraph
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - file
                                       url:
                                         type: string
                                         format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - title
-                                      - description
-                                      - image
+                                      - type
                                       - url
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - title
-                                  - description
-                                  - favicon
-                                  - opengraph
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - file
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - position
+                                      - mediaType
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - image
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - image
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - video
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - video
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
-                                    properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
-                                    required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                              - type: 'null'
+                              - type: 'null'
                         viewerReactions:
                           type: object
                           additionalProperties:
@@ -2890,279 +2905,282 @@ paths:
                                   type: array
                                   items:
                                     anyOf:
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - ens
-                                          avatarUrl:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          name:
-                                            type: string
-                                          address: {}
-                                          position:
-                                            type: object
+                                      - anyOf:
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - ens
+                                              avatarUrl:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              name:
+                                                type: string
+                                              address: {}
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              url:
+                                                type: string
+                                                format: uri
                                             required:
-                                              - start
-                                              - end
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - type
-                                          - avatarUrl
-                                          - name
-                                          - address
-                                          - position
-                                          - url
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - erc20
-                                          symbol:
-                                            type: string
-                                          logoURI:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          name:
-                                            type: string
-                                          address: {}
-                                          decimals:
-                                            type: integer
-                                          position:
-                                            type: object
+                                              - type
+                                              - avatarUrl
+                                              - name
+                                              - address
+                                              - position
+                                              - url
+                                          - type: object
                                             properties:
-                                              start:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - erc20
+                                              symbol:
+                                                type: string
+                                              logoURI:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              name:
+                                                type: string
+                                              address: {}
+                                              decimals:
                                                 type: integer
-                                              end:
-                                                type: integer
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              chainId:
+                                                type:
+                                                  - integer
+                                                  - 'null'
+                                                exclusiveMinimum: 0
+                                              chains:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    caip:
+                                                      type: string
+                                                    chainId:
+                                                      type: integer
+                                                      exclusiveMinimum: 0
+                                                  required:
+                                                    - caip
+                                                    - chainId
                                             required:
-                                              - start
-                                              - end
-                                          chainId:
-                                            type:
-                                              - integer
-                                              - 'null'
-                                            exclusiveMinimum: 0
-                                          chains:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                caip:
-                                                  type: string
-                                                chainId:
-                                                  type: integer
-                                                  exclusiveMinimum: 0
-                                              required:
-                                                - caip
-                                                - chainId
-                                        required:
-                                          - type
-                                          - symbol
-                                          - logoURI
-                                          - name
-                                          - address
-                                          - decimals
-                                          - position
-                                          - chainId
-                                          - chains
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - farcaster
-                                          address: {}
-                                          fid:
-                                            type: integer
-                                          fname:
-                                            type: string
-                                          username:
-                                            type: string
-                                          displayName:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          pfpUrl:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          position:
-                                            type: object
+                                              - type
+                                              - symbol
+                                              - logoURI
+                                              - name
+                                              - address
+                                              - decimals
+                                              - position
+                                              - chainId
+                                              - chains
+                                          - type: object
                                             properties:
-                                              start:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - farcaster
+                                              address: {}
+                                              fid:
                                                 type: integer
-                                              end:
-                                                type: integer
+                                              fname:
+                                                type: string
+                                              username:
+                                                type: string
+                                              displayName:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              pfpUrl:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              url:
+                                                type: string
+                                                format: uri
                                             required:
-                                              - start
-                                              - end
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - type
-                                          - address
-                                          - fid
-                                          - fname
-                                          - username
-                                          - displayName
-                                          - pfpUrl
-                                          - position
-                                          - url
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - webpage
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
+                                              - type
+                                              - address
+                                              - fid
+                                              - fname
+                                              - username
+                                              - displayName
+                                              - pfpUrl
+                                              - position
+                                              - url
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          title:
-                                            type: string
-                                          description:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          favicon:
-                                            type:
-                                              - string
-                                              - 'null'
-                                            format: uri
-                                          opengraph:
-                                            type:
-                                              - object
-                                              - 'null'
-                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - webpage
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
                                               title:
                                                 type: string
                                               description:
                                                 type:
                                                   - string
                                                   - 'null'
-                                              image:
-                                                anyOf:
-                                                  - type: string
+                                              favicon:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                                format: uri
+                                              opengraph:
+                                                type:
+                                                  - object
+                                                  - 'null'
+                                                properties:
+                                                  title:
+                                                    type: string
+                                                  description:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                  image:
+                                                    anyOf:
+                                                      - type: string
+                                                        format: uri
+                                                      - type: string
+                                                        pattern: ^\/[^\s]+$
+                                                  url:
+                                                    type: string
                                                     format: uri
-                                                  - type: string
-                                                    pattern: ^\/[^\s]+$
+                                                required:
+                                                  - title
+                                                  - description
+                                                  - image
+                                                  - url
+                                            required:
+                                              - type
+                                              - url
+                                              - position
+                                              - title
+                                              - description
+                                              - favicon
+                                              - opengraph
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - file
                                               url:
                                                 type: string
                                                 format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
                                             required:
-                                              - title
-                                              - description
-                                              - image
+                                              - type
                                               - url
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - title
-                                          - description
-                                          - favicon
-                                          - opengraph
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - file
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
+                                              - position
+                                              - mediaType
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - image
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
                                             required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - image
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - video
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
                                             required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - video
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                      - type: 'null'
+                                      - type: 'null'
                               required:
                                 - app
                                 - author
@@ -3364,279 +3382,282 @@ paths:
                                     type: array
                                     items:
                                       anyOf:
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - ens
-                                            avatarUrl:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            name:
-                                              type: string
-                                            address: {}
-                                            position:
-                                              type: object
+                                        - anyOf:
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - ens
+                                                avatarUrl:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                name:
+                                                  type: string
+                                                address: {}
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                url:
+                                                  type: string
+                                                  format: uri
                                               required:
-                                                - start
-                                                - end
-                                            url:
-                                              type: string
-                                              format: uri
-                                          required:
-                                            - type
-                                            - avatarUrl
-                                            - name
-                                            - address
-                                            - position
-                                            - url
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - erc20
-                                            symbol:
-                                              type: string
-                                            logoURI:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            name:
-                                              type: string
-                                            address: {}
-                                            decimals:
-                                              type: integer
-                                            position:
-                                              type: object
+                                                - type
+                                                - avatarUrl
+                                                - name
+                                                - address
+                                                - position
+                                                - url
+                                            - type: object
                                               properties:
-                                                start:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - erc20
+                                                symbol:
+                                                  type: string
+                                                logoURI:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                name:
+                                                  type: string
+                                                address: {}
+                                                decimals:
                                                   type: integer
-                                                end:
-                                                  type: integer
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                chainId:
+                                                  type:
+                                                    - integer
+                                                    - 'null'
+                                                  exclusiveMinimum: 0
+                                                chains:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      caip:
+                                                        type: string
+                                                      chainId:
+                                                        type: integer
+                                                        exclusiveMinimum: 0
+                                                    required:
+                                                      - caip
+                                                      - chainId
                                               required:
-                                                - start
-                                                - end
-                                            chainId:
-                                              type:
-                                                - integer
-                                                - 'null'
-                                              exclusiveMinimum: 0
-                                            chains:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  caip:
-                                                    type: string
-                                                  chainId:
-                                                    type: integer
-                                                    exclusiveMinimum: 0
-                                                required:
-                                                  - caip
-                                                  - chainId
-                                          required:
-                                            - type
-                                            - symbol
-                                            - logoURI
-                                            - name
-                                            - address
-                                            - decimals
-                                            - position
-                                            - chainId
-                                            - chains
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - farcaster
-                                            address: {}
-                                            fid:
-                                              type: integer
-                                            fname:
-                                              type: string
-                                            username:
-                                              type: string
-                                            displayName:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            pfpUrl:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            position:
-                                              type: object
+                                                - type
+                                                - symbol
+                                                - logoURI
+                                                - name
+                                                - address
+                                                - decimals
+                                                - position
+                                                - chainId
+                                                - chains
+                                            - type: object
                                               properties:
-                                                start:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - farcaster
+                                                address: {}
+                                                fid:
                                                   type: integer
-                                                end:
-                                                  type: integer
+                                                fname:
+                                                  type: string
+                                                username:
+                                                  type: string
+                                                displayName:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                pfpUrl:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                url:
+                                                  type: string
+                                                  format: uri
                                               required:
-                                                - start
-                                                - end
-                                            url:
-                                              type: string
-                                              format: uri
-                                          required:
-                                            - type
-                                            - address
-                                            - fid
-                                            - fname
-                                            - username
-                                            - displayName
-                                            - pfpUrl
-                                            - position
-                                            - url
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - webpage
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
+                                                - type
+                                                - address
+                                                - fid
+                                                - fname
+                                                - username
+                                                - displayName
+                                                - pfpUrl
+                                                - position
+                                                - url
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
-                                              required:
-                                                - start
-                                                - end
-                                            title:
-                                              type: string
-                                            description:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            favicon:
-                                              type:
-                                                - string
-                                                - 'null'
-                                              format: uri
-                                            opengraph:
-                                              type:
-                                                - object
-                                                - 'null'
-                                              properties:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - webpage
+                                                url:
+                                                  type: string
+                                                  format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
                                                 title:
                                                   type: string
                                                 description:
                                                   type:
                                                     - string
                                                     - 'null'
-                                                image:
-                                                  anyOf:
-                                                    - type: string
+                                                favicon:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                  format: uri
+                                                opengraph:
+                                                  type:
+                                                    - object
+                                                    - 'null'
+                                                  properties:
+                                                    title:
+                                                      type: string
+                                                    description:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    image:
+                                                      anyOf:
+                                                        - type: string
+                                                          format: uri
+                                                        - type: string
+                                                          pattern: ^\/[^\s]+$
+                                                    url:
+                                                      type: string
                                                       format: uri
-                                                    - type: string
-                                                      pattern: ^\/[^\s]+$
+                                                  required:
+                                                    - title
+                                                    - description
+                                                    - image
+                                                    - url
+                                              required:
+                                                - type
+                                                - url
+                                                - position
+                                                - title
+                                                - description
+                                                - favicon
+                                                - opengraph
+                                            - type: object
+                                              properties:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - file
                                                 url:
                                                   type: string
                                                   format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                mediaType:
+                                                  type: string
                                               required:
-                                                - title
-                                                - description
-                                                - image
+                                                - type
                                                 - url
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - title
-                                            - description
-                                            - favicon
-                                            - opengraph
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - file
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
+                                                - position
+                                                - mediaType
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - image
+                                                url:
+                                                  type: string
+                                                  format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                mediaType:
+                                                  type: string
                                               required:
-                                                - start
-                                                - end
-                                            mediaType:
-                                              type: string
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - mediaType
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - image
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
+                                                - type
+                                                - url
+                                                - position
+                                                - mediaType
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - video
+                                                url:
+                                                  type: string
+                                                  format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                mediaType:
+                                                  type: string
                                               required:
-                                                - start
-                                                - end
-                                            mediaType:
-                                              type: string
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - mediaType
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - video
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
-                                              properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
-                                              required:
-                                                - start
-                                                - end
-                                            mediaType:
-                                              type: string
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - mediaType
+                                                - type
+                                                - url
+                                                - position
+                                                - mediaType
+                                        - type: 'null'
+                                        - type: 'null'
                                   viewerReactions:
                                     type: object
                                     additionalProperties:
@@ -3796,279 +3817,282 @@ paths:
                                             type: array
                                             items:
                                               anyOf:
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - ens
-                                                    avatarUrl:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    name:
-                                                      type: string
-                                                    address: {}
-                                                    position:
-                                                      type: object
+                                                - anyOf:
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - ens
+                                                        avatarUrl:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        name:
+                                                          type: string
+                                                        address: {}
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        url:
+                                                          type: string
+                                                          format: uri
                                                       required:
-                                                        - start
-                                                        - end
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                  required:
-                                                    - type
-                                                    - avatarUrl
-                                                    - name
-                                                    - address
-                                                    - position
-                                                    - url
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - erc20
-                                                    symbol:
-                                                      type: string
-                                                    logoURI:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    name:
-                                                      type: string
-                                                    address: {}
-                                                    decimals:
-                                                      type: integer
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - avatarUrl
+                                                        - name
+                                                        - address
+                                                        - position
+                                                        - url
+                                                    - type: object
                                                       properties:
-                                                        start:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - erc20
+                                                        symbol:
+                                                          type: string
+                                                        logoURI:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        name:
+                                                          type: string
+                                                        address: {}
+                                                        decimals:
                                                           type: integer
-                                                        end:
-                                                          type: integer
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        chainId:
+                                                          type:
+                                                            - integer
+                                                            - 'null'
+                                                          exclusiveMinimum: 0
+                                                        chains:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            properties:
+                                                              caip:
+                                                                type: string
+                                                              chainId:
+                                                                type: integer
+                                                                exclusiveMinimum: 0
+                                                            required:
+                                                              - caip
+                                                              - chainId
                                                       required:
-                                                        - start
-                                                        - end
-                                                    chainId:
-                                                      type:
-                                                        - integer
-                                                        - 'null'
-                                                      exclusiveMinimum: 0
-                                                    chains:
-                                                      type: array
-                                                      items:
-                                                        type: object
-                                                        properties:
-                                                          caip:
-                                                            type: string
-                                                          chainId:
-                                                            type: integer
-                                                            exclusiveMinimum: 0
-                                                        required:
-                                                          - caip
-                                                          - chainId
-                                                  required:
-                                                    - type
-                                                    - symbol
-                                                    - logoURI
-                                                    - name
-                                                    - address
-                                                    - decimals
-                                                    - position
-                                                    - chainId
-                                                    - chains
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - farcaster
-                                                    address: {}
-                                                    fid:
-                                                      type: integer
-                                                    fname:
-                                                      type: string
-                                                    username:
-                                                      type: string
-                                                    displayName:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    pfpUrl:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - symbol
+                                                        - logoURI
+                                                        - name
+                                                        - address
+                                                        - decimals
+                                                        - position
+                                                        - chainId
+                                                        - chains
+                                                    - type: object
                                                       properties:
-                                                        start:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - farcaster
+                                                        address: {}
+                                                        fid:
                                                           type: integer
-                                                        end:
-                                                          type: integer
+                                                        fname:
+                                                          type: string
+                                                        username:
+                                                          type: string
+                                                        displayName:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        pfpUrl:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        url:
+                                                          type: string
+                                                          format: uri
                                                       required:
-                                                        - start
-                                                        - end
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                  required:
-                                                    - type
-                                                    - address
-                                                    - fid
-                                                    - fname
-                                                    - username
-                                                    - displayName
-                                                    - pfpUrl
-                                                    - position
-                                                    - url
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - webpage
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - address
+                                                        - fid
+                                                        - fname
+                                                        - username
+                                                        - displayName
+                                                        - pfpUrl
+                                                        - position
+                                                        - url
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
-                                                      required:
-                                                        - start
-                                                        - end
-                                                    title:
-                                                      type: string
-                                                    description:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    favicon:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                      format: uri
-                                                    opengraph:
-                                                      type:
-                                                        - object
-                                                        - 'null'
-                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - webpage
+                                                        url:
+                                                          type: string
+                                                          format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
                                                         title:
                                                           type: string
                                                         description:
                                                           type:
                                                             - string
                                                             - 'null'
-                                                        image:
-                                                          anyOf:
-                                                            - type: string
+                                                        favicon:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                          format: uri
+                                                        opengraph:
+                                                          type:
+                                                            - object
+                                                            - 'null'
+                                                          properties:
+                                                            title:
+                                                              type: string
+                                                            description:
+                                                              type:
+                                                                - string
+                                                                - 'null'
+                                                            image:
+                                                              anyOf:
+                                                                - type: string
+                                                                  format: uri
+                                                                - type: string
+                                                                  pattern: ^\/[^\s]+$
+                                                            url:
+                                                              type: string
                                                               format: uri
-                                                            - type: string
-                                                              pattern: ^\/[^\s]+$
+                                                          required:
+                                                            - title
+                                                            - description
+                                                            - image
+                                                            - url
+                                                      required:
+                                                        - type
+                                                        - url
+                                                        - position
+                                                        - title
+                                                        - description
+                                                        - favicon
+                                                        - opengraph
+                                                    - type: object
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - file
                                                         url:
                                                           type: string
                                                           format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        mediaType:
+                                                          type: string
                                                       required:
-                                                        - title
-                                                        - description
-                                                        - image
+                                                        - type
                                                         - url
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - title
-                                                    - description
-                                                    - favicon
-                                                    - opengraph
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - file
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
+                                                        - position
+                                                        - mediaType
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - image
+                                                        url:
+                                                          type: string
+                                                          format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        mediaType:
+                                                          type: string
                                                       required:
-                                                        - start
-                                                        - end
-                                                    mediaType:
-                                                      type: string
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - mediaType
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - image
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - url
+                                                        - position
+                                                        - mediaType
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - video
+                                                        url:
+                                                          type: string
+                                                          format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        mediaType:
+                                                          type: string
                                                       required:
-                                                        - start
-                                                        - end
-                                                    mediaType:
-                                                      type: string
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - mediaType
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - video
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
-                                                      properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
-                                                      required:
-                                                        - start
-                                                        - end
-                                                    mediaType:
-                                                      type: string
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - mediaType
+                                                        - type
+                                                        - url
+                                                        - position
+                                                        - mediaType
+                                                - type: 'null'
+                                                - type: 'null'
                                         required:
                                           - app
                                           - author
@@ -4509,279 +4533,282 @@ paths:
                           type: array
                           items:
                             anyOf:
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - ens
-                                  avatarUrl:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  name:
-                                    type: string
-                                  address: {}
-                                  position:
-                                    type: object
+                              - anyOf:
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - ens
+                                      avatarUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - start
-                                      - end
-                                  url:
-                                    type: string
-                                    format: uri
-                                required:
-                                  - type
-                                  - avatarUrl
-                                  - name
-                                  - address
-                                  - position
-                                  - url
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - erc20
-                                  symbol:
-                                    type: string
-                                  logoURI:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  name:
-                                    type: string
-                                  address: {}
-                                  decimals:
-                                    type: integer
-                                  position:
-                                    type: object
+                                      - type
+                                      - avatarUrl
+                                      - name
+                                      - address
+                                      - position
+                                      - url
+                                  - type: object
                                     properties:
-                                      start:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - erc20
+                                      symbol:
+                                        type: string
+                                      logoURI:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      decimals:
                                         type: integer
-                                      end:
-                                        type: integer
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      chainId:
+                                        type:
+                                          - integer
+                                          - 'null'
+                                        exclusiveMinimum: 0
+                                      chains:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            caip:
+                                              type: string
+                                            chainId:
+                                              type: integer
+                                              exclusiveMinimum: 0
+                                          required:
+                                            - caip
+                                            - chainId
                                     required:
-                                      - start
-                                      - end
-                                  chainId:
-                                    type:
-                                      - integer
-                                      - 'null'
-                                    exclusiveMinimum: 0
-                                  chains:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        caip:
-                                          type: string
-                                        chainId:
-                                          type: integer
-                                          exclusiveMinimum: 0
-                                      required:
-                                        - caip
-                                        - chainId
-                                required:
-                                  - type
-                                  - symbol
-                                  - logoURI
-                                  - name
-                                  - address
-                                  - decimals
-                                  - position
-                                  - chainId
-                                  - chains
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - farcaster
-                                  address: {}
-                                  fid:
-                                    type: integer
-                                  fname:
-                                    type: string
-                                  username:
-                                    type: string
-                                  displayName:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  pfpUrl:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  position:
-                                    type: object
+                                      - type
+                                      - symbol
+                                      - logoURI
+                                      - name
+                                      - address
+                                      - decimals
+                                      - position
+                                      - chainId
+                                      - chains
+                                  - type: object
                                     properties:
-                                      start:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - farcaster
+                                      address: {}
+                                      fid:
                                         type: integer
-                                      end:
-                                        type: integer
+                                      fname:
+                                        type: string
+                                      username:
+                                        type: string
+                                      displayName:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      pfpUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - start
-                                      - end
-                                  url:
-                                    type: string
-                                    format: uri
-                                required:
-                                  - type
-                                  - address
-                                  - fid
-                                  - fname
-                                  - username
-                                  - displayName
-                                  - pfpUrl
-                                  - position
-                                  - url
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - webpage
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - type
+                                      - address
+                                      - fid
+                                      - fname
+                                      - username
+                                      - displayName
+                                      - pfpUrl
+                                      - position
+                                      - url
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
-                                    required:
-                                      - start
-                                      - end
-                                  title:
-                                    type: string
-                                  description:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  favicon:
-                                    type:
-                                      - string
-                                      - 'null'
-                                    format: uri
-                                  opengraph:
-                                    type:
-                                      - object
-                                      - 'null'
-                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - webpage
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
                                       title:
                                         type: string
                                       description:
                                         type:
                                           - string
                                           - 'null'
-                                      image:
-                                        anyOf:
-                                          - type: string
+                                      favicon:
+                                        type:
+                                          - string
+                                          - 'null'
+                                        format: uri
+                                      opengraph:
+                                        type:
+                                          - object
+                                          - 'null'
+                                        properties:
+                                          title:
+                                            type: string
+                                          description:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          image:
+                                            anyOf:
+                                              - type: string
+                                                format: uri
+                                              - type: string
+                                                pattern: ^\/[^\s]+$
+                                          url:
+                                            type: string
                                             format: uri
-                                          - type: string
-                                            pattern: ^\/[^\s]+$
+                                        required:
+                                          - title
+                                          - description
+                                          - image
+                                          - url
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - title
+                                      - description
+                                      - favicon
+                                      - opengraph
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - file
                                       url:
                                         type: string
                                         format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - title
-                                      - description
-                                      - image
+                                      - type
                                       - url
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - title
-                                  - description
-                                  - favicon
-                                  - opengraph
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - file
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - position
+                                      - mediaType
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - image
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - image
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - video
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - video
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
-                                    properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
-                                    required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                              - type: 'null'
+                              - type: 'null'
                         viewerReactions:
                           type: object
                           additionalProperties:
@@ -4941,279 +4968,282 @@ paths:
                                   type: array
                                   items:
                                     anyOf:
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - ens
-                                          avatarUrl:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          name:
-                                            type: string
-                                          address: {}
-                                          position:
-                                            type: object
+                                      - anyOf:
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - ens
+                                              avatarUrl:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              name:
+                                                type: string
+                                              address: {}
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              url:
+                                                type: string
+                                                format: uri
                                             required:
-                                              - start
-                                              - end
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - type
-                                          - avatarUrl
-                                          - name
-                                          - address
-                                          - position
-                                          - url
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - erc20
-                                          symbol:
-                                            type: string
-                                          logoURI:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          name:
-                                            type: string
-                                          address: {}
-                                          decimals:
-                                            type: integer
-                                          position:
-                                            type: object
+                                              - type
+                                              - avatarUrl
+                                              - name
+                                              - address
+                                              - position
+                                              - url
+                                          - type: object
                                             properties:
-                                              start:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - erc20
+                                              symbol:
+                                                type: string
+                                              logoURI:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              name:
+                                                type: string
+                                              address: {}
+                                              decimals:
                                                 type: integer
-                                              end:
-                                                type: integer
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              chainId:
+                                                type:
+                                                  - integer
+                                                  - 'null'
+                                                exclusiveMinimum: 0
+                                              chains:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    caip:
+                                                      type: string
+                                                    chainId:
+                                                      type: integer
+                                                      exclusiveMinimum: 0
+                                                  required:
+                                                    - caip
+                                                    - chainId
                                             required:
-                                              - start
-                                              - end
-                                          chainId:
-                                            type:
-                                              - integer
-                                              - 'null'
-                                            exclusiveMinimum: 0
-                                          chains:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                caip:
-                                                  type: string
-                                                chainId:
-                                                  type: integer
-                                                  exclusiveMinimum: 0
-                                              required:
-                                                - caip
-                                                - chainId
-                                        required:
-                                          - type
-                                          - symbol
-                                          - logoURI
-                                          - name
-                                          - address
-                                          - decimals
-                                          - position
-                                          - chainId
-                                          - chains
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - farcaster
-                                          address: {}
-                                          fid:
-                                            type: integer
-                                          fname:
-                                            type: string
-                                          username:
-                                            type: string
-                                          displayName:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          pfpUrl:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          position:
-                                            type: object
+                                              - type
+                                              - symbol
+                                              - logoURI
+                                              - name
+                                              - address
+                                              - decimals
+                                              - position
+                                              - chainId
+                                              - chains
+                                          - type: object
                                             properties:
-                                              start:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - farcaster
+                                              address: {}
+                                              fid:
                                                 type: integer
-                                              end:
-                                                type: integer
+                                              fname:
+                                                type: string
+                                              username:
+                                                type: string
+                                              displayName:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              pfpUrl:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              url:
+                                                type: string
+                                                format: uri
                                             required:
-                                              - start
-                                              - end
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - type
-                                          - address
-                                          - fid
-                                          - fname
-                                          - username
-                                          - displayName
-                                          - pfpUrl
-                                          - position
-                                          - url
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - webpage
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
+                                              - type
+                                              - address
+                                              - fid
+                                              - fname
+                                              - username
+                                              - displayName
+                                              - pfpUrl
+                                              - position
+                                              - url
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          title:
-                                            type: string
-                                          description:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          favicon:
-                                            type:
-                                              - string
-                                              - 'null'
-                                            format: uri
-                                          opengraph:
-                                            type:
-                                              - object
-                                              - 'null'
-                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - webpage
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
                                               title:
                                                 type: string
                                               description:
                                                 type:
                                                   - string
                                                   - 'null'
-                                              image:
-                                                anyOf:
-                                                  - type: string
+                                              favicon:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                                format: uri
+                                              opengraph:
+                                                type:
+                                                  - object
+                                                  - 'null'
+                                                properties:
+                                                  title:
+                                                    type: string
+                                                  description:
+                                                    type:
+                                                      - string
+                                                      - 'null'
+                                                  image:
+                                                    anyOf:
+                                                      - type: string
+                                                        format: uri
+                                                      - type: string
+                                                        pattern: ^\/[^\s]+$
+                                                  url:
+                                                    type: string
                                                     format: uri
-                                                  - type: string
-                                                    pattern: ^\/[^\s]+$
+                                                required:
+                                                  - title
+                                                  - description
+                                                  - image
+                                                  - url
+                                            required:
+                                              - type
+                                              - url
+                                              - position
+                                              - title
+                                              - description
+                                              - favicon
+                                              - opengraph
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - file
                                               url:
                                                 type: string
                                                 format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
                                             required:
-                                              - title
-                                              - description
-                                              - image
+                                              - type
                                               - url
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - title
-                                          - description
-                                          - favicon
-                                          - opengraph
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - file
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
+                                              - position
+                                              - mediaType
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - image
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
                                             required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - image
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                          - type: object
                                             properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - video
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
                                             required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - video
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                      - type: 'null'
+                                      - type: 'null'
                               required:
                                 - app
                                 - author
@@ -5415,279 +5445,282 @@ paths:
                                     type: array
                                     items:
                                       anyOf:
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - ens
-                                            avatarUrl:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            name:
-                                              type: string
-                                            address: {}
-                                            position:
-                                              type: object
+                                        - anyOf:
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - ens
+                                                avatarUrl:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                name:
+                                                  type: string
+                                                address: {}
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                url:
+                                                  type: string
+                                                  format: uri
                                               required:
-                                                - start
-                                                - end
-                                            url:
-                                              type: string
-                                              format: uri
-                                          required:
-                                            - type
-                                            - avatarUrl
-                                            - name
-                                            - address
-                                            - position
-                                            - url
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - erc20
-                                            symbol:
-                                              type: string
-                                            logoURI:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            name:
-                                              type: string
-                                            address: {}
-                                            decimals:
-                                              type: integer
-                                            position:
-                                              type: object
+                                                - type
+                                                - avatarUrl
+                                                - name
+                                                - address
+                                                - position
+                                                - url
+                                            - type: object
                                               properties:
-                                                start:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - erc20
+                                                symbol:
+                                                  type: string
+                                                logoURI:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                name:
+                                                  type: string
+                                                address: {}
+                                                decimals:
                                                   type: integer
-                                                end:
-                                                  type: integer
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                chainId:
+                                                  type:
+                                                    - integer
+                                                    - 'null'
+                                                  exclusiveMinimum: 0
+                                                chains:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      caip:
+                                                        type: string
+                                                      chainId:
+                                                        type: integer
+                                                        exclusiveMinimum: 0
+                                                    required:
+                                                      - caip
+                                                      - chainId
                                               required:
-                                                - start
-                                                - end
-                                            chainId:
-                                              type:
-                                                - integer
-                                                - 'null'
-                                              exclusiveMinimum: 0
-                                            chains:
-                                              type: array
-                                              items:
-                                                type: object
-                                                properties:
-                                                  caip:
-                                                    type: string
-                                                  chainId:
-                                                    type: integer
-                                                    exclusiveMinimum: 0
-                                                required:
-                                                  - caip
-                                                  - chainId
-                                          required:
-                                            - type
-                                            - symbol
-                                            - logoURI
-                                            - name
-                                            - address
-                                            - decimals
-                                            - position
-                                            - chainId
-                                            - chains
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - farcaster
-                                            address: {}
-                                            fid:
-                                              type: integer
-                                            fname:
-                                              type: string
-                                            username:
-                                              type: string
-                                            displayName:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            pfpUrl:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            position:
-                                              type: object
+                                                - type
+                                                - symbol
+                                                - logoURI
+                                                - name
+                                                - address
+                                                - decimals
+                                                - position
+                                                - chainId
+                                                - chains
+                                            - type: object
                                               properties:
-                                                start:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - farcaster
+                                                address: {}
+                                                fid:
                                                   type: integer
-                                                end:
-                                                  type: integer
+                                                fname:
+                                                  type: string
+                                                username:
+                                                  type: string
+                                                displayName:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                pfpUrl:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                url:
+                                                  type: string
+                                                  format: uri
                                               required:
-                                                - start
-                                                - end
-                                            url:
-                                              type: string
-                                              format: uri
-                                          required:
-                                            - type
-                                            - address
-                                            - fid
-                                            - fname
-                                            - username
-                                            - displayName
-                                            - pfpUrl
-                                            - position
-                                            - url
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - webpage
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
+                                                - type
+                                                - address
+                                                - fid
+                                                - fname
+                                                - username
+                                                - displayName
+                                                - pfpUrl
+                                                - position
+                                                - url
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
-                                              required:
-                                                - start
-                                                - end
-                                            title:
-                                              type: string
-                                            description:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            favicon:
-                                              type:
-                                                - string
-                                                - 'null'
-                                              format: uri
-                                            opengraph:
-                                              type:
-                                                - object
-                                                - 'null'
-                                              properties:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - webpage
+                                                url:
+                                                  type: string
+                                                  format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
                                                 title:
                                                   type: string
                                                 description:
                                                   type:
                                                     - string
                                                     - 'null'
-                                                image:
-                                                  anyOf:
-                                                    - type: string
+                                                favicon:
+                                                  type:
+                                                    - string
+                                                    - 'null'
+                                                  format: uri
+                                                opengraph:
+                                                  type:
+                                                    - object
+                                                    - 'null'
+                                                  properties:
+                                                    title:
+                                                      type: string
+                                                    description:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    image:
+                                                      anyOf:
+                                                        - type: string
+                                                          format: uri
+                                                        - type: string
+                                                          pattern: ^\/[^\s]+$
+                                                    url:
+                                                      type: string
                                                       format: uri
-                                                    - type: string
-                                                      pattern: ^\/[^\s]+$
+                                                  required:
+                                                    - title
+                                                    - description
+                                                    - image
+                                                    - url
+                                              required:
+                                                - type
+                                                - url
+                                                - position
+                                                - title
+                                                - description
+                                                - favicon
+                                                - opengraph
+                                            - type: object
+                                              properties:
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - file
                                                 url:
                                                   type: string
                                                   format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                mediaType:
+                                                  type: string
                                               required:
-                                                - title
-                                                - description
-                                                - image
+                                                - type
                                                 - url
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - title
-                                            - description
-                                            - favicon
-                                            - opengraph
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - file
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
+                                                - position
+                                                - mediaType
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - image
+                                                url:
+                                                  type: string
+                                                  format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                mediaType:
+                                                  type: string
                                               required:
-                                                - start
-                                                - end
-                                            mediaType:
-                                              type: string
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - mediaType
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - image
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
+                                                - type
+                                                - url
+                                                - position
+                                                - mediaType
+                                            - type: object
                                               properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
+                                                type:
+                                                  type: string
+                                                  enum:
+                                                    - video
+                                                url:
+                                                  type: string
+                                                  format: uri
+                                                position:
+                                                  type: object
+                                                  properties:
+                                                    start:
+                                                      type: integer
+                                                    end:
+                                                      type: integer
+                                                  required:
+                                                    - start
+                                                    - end
+                                                mediaType:
+                                                  type: string
                                               required:
-                                                - start
-                                                - end
-                                            mediaType:
-                                              type: string
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - mediaType
-                                        - type: object
-                                          properties:
-                                            type:
-                                              type: string
-                                              enum:
-                                                - video
-                                            url:
-                                              type: string
-                                              format: uri
-                                            position:
-                                              type: object
-                                              properties:
-                                                start:
-                                                  type: integer
-                                                end:
-                                                  type: integer
-                                              required:
-                                                - start
-                                                - end
-                                            mediaType:
-                                              type: string
-                                          required:
-                                            - type
-                                            - url
-                                            - position
-                                            - mediaType
+                                                - type
+                                                - url
+                                                - position
+                                                - mediaType
+                                        - type: 'null'
+                                        - type: 'null'
                                   viewerReactions:
                                     type: object
                                     additionalProperties:
@@ -5847,279 +5880,282 @@ paths:
                                             type: array
                                             items:
                                               anyOf:
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - ens
-                                                    avatarUrl:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    name:
-                                                      type: string
-                                                    address: {}
-                                                    position:
-                                                      type: object
+                                                - anyOf:
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - ens
+                                                        avatarUrl:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        name:
+                                                          type: string
+                                                        address: {}
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        url:
+                                                          type: string
+                                                          format: uri
                                                       required:
-                                                        - start
-                                                        - end
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                  required:
-                                                    - type
-                                                    - avatarUrl
-                                                    - name
-                                                    - address
-                                                    - position
-                                                    - url
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - erc20
-                                                    symbol:
-                                                      type: string
-                                                    logoURI:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    name:
-                                                      type: string
-                                                    address: {}
-                                                    decimals:
-                                                      type: integer
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - avatarUrl
+                                                        - name
+                                                        - address
+                                                        - position
+                                                        - url
+                                                    - type: object
                                                       properties:
-                                                        start:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - erc20
+                                                        symbol:
+                                                          type: string
+                                                        logoURI:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        name:
+                                                          type: string
+                                                        address: {}
+                                                        decimals:
                                                           type: integer
-                                                        end:
-                                                          type: integer
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        chainId:
+                                                          type:
+                                                            - integer
+                                                            - 'null'
+                                                          exclusiveMinimum: 0
+                                                        chains:
+                                                          type: array
+                                                          items:
+                                                            type: object
+                                                            properties:
+                                                              caip:
+                                                                type: string
+                                                              chainId:
+                                                                type: integer
+                                                                exclusiveMinimum: 0
+                                                            required:
+                                                              - caip
+                                                              - chainId
                                                       required:
-                                                        - start
-                                                        - end
-                                                    chainId:
-                                                      type:
-                                                        - integer
-                                                        - 'null'
-                                                      exclusiveMinimum: 0
-                                                    chains:
-                                                      type: array
-                                                      items:
-                                                        type: object
-                                                        properties:
-                                                          caip:
-                                                            type: string
-                                                          chainId:
-                                                            type: integer
-                                                            exclusiveMinimum: 0
-                                                        required:
-                                                          - caip
-                                                          - chainId
-                                                  required:
-                                                    - type
-                                                    - symbol
-                                                    - logoURI
-                                                    - name
-                                                    - address
-                                                    - decimals
-                                                    - position
-                                                    - chainId
-                                                    - chains
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - farcaster
-                                                    address: {}
-                                                    fid:
-                                                      type: integer
-                                                    fname:
-                                                      type: string
-                                                    username:
-                                                      type: string
-                                                    displayName:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    pfpUrl:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - symbol
+                                                        - logoURI
+                                                        - name
+                                                        - address
+                                                        - decimals
+                                                        - position
+                                                        - chainId
+                                                        - chains
+                                                    - type: object
                                                       properties:
-                                                        start:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - farcaster
+                                                        address: {}
+                                                        fid:
                                                           type: integer
-                                                        end:
-                                                          type: integer
+                                                        fname:
+                                                          type: string
+                                                        username:
+                                                          type: string
+                                                        displayName:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        pfpUrl:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        url:
+                                                          type: string
+                                                          format: uri
                                                       required:
-                                                        - start
-                                                        - end
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                  required:
-                                                    - type
-                                                    - address
-                                                    - fid
-                                                    - fname
-                                                    - username
-                                                    - displayName
-                                                    - pfpUrl
-                                                    - position
-                                                    - url
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - webpage
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - address
+                                                        - fid
+                                                        - fname
+                                                        - username
+                                                        - displayName
+                                                        - pfpUrl
+                                                        - position
+                                                        - url
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
-                                                      required:
-                                                        - start
-                                                        - end
-                                                    title:
-                                                      type: string
-                                                    description:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    favicon:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                      format: uri
-                                                    opengraph:
-                                                      type:
-                                                        - object
-                                                        - 'null'
-                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - webpage
+                                                        url:
+                                                          type: string
+                                                          format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
                                                         title:
                                                           type: string
                                                         description:
                                                           type:
                                                             - string
                                                             - 'null'
-                                                        image:
-                                                          anyOf:
-                                                            - type: string
+                                                        favicon:
+                                                          type:
+                                                            - string
+                                                            - 'null'
+                                                          format: uri
+                                                        opengraph:
+                                                          type:
+                                                            - object
+                                                            - 'null'
+                                                          properties:
+                                                            title:
+                                                              type: string
+                                                            description:
+                                                              type:
+                                                                - string
+                                                                - 'null'
+                                                            image:
+                                                              anyOf:
+                                                                - type: string
+                                                                  format: uri
+                                                                - type: string
+                                                                  pattern: ^\/[^\s]+$
+                                                            url:
+                                                              type: string
                                                               format: uri
-                                                            - type: string
-                                                              pattern: ^\/[^\s]+$
+                                                          required:
+                                                            - title
+                                                            - description
+                                                            - image
+                                                            - url
+                                                      required:
+                                                        - type
+                                                        - url
+                                                        - position
+                                                        - title
+                                                        - description
+                                                        - favicon
+                                                        - opengraph
+                                                    - type: object
+                                                      properties:
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - file
                                                         url:
                                                           type: string
                                                           format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        mediaType:
+                                                          type: string
                                                       required:
-                                                        - title
-                                                        - description
-                                                        - image
+                                                        - type
                                                         - url
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - title
-                                                    - description
-                                                    - favicon
-                                                    - opengraph
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - file
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
+                                                        - position
+                                                        - mediaType
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - image
+                                                        url:
+                                                          type: string
+                                                          format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        mediaType:
+                                                          type: string
                                                       required:
-                                                        - start
-                                                        - end
-                                                    mediaType:
-                                                      type: string
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - mediaType
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - image
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
+                                                        - type
+                                                        - url
+                                                        - position
+                                                        - mediaType
+                                                    - type: object
                                                       properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
+                                                        type:
+                                                          type: string
+                                                          enum:
+                                                            - video
+                                                        url:
+                                                          type: string
+                                                          format: uri
+                                                        position:
+                                                          type: object
+                                                          properties:
+                                                            start:
+                                                              type: integer
+                                                            end:
+                                                              type: integer
+                                                          required:
+                                                            - start
+                                                            - end
+                                                        mediaType:
+                                                          type: string
                                                       required:
-                                                        - start
-                                                        - end
-                                                    mediaType:
-                                                      type: string
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - mediaType
-                                                - type: object
-                                                  properties:
-                                                    type:
-                                                      type: string
-                                                      enum:
-                                                        - video
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                    position:
-                                                      type: object
-                                                      properties:
-                                                        start:
-                                                          type: integer
-                                                        end:
-                                                          type: integer
-                                                      required:
-                                                        - start
-                                                        - end
-                                                    mediaType:
-                                                      type: string
-                                                  required:
-                                                    - type
-                                                    - url
-                                                    - position
-                                                    - mediaType
+                                                        - type
+                                                        - url
+                                                        - position
+                                                        - mediaType
+                                                - type: 'null'
+                                                - type: 'null'
                                         required:
                                           - app
                                           - author
@@ -6798,279 +6834,282 @@ paths:
                           type: array
                           items:
                             anyOf:
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - ens
-                                  avatarUrl:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  name:
-                                    type: string
-                                  address: {}
-                                  position:
-                                    type: object
+                              - anyOf:
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - ens
+                                      avatarUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - start
-                                      - end
-                                  url:
-                                    type: string
-                                    format: uri
-                                required:
-                                  - type
-                                  - avatarUrl
-                                  - name
-                                  - address
-                                  - position
-                                  - url
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - erc20
-                                  symbol:
-                                    type: string
-                                  logoURI:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  name:
-                                    type: string
-                                  address: {}
-                                  decimals:
-                                    type: integer
-                                  position:
-                                    type: object
+                                      - type
+                                      - avatarUrl
+                                      - name
+                                      - address
+                                      - position
+                                      - url
+                                  - type: object
                                     properties:
-                                      start:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - erc20
+                                      symbol:
+                                        type: string
+                                      logoURI:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      decimals:
                                         type: integer
-                                      end:
-                                        type: integer
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      chainId:
+                                        type:
+                                          - integer
+                                          - 'null'
+                                        exclusiveMinimum: 0
+                                      chains:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            caip:
+                                              type: string
+                                            chainId:
+                                              type: integer
+                                              exclusiveMinimum: 0
+                                          required:
+                                            - caip
+                                            - chainId
                                     required:
-                                      - start
-                                      - end
-                                  chainId:
-                                    type:
-                                      - integer
-                                      - 'null'
-                                    exclusiveMinimum: 0
-                                  chains:
-                                    type: array
-                                    items:
-                                      type: object
-                                      properties:
-                                        caip:
-                                          type: string
-                                        chainId:
-                                          type: integer
-                                          exclusiveMinimum: 0
-                                      required:
-                                        - caip
-                                        - chainId
-                                required:
-                                  - type
-                                  - symbol
-                                  - logoURI
-                                  - name
-                                  - address
-                                  - decimals
-                                  - position
-                                  - chainId
-                                  - chains
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - farcaster
-                                  address: {}
-                                  fid:
-                                    type: integer
-                                  fname:
-                                    type: string
-                                  username:
-                                    type: string
-                                  displayName:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  pfpUrl:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  position:
-                                    type: object
+                                      - type
+                                      - symbol
+                                      - logoURI
+                                      - name
+                                      - address
+                                      - decimals
+                                      - position
+                                      - chainId
+                                      - chains
+                                  - type: object
                                     properties:
-                                      start:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - farcaster
+                                      address: {}
+                                      fid:
                                         type: integer
-                                      end:
-                                        type: integer
+                                      fname:
+                                        type: string
+                                      username:
+                                        type: string
+                                      displayName:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      pfpUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - start
-                                      - end
-                                  url:
-                                    type: string
-                                    format: uri
-                                required:
-                                  - type
-                                  - address
-                                  - fid
-                                  - fname
-                                  - username
-                                  - displayName
-                                  - pfpUrl
-                                  - position
-                                  - url
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - webpage
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - type
+                                      - address
+                                      - fid
+                                      - fname
+                                      - username
+                                      - displayName
+                                      - pfpUrl
+                                      - position
+                                      - url
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
-                                    required:
-                                      - start
-                                      - end
-                                  title:
-                                    type: string
-                                  description:
-                                    type:
-                                      - string
-                                      - 'null'
-                                  favicon:
-                                    type:
-                                      - string
-                                      - 'null'
-                                    format: uri
-                                  opengraph:
-                                    type:
-                                      - object
-                                      - 'null'
-                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - webpage
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
                                       title:
                                         type: string
                                       description:
                                         type:
                                           - string
                                           - 'null'
-                                      image:
-                                        anyOf:
-                                          - type: string
+                                      favicon:
+                                        type:
+                                          - string
+                                          - 'null'
+                                        format: uri
+                                      opengraph:
+                                        type:
+                                          - object
+                                          - 'null'
+                                        properties:
+                                          title:
+                                            type: string
+                                          description:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          image:
+                                            anyOf:
+                                              - type: string
+                                                format: uri
+                                              - type: string
+                                                pattern: ^\/[^\s]+$
+                                          url:
+                                            type: string
                                             format: uri
-                                          - type: string
-                                            pattern: ^\/[^\s]+$
+                                        required:
+                                          - title
+                                          - description
+                                          - image
+                                          - url
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - title
+                                      - description
+                                      - favicon
+                                      - opengraph
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - file
                                       url:
                                         type: string
                                         format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - title
-                                      - description
-                                      - image
+                                      - type
                                       - url
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - title
-                                  - description
-                                  - favicon
-                                  - opengraph
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - file
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - position
+                                      - mediaType
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - image
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - image
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                                  - type: object
                                     properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
+                                      type:
+                                        type: string
+                                        enum:
+                                          - video
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
                                     required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
-                              - type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    enum:
-                                      - video
-                                  url:
-                                    type: string
-                                    format: uri
-                                  position:
-                                    type: object
-                                    properties:
-                                      start:
-                                        type: integer
-                                      end:
-                                        type: integer
-                                    required:
-                                      - start
-                                      - end
-                                  mediaType:
-                                    type: string
-                                required:
-                                  - type
-                                  - url
-                                  - position
-                                  - mediaType
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                              - type: 'null'
+                              - type: 'null'
                       required:
                         - app
                         - author
@@ -7330,279 +7369,282 @@ paths:
                     type: array
                     items:
                       anyOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - ens
-                            avatarUrl:
-                              type:
-                                - string
-                                - 'null'
-                            name:
-                              type: string
-                            address: {}
-                            position:
-                              type: object
+                        - anyOf:
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - ens
+                                avatarUrl:
+                                  type:
+                                    - string
+                                    - 'null'
+                                name:
+                                  type: string
+                                address: {}
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - start
-                                - end
-                            url:
-                              type: string
-                              format: uri
-                          required:
-                            - type
-                            - avatarUrl
-                            - name
-                            - address
-                            - position
-                            - url
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - erc20
-                            symbol:
-                              type: string
-                            logoURI:
-                              type:
-                                - string
-                                - 'null'
-                            name:
-                              type: string
-                            address: {}
-                            decimals:
-                              type: integer
-                            position:
-                              type: object
+                                - type
+                                - avatarUrl
+                                - name
+                                - address
+                                - position
+                                - url
+                            - type: object
                               properties:
-                                start:
+                                type:
+                                  type: string
+                                  enum:
+                                    - erc20
+                                symbol:
+                                  type: string
+                                logoURI:
+                                  type:
+                                    - string
+                                    - 'null'
+                                name:
+                                  type: string
+                                address: {}
+                                decimals:
                                   type: integer
-                                end:
-                                  type: integer
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                chainId:
+                                  type:
+                                    - integer
+                                    - 'null'
+                                  exclusiveMinimum: 0
+                                chains:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      caip:
+                                        type: string
+                                      chainId:
+                                        type: integer
+                                        exclusiveMinimum: 0
+                                    required:
+                                      - caip
+                                      - chainId
                               required:
-                                - start
-                                - end
-                            chainId:
-                              type:
-                                - integer
-                                - 'null'
-                              exclusiveMinimum: 0
-                            chains:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  caip:
-                                    type: string
-                                  chainId:
-                                    type: integer
-                                    exclusiveMinimum: 0
-                                required:
-                                  - caip
-                                  - chainId
-                          required:
-                            - type
-                            - symbol
-                            - logoURI
-                            - name
-                            - address
-                            - decimals
-                            - position
-                            - chainId
-                            - chains
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - farcaster
-                            address: {}
-                            fid:
-                              type: integer
-                            fname:
-                              type: string
-                            username:
-                              type: string
-                            displayName:
-                              type:
-                                - string
-                                - 'null'
-                            pfpUrl:
-                              type:
-                                - string
-                                - 'null'
-                            position:
-                              type: object
+                                - type
+                                - symbol
+                                - logoURI
+                                - name
+                                - address
+                                - decimals
+                                - position
+                                - chainId
+                                - chains
+                            - type: object
                               properties:
-                                start:
+                                type:
+                                  type: string
+                                  enum:
+                                    - farcaster
+                                address: {}
+                                fid:
                                   type: integer
-                                end:
-                                  type: integer
+                                fname:
+                                  type: string
+                                username:
+                                  type: string
+                                displayName:
+                                  type:
+                                    - string
+                                    - 'null'
+                                pfpUrl:
+                                  type:
+                                    - string
+                                    - 'null'
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - start
-                                - end
-                            url:
-                              type: string
-                              format: uri
-                          required:
-                            - type
-                            - address
-                            - fid
-                            - fname
-                            - username
-                            - displayName
-                            - pfpUrl
-                            - position
-                            - url
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - webpage
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - type
+                                - address
+                                - fid
+                                - fname
+                                - username
+                                - displayName
+                                - pfpUrl
+                                - position
+                                - url
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
-                              required:
-                                - start
-                                - end
-                            title:
-                              type: string
-                            description:
-                              type:
-                                - string
-                                - 'null'
-                            favicon:
-                              type:
-                                - string
-                                - 'null'
-                              format: uri
-                            opengraph:
-                              type:
-                                - object
-                                - 'null'
-                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - webpage
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
                                 title:
                                   type: string
                                 description:
                                   type:
                                     - string
                                     - 'null'
-                                image:
-                                  anyOf:
-                                    - type: string
+                                favicon:
+                                  type:
+                                    - string
+                                    - 'null'
+                                  format: uri
+                                opengraph:
+                                  type:
+                                    - object
+                                    - 'null'
+                                  properties:
+                                    title:
+                                      type: string
+                                    description:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    image:
+                                      anyOf:
+                                        - type: string
+                                          format: uri
+                                        - type: string
+                                          pattern: ^\/[^\s]+$
+                                    url:
+                                      type: string
                                       format: uri
-                                    - type: string
-                                      pattern: ^\/[^\s]+$
+                                  required:
+                                    - title
+                                    - description
+                                    - image
+                                    - url
+                              required:
+                                - type
+                                - url
+                                - position
+                                - title
+                                - description
+                                - favicon
+                                - opengraph
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - file
                                 url:
                                   type: string
                                   format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - title
-                                - description
-                                - image
+                                - type
                                 - url
-                          required:
-                            - type
-                            - url
-                            - position
-                            - title
-                            - description
-                            - favicon
-                            - opengraph
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - file
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - position
+                                - mediaType
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - image
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - image
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - type
+                                - url
+                                - position
+                                - mediaType
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - video
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - video
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
-                              properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
-                              required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
+                                - type
+                                - url
+                                - position
+                                - mediaType
+                        - type: 'null'
+                        - type: 'null'
                 required:
                   - app
                   - author
@@ -7836,279 +7878,282 @@ paths:
                     type: array
                     items:
                       anyOf:
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - ens
-                            avatarUrl:
-                              type:
-                                - string
-                                - 'null'
-                            name:
-                              type: string
-                            address: {}
-                            position:
-                              type: object
+                        - anyOf:
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - ens
+                                avatarUrl:
+                                  type:
+                                    - string
+                                    - 'null'
+                                name:
+                                  type: string
+                                address: {}
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - start
-                                - end
-                            url:
-                              type: string
-                              format: uri
-                          required:
-                            - type
-                            - avatarUrl
-                            - name
-                            - address
-                            - position
-                            - url
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - erc20
-                            symbol:
-                              type: string
-                            logoURI:
-                              type:
-                                - string
-                                - 'null'
-                            name:
-                              type: string
-                            address: {}
-                            decimals:
-                              type: integer
-                            position:
-                              type: object
+                                - type
+                                - avatarUrl
+                                - name
+                                - address
+                                - position
+                                - url
+                            - type: object
                               properties:
-                                start:
+                                type:
+                                  type: string
+                                  enum:
+                                    - erc20
+                                symbol:
+                                  type: string
+                                logoURI:
+                                  type:
+                                    - string
+                                    - 'null'
+                                name:
+                                  type: string
+                                address: {}
+                                decimals:
                                   type: integer
-                                end:
-                                  type: integer
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                chainId:
+                                  type:
+                                    - integer
+                                    - 'null'
+                                  exclusiveMinimum: 0
+                                chains:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      caip:
+                                        type: string
+                                      chainId:
+                                        type: integer
+                                        exclusiveMinimum: 0
+                                    required:
+                                      - caip
+                                      - chainId
                               required:
-                                - start
-                                - end
-                            chainId:
-                              type:
-                                - integer
-                                - 'null'
-                              exclusiveMinimum: 0
-                            chains:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  caip:
-                                    type: string
-                                  chainId:
-                                    type: integer
-                                    exclusiveMinimum: 0
-                                required:
-                                  - caip
-                                  - chainId
-                          required:
-                            - type
-                            - symbol
-                            - logoURI
-                            - name
-                            - address
-                            - decimals
-                            - position
-                            - chainId
-                            - chains
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - farcaster
-                            address: {}
-                            fid:
-                              type: integer
-                            fname:
-                              type: string
-                            username:
-                              type: string
-                            displayName:
-                              type:
-                                - string
-                                - 'null'
-                            pfpUrl:
-                              type:
-                                - string
-                                - 'null'
-                            position:
-                              type: object
+                                - type
+                                - symbol
+                                - logoURI
+                                - name
+                                - address
+                                - decimals
+                                - position
+                                - chainId
+                                - chains
+                            - type: object
                               properties:
-                                start:
+                                type:
+                                  type: string
+                                  enum:
+                                    - farcaster
+                                address: {}
+                                fid:
                                   type: integer
-                                end:
-                                  type: integer
+                                fname:
+                                  type: string
+                                username:
+                                  type: string
+                                displayName:
+                                  type:
+                                    - string
+                                    - 'null'
+                                pfpUrl:
+                                  type:
+                                    - string
+                                    - 'null'
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - start
-                                - end
-                            url:
-                              type: string
-                              format: uri
-                          required:
-                            - type
-                            - address
-                            - fid
-                            - fname
-                            - username
-                            - displayName
-                            - pfpUrl
-                            - position
-                            - url
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - webpage
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - type
+                                - address
+                                - fid
+                                - fname
+                                - username
+                                - displayName
+                                - pfpUrl
+                                - position
+                                - url
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
-                              required:
-                                - start
-                                - end
-                            title:
-                              type: string
-                            description:
-                              type:
-                                - string
-                                - 'null'
-                            favicon:
-                              type:
-                                - string
-                                - 'null'
-                              format: uri
-                            opengraph:
-                              type:
-                                - object
-                                - 'null'
-                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - webpage
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
                                 title:
                                   type: string
                                 description:
                                   type:
                                     - string
                                     - 'null'
-                                image:
-                                  anyOf:
-                                    - type: string
+                                favicon:
+                                  type:
+                                    - string
+                                    - 'null'
+                                  format: uri
+                                opengraph:
+                                  type:
+                                    - object
+                                    - 'null'
+                                  properties:
+                                    title:
+                                      type: string
+                                    description:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    image:
+                                      anyOf:
+                                        - type: string
+                                          format: uri
+                                        - type: string
+                                          pattern: ^\/[^\s]+$
+                                    url:
+                                      type: string
                                       format: uri
-                                    - type: string
-                                      pattern: ^\/[^\s]+$
+                                  required:
+                                    - title
+                                    - description
+                                    - image
+                                    - url
+                              required:
+                                - type
+                                - url
+                                - position
+                                - title
+                                - description
+                                - favicon
+                                - opengraph
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  enum:
+                                    - file
                                 url:
                                   type: string
                                   format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - title
-                                - description
-                                - image
+                                - type
                                 - url
-                          required:
-                            - type
-                            - url
-                            - position
-                            - title
-                            - description
-                            - favicon
-                            - opengraph
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - file
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - position
+                                - mediaType
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - image
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - image
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
+                                - type
+                                - url
+                                - position
+                                - mediaType
+                            - type: object
                               properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
+                                type:
+                                  type: string
+                                  enum:
+                                    - video
+                                url:
+                                  type: string
+                                  format: uri
+                                position:
+                                  type: object
+                                  properties:
+                                    start:
+                                      type: integer
+                                    end:
+                                      type: integer
+                                  required:
+                                    - start
+                                    - end
+                                mediaType:
+                                  type: string
                               required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
-                        - type: object
-                          properties:
-                            type:
-                              type: string
-                              enum:
-                                - video
-                            url:
-                              type: string
-                              format: uri
-                            position:
-                              type: object
-                              properties:
-                                start:
-                                  type: integer
-                                end:
-                                  type: integer
-                              required:
-                                - start
-                                - end
-                            mediaType:
-                              type: string
-                          required:
-                            - type
-                            - url
-                            - position
-                            - mediaType
+                                - type
+                                - url
+                                - position
+                                - mediaType
+                        - type: 'null'
+                        - type: 'null'
                 required:
                   - app
                   - author

--- a/docs/public/indexer-openapi.yaml
+++ b/docs/public/indexer-openapi.yaml
@@ -422,281 +422,277 @@ paths:
                     type: array
                     items:
                       anyOf:
-                        - anyOf:
-                            - type: object
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - ens
+                            avatarUrl:
+                              type:
+                                - string
+                                - 'null'
+                            name:
+                              type: string
+                            address: {}
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - ens
-                                avatarUrl:
-                                  type:
-                                    - string
-                                    - 'null'
-                                name:
-                                  type: string
-                                address: {}
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                url:
-                                  type: string
-                                  format: uri
-                              required:
-                                - type
-                                - avatarUrl
-                                - name
-                                - address
-                                - position
-                                - url
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - erc20
-                                symbol:
-                                  type: string
-                                logoURI:
-                                  type:
-                                    - string
-                                    - 'null'
-                                name:
-                                  type: string
-                                address: {}
-                                decimals:
+                                start:
                                   type: integer
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                chainId:
-                                  type:
-                                    - integer
-                                    - 'null'
-                                  exclusiveMinimum: 0
-                                chains:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      caip:
-                                        type: string
-                                      chainId:
-                                        type: integer
-                                        exclusiveMinimum: 0
-                                    required:
-                                      - caip
-                                      - chainId
-                              required:
-                                - type
-                                - symbol
-                                - logoURI
-                                - name
-                                - address
-                                - decimals
-                                - position
-                                - chainId
-                                - chains
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - farcaster
-                                address: {}
-                                fid:
+                                end:
                                   type: integer
-                                fname:
-                                  type: string
-                                username:
-                                  type: string
-                                displayName:
-                                  type:
-                                    - string
-                                    - 'null'
-                                pfpUrl:
-                                  type:
-                                    - string
-                                    - 'null'
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                url:
-                                  type: string
-                                  format: uri
                               required:
-                                - type
-                                - address
-                                - fid
-                                - fname
-                                - username
-                                - displayName
-                                - pfpUrl
-                                - position
-                                - url
-                            - type: object
+                                - start
+                                - end
+                            url:
+                              type: string
+                              format: uri
+                          required:
+                            - type
+                            - avatarUrl
+                            - name
+                            - address
+                            - position
+                            - url
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - erc20
+                            symbol:
+                              type: string
+                            logoURI:
+                              type:
+                                - string
+                                - 'null'
+                            name:
+                              type: string
+                            address: {}
+                            decimals:
+                              type: integer
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - webpage
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            chainId:
+                              type:
+                                - integer
+                                - 'null'
+                              exclusiveMinimum: 0
+                            chains:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  caip:
+                                    type: string
+                                  chainId:
+                                    type: integer
+                                    exclusiveMinimum: 0
+                                required:
+                                  - caip
+                                  - chainId
+                          required:
+                            - type
+                            - symbol
+                            - logoURI
+                            - name
+                            - address
+                            - decimals
+                            - position
+                            - chainId
+                            - chains
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - farcaster
+                            address: {}
+                            fid:
+                              type: integer
+                            fname:
+                              type: string
+                            username:
+                              type: string
+                            displayName:
+                              type:
+                                - string
+                                - 'null'
+                            pfpUrl:
+                              type:
+                                - string
+                                - 'null'
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            url:
+                              type: string
+                              format: uri
+                          required:
+                            - type
+                            - address
+                            - fid
+                            - fname
+                            - username
+                            - displayName
+                            - pfpUrl
+                            - position
+                            - url
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - webpage
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            title:
+                              type: string
+                            description:
+                              type:
+                                - string
+                                - 'null'
+                            favicon:
+                              type:
+                                - string
+                                - 'null'
+                              format: uri
+                            opengraph:
+                              type:
+                                - object
+                                - 'null'
+                              properties:
                                 title:
                                   type: string
                                 description:
                                   type:
                                     - string
                                     - 'null'
-                                favicon:
-                                  type:
-                                    - string
-                                    - 'null'
+                                image:
+                                  type: string
                                   format: uri
-                                opengraph:
-                                  type:
-                                    - object
-                                    - 'null'
-                                  properties:
-                                    title:
-                                      type: string
-                                    description:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    image:
-                                      anyOf:
-                                        - type: string
-                                          format: uri
-                                        - type: string
-                                          pattern: ^\/[^\s]+$
-                                    url:
-                                      type: string
-                                      format: uri
-                                  required:
-                                    - title
-                                    - description
-                                    - image
-                                    - url
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - type
-                                - url
-                                - position
                                 - title
                                 - description
-                                - favicon
-                                - opengraph
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - file
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
-                              required:
-                                - type
+                                - image
                                 - url
-                                - position
-                                - mediaType
-                            - type: object
+                          required:
+                            - type
+                            - url
+                            - position
+                            - title
+                            - description
+                            - favicon
+                            - opengraph
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - file
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - image
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
                               required:
-                                - type
-                                - url
-                                - position
-                                - mediaType
-                            - type: object
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - image
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - video
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
                               required:
-                                - type
-                                - url
-                                - position
-                                - mediaType
-                        - type: 'null'
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - video
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - {}
                         - type: 'null'
                   viewerReactions:
                     type: object
@@ -857,281 +853,277 @@ paths:
                             type: array
                             items:
                               anyOf:
-                                - anyOf:
-                                    - type: object
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - ens
+                                    avatarUrl:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    name:
+                                      type: string
+                                    address: {}
+                                    position:
+                                      type: object
                                       properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - ens
-                                        avatarUrl:
-                                          type:
-                                            - string
-                                            - 'null'
-                                        name:
-                                          type: string
-                                        address: {}
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
-                                        url:
-                                          type: string
-                                          format: uri
-                                      required:
-                                        - type
-                                        - avatarUrl
-                                        - name
-                                        - address
-                                        - position
-                                        - url
-                                    - type: object
-                                      properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - erc20
-                                        symbol:
-                                          type: string
-                                        logoURI:
-                                          type:
-                                            - string
-                                            - 'null'
-                                        name:
-                                          type: string
-                                        address: {}
-                                        decimals:
+                                        start:
                                           type: integer
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
-                                        chainId:
-                                          type:
-                                            - integer
-                                            - 'null'
-                                          exclusiveMinimum: 0
-                                        chains:
-                                          type: array
-                                          items:
-                                            type: object
-                                            properties:
-                                              caip:
-                                                type: string
-                                              chainId:
-                                                type: integer
-                                                exclusiveMinimum: 0
-                                            required:
-                                              - caip
-                                              - chainId
-                                      required:
-                                        - type
-                                        - symbol
-                                        - logoURI
-                                        - name
-                                        - address
-                                        - decimals
-                                        - position
-                                        - chainId
-                                        - chains
-                                    - type: object
-                                      properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - farcaster
-                                        address: {}
-                                        fid:
+                                        end:
                                           type: integer
-                                        fname:
-                                          type: string
-                                        username:
-                                          type: string
-                                        displayName:
-                                          type:
-                                            - string
-                                            - 'null'
-                                        pfpUrl:
-                                          type:
-                                            - string
-                                            - 'null'
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
-                                        url:
-                                          type: string
-                                          format: uri
                                       required:
-                                        - type
-                                        - address
-                                        - fid
-                                        - fname
-                                        - username
-                                        - displayName
-                                        - pfpUrl
-                                        - position
-                                        - url
-                                    - type: object
+                                        - start
+                                        - end
+                                    url:
+                                      type: string
+                                      format: uri
+                                  required:
+                                    - type
+                                    - avatarUrl
+                                    - name
+                                    - address
+                                    - position
+                                    - url
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - erc20
+                                    symbol:
+                                      type: string
+                                    logoURI:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    name:
+                                      type: string
+                                    address: {}
+                                    decimals:
+                                      type: integer
+                                    position:
+                                      type: object
                                       properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - webpage
-                                        url:
-                                          type: string
-                                          format: uri
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
+                                        start:
+                                          type: integer
+                                        end:
+                                          type: integer
+                                      required:
+                                        - start
+                                        - end
+                                    chainId:
+                                      type:
+                                        - integer
+                                        - 'null'
+                                      exclusiveMinimum: 0
+                                    chains:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          caip:
+                                            type: string
+                                          chainId:
+                                            type: integer
+                                            exclusiveMinimum: 0
+                                        required:
+                                          - caip
+                                          - chainId
+                                  required:
+                                    - type
+                                    - symbol
+                                    - logoURI
+                                    - name
+                                    - address
+                                    - decimals
+                                    - position
+                                    - chainId
+                                    - chains
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - farcaster
+                                    address: {}
+                                    fid:
+                                      type: integer
+                                    fname:
+                                      type: string
+                                    username:
+                                      type: string
+                                    displayName:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    pfpUrl:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    position:
+                                      type: object
+                                      properties:
+                                        start:
+                                          type: integer
+                                        end:
+                                          type: integer
+                                      required:
+                                        - start
+                                        - end
+                                    url:
+                                      type: string
+                                      format: uri
+                                  required:
+                                    - type
+                                    - address
+                                    - fid
+                                    - fname
+                                    - username
+                                    - displayName
+                                    - pfpUrl
+                                    - position
+                                    - url
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - webpage
+                                    url:
+                                      type: string
+                                      format: uri
+                                    position:
+                                      type: object
+                                      properties:
+                                        start:
+                                          type: integer
+                                        end:
+                                          type: integer
+                                      required:
+                                        - start
+                                        - end
+                                    title:
+                                      type: string
+                                    description:
+                                      type:
+                                        - string
+                                        - 'null'
+                                    favicon:
+                                      type:
+                                        - string
+                                        - 'null'
+                                      format: uri
+                                    opengraph:
+                                      type:
+                                        - object
+                                        - 'null'
+                                      properties:
                                         title:
                                           type: string
                                         description:
                                           type:
                                             - string
                                             - 'null'
-                                        favicon:
-                                          type:
-                                            - string
-                                            - 'null'
+                                        image:
+                                          type: string
                                           format: uri
-                                        opengraph:
-                                          type:
-                                            - object
-                                            - 'null'
-                                          properties:
-                                            title:
-                                              type: string
-                                            description:
-                                              type:
-                                                - string
-                                                - 'null'
-                                            image:
-                                              anyOf:
-                                                - type: string
-                                                  format: uri
-                                                - type: string
-                                                  pattern: ^\/[^\s]+$
-                                            url:
-                                              type: string
-                                              format: uri
-                                          required:
-                                            - title
-                                            - description
-                                            - image
-                                            - url
+                                        url:
+                                          type: string
+                                          format: uri
                                       required:
-                                        - type
-                                        - url
-                                        - position
                                         - title
                                         - description
-                                        - favicon
-                                        - opengraph
-                                    - type: object
-                                      properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - file
-                                        url:
-                                          type: string
-                                          format: uri
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
-                                        mediaType:
-                                          type: string
-                                      required:
-                                        - type
+                                        - image
                                         - url
-                                        - position
-                                        - mediaType
-                                    - type: object
+                                  required:
+                                    - type
+                                    - url
+                                    - position
+                                    - title
+                                    - description
+                                    - favicon
+                                    - opengraph
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - file
+                                    url:
+                                      type: string
+                                      format: uri
+                                    position:
+                                      type: object
                                       properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - image
-                                        url:
-                                          type: string
-                                          format: uri
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
-                                        mediaType:
-                                          type: string
+                                        start:
+                                          type: integer
+                                        end:
+                                          type: integer
                                       required:
-                                        - type
-                                        - url
-                                        - position
-                                        - mediaType
-                                    - type: object
+                                        - start
+                                        - end
+                                    mediaType:
+                                      type: string
+                                  required:
+                                    - type
+                                    - url
+                                    - position
+                                    - mediaType
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - image
+                                    url:
+                                      type: string
+                                      format: uri
+                                    position:
+                                      type: object
                                       properties:
-                                        type:
-                                          type: string
-                                          enum:
-                                            - video
-                                        url:
-                                          type: string
-                                          format: uri
-                                        position:
-                                          type: object
-                                          properties:
-                                            start:
-                                              type: integer
-                                            end:
-                                              type: integer
-                                          required:
-                                            - start
-                                            - end
-                                        mediaType:
-                                          type: string
+                                        start:
+                                          type: integer
+                                        end:
+                                          type: integer
                                       required:
-                                        - type
-                                        - url
-                                        - position
-                                        - mediaType
-                                - type: 'null'
+                                        - start
+                                        - end
+                                    mediaType:
+                                      type: string
+                                  required:
+                                    - type
+                                    - url
+                                    - position
+                                    - mediaType
+                                - type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                      enum:
+                                        - video
+                                    url:
+                                      type: string
+                                      format: uri
+                                    position:
+                                      type: object
+                                      properties:
+                                        start:
+                                          type: integer
+                                        end:
+                                          type: integer
+                                      required:
+                                        - start
+                                        - end
+                                    mediaType:
+                                      type: string
+                                  required:
+                                    - type
+                                    - url
+                                    - position
+                                    - mediaType
+                                - {}
                                 - type: 'null'
                         required:
                           - app
@@ -1334,281 +1326,277 @@ paths:
                               type: array
                               items:
                                 anyOf:
-                                  - anyOf:
-                                      - type: object
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - ens
+                                      avatarUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      position:
+                                        type: object
                                         properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - ens
-                                          avatarUrl:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          name:
-                                            type: string
-                                          address: {}
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - type
-                                          - avatarUrl
-                                          - name
-                                          - address
-                                          - position
-                                          - url
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - erc20
-                                          symbol:
-                                            type: string
-                                          logoURI:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          name:
-                                            type: string
-                                          address: {}
-                                          decimals:
+                                          start:
                                             type: integer
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          chainId:
-                                            type:
-                                              - integer
-                                              - 'null'
-                                            exclusiveMinimum: 0
-                                          chains:
-                                            type: array
-                                            items:
-                                              type: object
-                                              properties:
-                                                caip:
-                                                  type: string
-                                                chainId:
-                                                  type: integer
-                                                  exclusiveMinimum: 0
-                                              required:
-                                                - caip
-                                                - chainId
-                                        required:
-                                          - type
-                                          - symbol
-                                          - logoURI
-                                          - name
-                                          - address
-                                          - decimals
-                                          - position
-                                          - chainId
-                                          - chains
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - farcaster
-                                          address: {}
-                                          fid:
+                                          end:
                                             type: integer
-                                          fname:
-                                            type: string
-                                          username:
-                                            type: string
-                                          displayName:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          pfpUrl:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          url:
-                                            type: string
-                                            format: uri
                                         required:
-                                          - type
-                                          - address
-                                          - fid
-                                          - fname
-                                          - username
-                                          - displayName
-                                          - pfpUrl
-                                          - position
-                                          - url
-                                      - type: object
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
+                                    required:
+                                      - type
+                                      - avatarUrl
+                                      - name
+                                      - address
+                                      - position
+                                      - url
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - erc20
+                                      symbol:
+                                        type: string
+                                      logoURI:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      name:
+                                        type: string
+                                      address: {}
+                                      decimals:
+                                        type: integer
+                                      position:
+                                        type: object
                                         properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - webpage
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      chainId:
+                                        type:
+                                          - integer
+                                          - 'null'
+                                        exclusiveMinimum: 0
+                                      chains:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            caip:
+                                              type: string
+                                            chainId:
+                                              type: integer
+                                              exclusiveMinimum: 0
+                                          required:
+                                            - caip
+                                            - chainId
+                                    required:
+                                      - type
+                                      - symbol
+                                      - logoURI
+                                      - name
+                                      - address
+                                      - decimals
+                                      - position
+                                      - chainId
+                                      - chains
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - farcaster
+                                      address: {}
+                                      fid:
+                                        type: integer
+                                      fname:
+                                        type: string
+                                      username:
+                                        type: string
+                                      displayName:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      pfpUrl:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      url:
+                                        type: string
+                                        format: uri
+                                    required:
+                                      - type
+                                      - address
+                                      - fid
+                                      - fname
+                                      - username
+                                      - displayName
+                                      - pfpUrl
+                                      - position
+                                      - url
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - webpage
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      title:
+                                        type: string
+                                      description:
+                                        type:
+                                          - string
+                                          - 'null'
+                                      favicon:
+                                        type:
+                                          - string
+                                          - 'null'
+                                        format: uri
+                                      opengraph:
+                                        type:
+                                          - object
+                                          - 'null'
+                                        properties:
                                           title:
                                             type: string
                                           description:
                                             type:
                                               - string
                                               - 'null'
-                                          favicon:
-                                            type:
-                                              - string
-                                              - 'null'
+                                          image:
+                                            type: string
                                             format: uri
-                                          opengraph:
-                                            type:
-                                              - object
-                                              - 'null'
-                                            properties:
-                                              title:
-                                                type: string
-                                              description:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              image:
-                                                anyOf:
-                                                  - type: string
-                                                    format: uri
-                                                  - type: string
-                                                    pattern: ^\/[^\s]+$
-                                              url:
-                                                type: string
-                                                format: uri
-                                            required:
-                                              - title
-                                              - description
-                                              - image
-                                              - url
+                                          url:
+                                            type: string
+                                            format: uri
                                         required:
-                                          - type
-                                          - url
-                                          - position
                                           - title
                                           - description
-                                          - favicon
-                                          - opengraph
-                                      - type: object
-                                        properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - file
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
-                                        required:
-                                          - type
+                                          - image
                                           - url
-                                          - position
-                                          - mediaType
-                                      - type: object
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - title
+                                      - description
+                                      - favicon
+                                      - opengraph
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - file
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
                                         properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - image
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
                                         required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
-                                      - type: object
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - image
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
                                         properties:
-                                          type:
-                                            type: string
-                                            enum:
-                                              - video
-                                          url:
-                                            type: string
-                                            format: uri
-                                          position:
-                                            type: object
-                                            properties:
-                                              start:
-                                                type: integer
-                                              end:
-                                                type: integer
-                                            required:
-                                              - start
-                                              - end
-                                          mediaType:
-                                            type: string
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
                                         required:
-                                          - type
-                                          - url
-                                          - position
-                                          - mediaType
-                                  - type: 'null'
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        enum:
+                                          - video
+                                      url:
+                                        type: string
+                                        format: uri
+                                      position:
+                                        type: object
+                                        properties:
+                                          start:
+                                            type: integer
+                                          end:
+                                            type: integer
+                                        required:
+                                          - start
+                                          - end
+                                      mediaType:
+                                        type: string
+                                    required:
+                                      - type
+                                      - url
+                                      - position
+                                      - mediaType
+                                  - {}
                                   - type: 'null'
                             viewerReactions:
                               type: object
@@ -1769,281 +1757,277 @@ paths:
                                       type: array
                                       items:
                                         anyOf:
-                                          - anyOf:
-                                              - type: object
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - ens
+                                              avatarUrl:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              name:
+                                                type: string
+                                              address: {}
+                                              position:
+                                                type: object
                                                 properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - ens
-                                                  avatarUrl:
-                                                    type:
-                                                      - string
-                                                      - 'null'
-                                                  name:
-                                                    type: string
-                                                  address: {}
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                required:
-                                                  - type
-                                                  - avatarUrl
-                                                  - name
-                                                  - address
-                                                  - position
-                                                  - url
-                                              - type: object
-                                                properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - erc20
-                                                  symbol:
-                                                    type: string
-                                                  logoURI:
-                                                    type:
-                                                      - string
-                                                      - 'null'
-                                                  name:
-                                                    type: string
-                                                  address: {}
-                                                  decimals:
+                                                  start:
                                                     type: integer
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
-                                                  chainId:
-                                                    type:
-                                                      - integer
-                                                      - 'null'
-                                                    exclusiveMinimum: 0
-                                                  chains:
-                                                    type: array
-                                                    items:
-                                                      type: object
-                                                      properties:
-                                                        caip:
-                                                          type: string
-                                                        chainId:
-                                                          type: integer
-                                                          exclusiveMinimum: 0
-                                                      required:
-                                                        - caip
-                                                        - chainId
-                                                required:
-                                                  - type
-                                                  - symbol
-                                                  - logoURI
-                                                  - name
-                                                  - address
-                                                  - decimals
-                                                  - position
-                                                  - chainId
-                                                  - chains
-                                              - type: object
-                                                properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - farcaster
-                                                  address: {}
-                                                  fid:
+                                                  end:
                                                     type: integer
-                                                  fname:
-                                                    type: string
-                                                  username:
-                                                    type: string
-                                                  displayName:
-                                                    type:
-                                                      - string
-                                                      - 'null'
-                                                  pfpUrl:
-                                                    type:
-                                                      - string
-                                                      - 'null'
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
-                                                  url:
-                                                    type: string
-                                                    format: uri
                                                 required:
-                                                  - type
-                                                  - address
-                                                  - fid
-                                                  - fname
-                                                  - username
-                                                  - displayName
-                                                  - pfpUrl
-                                                  - position
-                                                  - url
-                                              - type: object
+                                                  - start
+                                                  - end
+                                              url:
+                                                type: string
+                                                format: uri
+                                            required:
+                                              - type
+                                              - avatarUrl
+                                              - name
+                                              - address
+                                              - position
+                                              - url
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - erc20
+                                              symbol:
+                                                type: string
+                                              logoURI:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              name:
+                                                type: string
+                                              address: {}
+                                              decimals:
+                                                type: integer
+                                              position:
+                                                type: object
                                                 properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - webpage
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              chainId:
+                                                type:
+                                                  - integer
+                                                  - 'null'
+                                                exclusiveMinimum: 0
+                                              chains:
+                                                type: array
+                                                items:
+                                                  type: object
+                                                  properties:
+                                                    caip:
+                                                      type: string
+                                                    chainId:
+                                                      type: integer
+                                                      exclusiveMinimum: 0
+                                                  required:
+                                                    - caip
+                                                    - chainId
+                                            required:
+                                              - type
+                                              - symbol
+                                              - logoURI
+                                              - name
+                                              - address
+                                              - decimals
+                                              - position
+                                              - chainId
+                                              - chains
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - farcaster
+                                              address: {}
+                                              fid:
+                                                type: integer
+                                              fname:
+                                                type: string
+                                              username:
+                                                type: string
+                                              displayName:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              pfpUrl:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              url:
+                                                type: string
+                                                format: uri
+                                            required:
+                                              - type
+                                              - address
+                                              - fid
+                                              - fname
+                                              - username
+                                              - displayName
+                                              - pfpUrl
+                                              - position
+                                              - url
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - webpage
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              title:
+                                                type: string
+                                              description:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                              favicon:
+                                                type:
+                                                  - string
+                                                  - 'null'
+                                                format: uri
+                                              opengraph:
+                                                type:
+                                                  - object
+                                                  - 'null'
+                                                properties:
                                                   title:
                                                     type: string
                                                   description:
                                                     type:
                                                       - string
                                                       - 'null'
-                                                  favicon:
-                                                    type:
-                                                      - string
-                                                      - 'null'
+                                                  image:
+                                                    type: string
                                                     format: uri
-                                                  opengraph:
-                                                    type:
-                                                      - object
-                                                      - 'null'
-                                                    properties:
-                                                      title:
-                                                        type: string
-                                                      description:
-                                                        type:
-                                                          - string
-                                                          - 'null'
-                                                      image:
-                                                        anyOf:
-                                                          - type: string
-                                                            format: uri
-                                                          - type: string
-                                                            pattern: ^\/[^\s]+$
-                                                      url:
-                                                        type: string
-                                                        format: uri
-                                                    required:
-                                                      - title
-                                                      - description
-                                                      - image
-                                                      - url
+                                                  url:
+                                                    type: string
+                                                    format: uri
                                                 required:
-                                                  - type
-                                                  - url
-                                                  - position
                                                   - title
                                                   - description
-                                                  - favicon
-                                                  - opengraph
-                                              - type: object
-                                                properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - file
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
-                                                  mediaType:
-                                                    type: string
-                                                required:
-                                                  - type
+                                                  - image
                                                   - url
-                                                  - position
-                                                  - mediaType
-                                              - type: object
+                                            required:
+                                              - type
+                                              - url
+                                              - position
+                                              - title
+                                              - description
+                                              - favicon
+                                              - opengraph
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - file
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
                                                 properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - image
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
-                                                  mediaType:
-                                                    type: string
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
                                                 required:
-                                                  - type
-                                                  - url
-                                                  - position
-                                                  - mediaType
-                                              - type: object
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
+                                            required:
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - image
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
                                                 properties:
-                                                  type:
-                                                    type: string
-                                                    enum:
-                                                      - video
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                  position:
-                                                    type: object
-                                                    properties:
-                                                      start:
-                                                        type: integer
-                                                      end:
-                                                        type: integer
-                                                    required:
-                                                      - start
-                                                      - end
-                                                  mediaType:
-                                                    type: string
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
                                                 required:
-                                                  - type
-                                                  - url
-                                                  - position
-                                                  - mediaType
-                                          - type: 'null'
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
+                                            required:
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                enum:
+                                                  - video
+                                              url:
+                                                type: string
+                                                format: uri
+                                              position:
+                                                type: object
+                                                properties:
+                                                  start:
+                                                    type: integer
+                                                  end:
+                                                    type: integer
+                                                required:
+                                                  - start
+                                                  - end
+                                              mediaType:
+                                                type: string
+                                            required:
+                                              - type
+                                              - url
+                                              - position
+                                              - mediaType
+                                          - {}
                                           - type: 'null'
                                   required:
                                     - app
@@ -2470,281 +2454,277 @@ paths:
                           type: array
                           items:
                             anyOf:
-                              - anyOf:
-                                  - type: object
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - ens
+                                  avatarUrl:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  name:
+                                    type: string
+                                  address: {}
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - ens
-                                      avatarUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
-                                    required:
-                                      - type
-                                      - avatarUrl
-                                      - name
-                                      - address
-                                      - position
-                                      - url
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - erc20
-                                      symbol:
-                                        type: string
-                                      logoURI:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      decimals:
+                                      start:
                                         type: integer
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      chainId:
-                                        type:
-                                          - integer
-                                          - 'null'
-                                        exclusiveMinimum: 0
-                                      chains:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            caip:
-                                              type: string
-                                            chainId:
-                                              type: integer
-                                              exclusiveMinimum: 0
-                                          required:
-                                            - caip
-                                            - chainId
-                                    required:
-                                      - type
-                                      - symbol
-                                      - logoURI
-                                      - name
-                                      - address
-                                      - decimals
-                                      - position
-                                      - chainId
-                                      - chains
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - farcaster
-                                      address: {}
-                                      fid:
+                                      end:
                                         type: integer
-                                      fname:
-                                        type: string
-                                      username:
-                                        type: string
-                                      displayName:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      pfpUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
                                     required:
-                                      - type
-                                      - address
-                                      - fid
-                                      - fname
-                                      - username
-                                      - displayName
-                                      - pfpUrl
-                                      - position
-                                      - url
-                                  - type: object
+                                      - start
+                                      - end
+                                  url:
+                                    type: string
+                                    format: uri
+                                required:
+                                  - type
+                                  - avatarUrl
+                                  - name
+                                  - address
+                                  - position
+                                  - url
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - erc20
+                                  symbol:
+                                    type: string
+                                  logoURI:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  name:
+                                    type: string
+                                  address: {}
+                                  decimals:
+                                    type: integer
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - webpage
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  chainId:
+                                    type:
+                                      - integer
+                                      - 'null'
+                                    exclusiveMinimum: 0
+                                  chains:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        caip:
+                                          type: string
+                                        chainId:
+                                          type: integer
+                                          exclusiveMinimum: 0
+                                      required:
+                                        - caip
+                                        - chainId
+                                required:
+                                  - type
+                                  - symbol
+                                  - logoURI
+                                  - name
+                                  - address
+                                  - decimals
+                                  - position
+                                  - chainId
+                                  - chains
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - farcaster
+                                  address: {}
+                                  fid:
+                                    type: integer
+                                  fname:
+                                    type: string
+                                  username:
+                                    type: string
+                                  displayName:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  pfpUrl:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  url:
+                                    type: string
+                                    format: uri
+                                required:
+                                  - type
+                                  - address
+                                  - fid
+                                  - fname
+                                  - username
+                                  - displayName
+                                  - pfpUrl
+                                  - position
+                                  - url
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - webpage
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  title:
+                                    type: string
+                                  description:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  favicon:
+                                    type:
+                                      - string
+                                      - 'null'
+                                    format: uri
+                                  opengraph:
+                                    type:
+                                      - object
+                                      - 'null'
+                                    properties:
                                       title:
                                         type: string
                                       description:
                                         type:
                                           - string
                                           - 'null'
-                                      favicon:
-                                        type:
-                                          - string
-                                          - 'null'
+                                      image:
+                                        type: string
                                         format: uri
-                                      opengraph:
-                                        type:
-                                          - object
-                                          - 'null'
-                                        properties:
-                                          title:
-                                            type: string
-                                          description:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          image:
-                                            anyOf:
-                                              - type: string
-                                                format: uri
-                                              - type: string
-                                                pattern: ^\/[^\s]+$
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - title
-                                          - description
-                                          - image
-                                          - url
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - type
-                                      - url
-                                      - position
                                       - title
                                       - description
-                                      - favicon
-                                      - opengraph
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - file
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
-                                    required:
-                                      - type
+                                      - image
                                       - url
-                                      - position
-                                      - mediaType
-                                  - type: object
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - title
+                                  - description
+                                  - favicon
+                                  - opengraph
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - file
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - image
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
                                     required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                                  - type: object
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - image
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - video
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
                                     required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                              - type: 'null'
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - video
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - {}
                               - type: 'null'
                         viewerReactions:
                           type: object
@@ -2905,281 +2885,277 @@ paths:
                                   type: array
                                   items:
                                     anyOf:
-                                      - anyOf:
-                                          - type: object
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - ens
+                                          avatarUrl:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          name:
+                                            type: string
+                                          address: {}
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - ens
-                                              avatarUrl:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              name:
-                                                type: string
-                                              address: {}
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              url:
-                                                type: string
-                                                format: uri
-                                            required:
-                                              - type
-                                              - avatarUrl
-                                              - name
-                                              - address
-                                              - position
-                                              - url
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - erc20
-                                              symbol:
-                                                type: string
-                                              logoURI:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              name:
-                                                type: string
-                                              address: {}
-                                              decimals:
+                                              start:
                                                 type: integer
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              chainId:
-                                                type:
-                                                  - integer
-                                                  - 'null'
-                                                exclusiveMinimum: 0
-                                              chains:
-                                                type: array
-                                                items:
-                                                  type: object
-                                                  properties:
-                                                    caip:
-                                                      type: string
-                                                    chainId:
-                                                      type: integer
-                                                      exclusiveMinimum: 0
-                                                  required:
-                                                    - caip
-                                                    - chainId
-                                            required:
-                                              - type
-                                              - symbol
-                                              - logoURI
-                                              - name
-                                              - address
-                                              - decimals
-                                              - position
-                                              - chainId
-                                              - chains
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - farcaster
-                                              address: {}
-                                              fid:
+                                              end:
                                                 type: integer
-                                              fname:
-                                                type: string
-                                              username:
-                                                type: string
-                                              displayName:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              pfpUrl:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              url:
-                                                type: string
-                                                format: uri
                                             required:
-                                              - type
-                                              - address
-                                              - fid
-                                              - fname
-                                              - username
-                                              - displayName
-                                              - pfpUrl
-                                              - position
-                                              - url
-                                          - type: object
+                                              - start
+                                              - end
+                                          url:
+                                            type: string
+                                            format: uri
+                                        required:
+                                          - type
+                                          - avatarUrl
+                                          - name
+                                          - address
+                                          - position
+                                          - url
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - erc20
+                                          symbol:
+                                            type: string
+                                          logoURI:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          name:
+                                            type: string
+                                          address: {}
+                                          decimals:
+                                            type: integer
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - webpage
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          chainId:
+                                            type:
+                                              - integer
+                                              - 'null'
+                                            exclusiveMinimum: 0
+                                          chains:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                caip:
+                                                  type: string
+                                                chainId:
+                                                  type: integer
+                                                  exclusiveMinimum: 0
+                                              required:
+                                                - caip
+                                                - chainId
+                                        required:
+                                          - type
+                                          - symbol
+                                          - logoURI
+                                          - name
+                                          - address
+                                          - decimals
+                                          - position
+                                          - chainId
+                                          - chains
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - farcaster
+                                          address: {}
+                                          fid:
+                                            type: integer
+                                          fname:
+                                            type: string
+                                          username:
+                                            type: string
+                                          displayName:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          pfpUrl:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          url:
+                                            type: string
+                                            format: uri
+                                        required:
+                                          - type
+                                          - address
+                                          - fid
+                                          - fname
+                                          - username
+                                          - displayName
+                                          - pfpUrl
+                                          - position
+                                          - url
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - webpage
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          title:
+                                            type: string
+                                          description:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          favicon:
+                                            type:
+                                              - string
+                                              - 'null'
+                                            format: uri
+                                          opengraph:
+                                            type:
+                                              - object
+                                              - 'null'
+                                            properties:
                                               title:
                                                 type: string
                                               description:
                                                 type:
                                                   - string
                                                   - 'null'
-                                              favicon:
-                                                type:
-                                                  - string
-                                                  - 'null'
+                                              image:
+                                                type: string
                                                 format: uri
-                                              opengraph:
-                                                type:
-                                                  - object
-                                                  - 'null'
-                                                properties:
-                                                  title:
-                                                    type: string
-                                                  description:
-                                                    type:
-                                                      - string
-                                                      - 'null'
-                                                  image:
-                                                    anyOf:
-                                                      - type: string
-                                                        format: uri
-                                                      - type: string
-                                                        pattern: ^\/[^\s]+$
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                required:
-                                                  - title
-                                                  - description
-                                                  - image
-                                                  - url
+                                              url:
+                                                type: string
+                                                format: uri
                                             required:
-                                              - type
-                                              - url
-                                              - position
                                               - title
                                               - description
-                                              - favicon
-                                              - opengraph
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - file
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
-                                            required:
-                                              - type
+                                              - image
                                               - url
-                                              - position
-                                              - mediaType
-                                          - type: object
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - title
+                                          - description
+                                          - favicon
+                                          - opengraph
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - file
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - image
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
                                             required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
-                                          - type: object
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - image
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - video
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
                                             required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
-                                      - type: 'null'
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - video
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - {}
                                       - type: 'null'
                               required:
                                 - app
@@ -3382,281 +3358,277 @@ paths:
                                     type: array
                                     items:
                                       anyOf:
-                                        - anyOf:
-                                            - type: object
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - ens
+                                            avatarUrl:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            name:
+                                              type: string
+                                            address: {}
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - ens
-                                                avatarUrl:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                name:
-                                                  type: string
-                                                address: {}
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                              required:
-                                                - type
-                                                - avatarUrl
-                                                - name
-                                                - address
-                                                - position
-                                                - url
-                                            - type: object
-                                              properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - erc20
-                                                symbol:
-                                                  type: string
-                                                logoURI:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                name:
-                                                  type: string
-                                                address: {}
-                                                decimals:
+                                                start:
                                                   type: integer
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                chainId:
-                                                  type:
-                                                    - integer
-                                                    - 'null'
-                                                  exclusiveMinimum: 0
-                                                chains:
-                                                  type: array
-                                                  items:
-                                                    type: object
-                                                    properties:
-                                                      caip:
-                                                        type: string
-                                                      chainId:
-                                                        type: integer
-                                                        exclusiveMinimum: 0
-                                                    required:
-                                                      - caip
-                                                      - chainId
-                                              required:
-                                                - type
-                                                - symbol
-                                                - logoURI
-                                                - name
-                                                - address
-                                                - decimals
-                                                - position
-                                                - chainId
-                                                - chains
-                                            - type: object
-                                              properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - farcaster
-                                                address: {}
-                                                fid:
+                                                end:
                                                   type: integer
-                                                fname:
-                                                  type: string
-                                                username:
-                                                  type: string
-                                                displayName:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                pfpUrl:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                url:
-                                                  type: string
-                                                  format: uri
                                               required:
-                                                - type
-                                                - address
-                                                - fid
-                                                - fname
-                                                - username
-                                                - displayName
-                                                - pfpUrl
-                                                - position
-                                                - url
-                                            - type: object
+                                                - start
+                                                - end
+                                            url:
+                                              type: string
+                                              format: uri
+                                          required:
+                                            - type
+                                            - avatarUrl
+                                            - name
+                                            - address
+                                            - position
+                                            - url
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - erc20
+                                            symbol:
+                                              type: string
+                                            logoURI:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            name:
+                                              type: string
+                                            address: {}
+                                            decimals:
+                                              type: integer
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - webpage
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            chainId:
+                                              type:
+                                                - integer
+                                                - 'null'
+                                              exclusiveMinimum: 0
+                                            chains:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  caip:
+                                                    type: string
+                                                  chainId:
+                                                    type: integer
+                                                    exclusiveMinimum: 0
+                                                required:
+                                                  - caip
+                                                  - chainId
+                                          required:
+                                            - type
+                                            - symbol
+                                            - logoURI
+                                            - name
+                                            - address
+                                            - decimals
+                                            - position
+                                            - chainId
+                                            - chains
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - farcaster
+                                            address: {}
+                                            fid:
+                                              type: integer
+                                            fname:
+                                              type: string
+                                            username:
+                                              type: string
+                                            displayName:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            pfpUrl:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            position:
+                                              type: object
+                                              properties:
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            url:
+                                              type: string
+                                              format: uri
+                                          required:
+                                            - type
+                                            - address
+                                            - fid
+                                            - fname
+                                            - username
+                                            - displayName
+                                            - pfpUrl
+                                            - position
+                                            - url
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - webpage
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
+                                              properties:
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            title:
+                                              type: string
+                                            description:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            favicon:
+                                              type:
+                                                - string
+                                                - 'null'
+                                              format: uri
+                                            opengraph:
+                                              type:
+                                                - object
+                                                - 'null'
+                                              properties:
                                                 title:
                                                   type: string
                                                 description:
                                                   type:
                                                     - string
                                                     - 'null'
-                                                favicon:
-                                                  type:
-                                                    - string
-                                                    - 'null'
+                                                image:
+                                                  type: string
                                                   format: uri
-                                                opengraph:
-                                                  type:
-                                                    - object
-                                                    - 'null'
-                                                  properties:
-                                                    title:
-                                                      type: string
-                                                    description:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    image:
-                                                      anyOf:
-                                                        - type: string
-                                                          format: uri
-                                                        - type: string
-                                                          pattern: ^\/[^\s]+$
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                  required:
-                                                    - title
-                                                    - description
-                                                    - image
-                                                    - url
+                                                url:
+                                                  type: string
+                                                  format: uri
                                               required:
-                                                - type
-                                                - url
-                                                - position
                                                 - title
                                                 - description
-                                                - favicon
-                                                - opengraph
-                                            - type: object
-                                              properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - file
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                mediaType:
-                                                  type: string
-                                              required:
-                                                - type
+                                                - image
                                                 - url
-                                                - position
-                                                - mediaType
-                                            - type: object
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - title
+                                            - description
+                                            - favicon
+                                            - opengraph
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - file
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - image
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                mediaType:
-                                                  type: string
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
                                               required:
-                                                - type
-                                                - url
-                                                - position
-                                                - mediaType
-                                            - type: object
+                                                - start
+                                                - end
+                                            mediaType:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - mediaType
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - image
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - video
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                mediaType:
-                                                  type: string
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
                                               required:
-                                                - type
-                                                - url
-                                                - position
-                                                - mediaType
-                                        - type: 'null'
+                                                - start
+                                                - end
+                                            mediaType:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - mediaType
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - video
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
+                                              properties:
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            mediaType:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - mediaType
+                                        - {}
                                         - type: 'null'
                                   viewerReactions:
                                     type: object
@@ -3817,281 +3789,277 @@ paths:
                                             type: array
                                             items:
                                               anyOf:
-                                                - anyOf:
-                                                    - type: object
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - ens
+                                                    avatarUrl:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    name:
+                                                      type: string
+                                                    address: {}
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - ens
-                                                        avatarUrl:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        name:
-                                                          type: string
-                                                        address: {}
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                      required:
-                                                        - type
-                                                        - avatarUrl
-                                                        - name
-                                                        - address
-                                                        - position
-                                                        - url
-                                                    - type: object
-                                                      properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - erc20
-                                                        symbol:
-                                                          type: string
-                                                        logoURI:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        name:
-                                                          type: string
-                                                        address: {}
-                                                        decimals:
+                                                        start:
                                                           type: integer
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        chainId:
-                                                          type:
-                                                            - integer
-                                                            - 'null'
-                                                          exclusiveMinimum: 0
-                                                        chains:
-                                                          type: array
-                                                          items:
-                                                            type: object
-                                                            properties:
-                                                              caip:
-                                                                type: string
-                                                              chainId:
-                                                                type: integer
-                                                                exclusiveMinimum: 0
-                                                            required:
-                                                              - caip
-                                                              - chainId
-                                                      required:
-                                                        - type
-                                                        - symbol
-                                                        - logoURI
-                                                        - name
-                                                        - address
-                                                        - decimals
-                                                        - position
-                                                        - chainId
-                                                        - chains
-                                                    - type: object
-                                                      properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - farcaster
-                                                        address: {}
-                                                        fid:
+                                                        end:
                                                           type: integer
-                                                        fname:
-                                                          type: string
-                                                        username:
-                                                          type: string
-                                                        displayName:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        pfpUrl:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        url:
-                                                          type: string
-                                                          format: uri
                                                       required:
-                                                        - type
-                                                        - address
-                                                        - fid
-                                                        - fname
-                                                        - username
-                                                        - displayName
-                                                        - pfpUrl
-                                                        - position
-                                                        - url
-                                                    - type: object
+                                                        - start
+                                                        - end
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                  required:
+                                                    - type
+                                                    - avatarUrl
+                                                    - name
+                                                    - address
+                                                    - position
+                                                    - url
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - erc20
+                                                    symbol:
+                                                      type: string
+                                                    logoURI:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    name:
+                                                      type: string
+                                                    address: {}
+                                                    decimals:
+                                                      type: integer
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - webpage
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    chainId:
+                                                      type:
+                                                        - integer
+                                                        - 'null'
+                                                      exclusiveMinimum: 0
+                                                    chains:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        properties:
+                                                          caip:
+                                                            type: string
+                                                          chainId:
+                                                            type: integer
+                                                            exclusiveMinimum: 0
+                                                        required:
+                                                          - caip
+                                                          - chainId
+                                                  required:
+                                                    - type
+                                                    - symbol
+                                                    - logoURI
+                                                    - name
+                                                    - address
+                                                    - decimals
+                                                    - position
+                                                    - chainId
+                                                    - chains
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - farcaster
+                                                    address: {}
+                                                    fid:
+                                                      type: integer
+                                                    fname:
+                                                      type: string
+                                                    username:
+                                                      type: string
+                                                    displayName:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    pfpUrl:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    position:
+                                                      type: object
+                                                      properties:
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                  required:
+                                                    - type
+                                                    - address
+                                                    - fid
+                                                    - fname
+                                                    - username
+                                                    - displayName
+                                                    - pfpUrl
+                                                    - position
+                                                    - url
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - webpage
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
+                                                      properties:
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    title:
+                                                      type: string
+                                                    description:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    favicon:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                      format: uri
+                                                    opengraph:
+                                                      type:
+                                                        - object
+                                                        - 'null'
+                                                      properties:
                                                         title:
                                                           type: string
                                                         description:
                                                           type:
                                                             - string
                                                             - 'null'
-                                                        favicon:
-                                                          type:
-                                                            - string
-                                                            - 'null'
+                                                        image:
+                                                          type: string
                                                           format: uri
-                                                        opengraph:
-                                                          type:
-                                                            - object
-                                                            - 'null'
-                                                          properties:
-                                                            title:
-                                                              type: string
-                                                            description:
-                                                              type:
-                                                                - string
-                                                                - 'null'
-                                                            image:
-                                                              anyOf:
-                                                                - type: string
-                                                                  format: uri
-                                                                - type: string
-                                                                  pattern: ^\/[^\s]+$
-                                                            url:
-                                                              type: string
-                                                              format: uri
-                                                          required:
-                                                            - title
-                                                            - description
-                                                            - image
-                                                            - url
+                                                        url:
+                                                          type: string
+                                                          format: uri
                                                       required:
-                                                        - type
-                                                        - url
-                                                        - position
                                                         - title
                                                         - description
-                                                        - favicon
-                                                        - opengraph
-                                                    - type: object
-                                                      properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - file
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        mediaType:
-                                                          type: string
-                                                      required:
-                                                        - type
+                                                        - image
                                                         - url
-                                                        - position
-                                                        - mediaType
-                                                    - type: object
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - title
+                                                    - description
+                                                    - favicon
+                                                    - opengraph
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - file
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - image
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        mediaType:
-                                                          type: string
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
                                                       required:
-                                                        - type
-                                                        - url
-                                                        - position
-                                                        - mediaType
-                                                    - type: object
+                                                        - start
+                                                        - end
+                                                    mediaType:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - mediaType
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - image
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - video
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        mediaType:
-                                                          type: string
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
                                                       required:
-                                                        - type
-                                                        - url
-                                                        - position
-                                                        - mediaType
-                                                - type: 'null'
+                                                        - start
+                                                        - end
+                                                    mediaType:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - mediaType
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - video
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
+                                                      properties:
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    mediaType:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - mediaType
+                                                - {}
                                                 - type: 'null'
                                         required:
                                           - app
@@ -4533,281 +4501,277 @@ paths:
                           type: array
                           items:
                             anyOf:
-                              - anyOf:
-                                  - type: object
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - ens
+                                  avatarUrl:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  name:
+                                    type: string
+                                  address: {}
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - ens
-                                      avatarUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
-                                    required:
-                                      - type
-                                      - avatarUrl
-                                      - name
-                                      - address
-                                      - position
-                                      - url
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - erc20
-                                      symbol:
-                                        type: string
-                                      logoURI:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      decimals:
+                                      start:
                                         type: integer
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      chainId:
-                                        type:
-                                          - integer
-                                          - 'null'
-                                        exclusiveMinimum: 0
-                                      chains:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            caip:
-                                              type: string
-                                            chainId:
-                                              type: integer
-                                              exclusiveMinimum: 0
-                                          required:
-                                            - caip
-                                            - chainId
-                                    required:
-                                      - type
-                                      - symbol
-                                      - logoURI
-                                      - name
-                                      - address
-                                      - decimals
-                                      - position
-                                      - chainId
-                                      - chains
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - farcaster
-                                      address: {}
-                                      fid:
+                                      end:
                                         type: integer
-                                      fname:
-                                        type: string
-                                      username:
-                                        type: string
-                                      displayName:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      pfpUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
                                     required:
-                                      - type
-                                      - address
-                                      - fid
-                                      - fname
-                                      - username
-                                      - displayName
-                                      - pfpUrl
-                                      - position
-                                      - url
-                                  - type: object
+                                      - start
+                                      - end
+                                  url:
+                                    type: string
+                                    format: uri
+                                required:
+                                  - type
+                                  - avatarUrl
+                                  - name
+                                  - address
+                                  - position
+                                  - url
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - erc20
+                                  symbol:
+                                    type: string
+                                  logoURI:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  name:
+                                    type: string
+                                  address: {}
+                                  decimals:
+                                    type: integer
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - webpage
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  chainId:
+                                    type:
+                                      - integer
+                                      - 'null'
+                                    exclusiveMinimum: 0
+                                  chains:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        caip:
+                                          type: string
+                                        chainId:
+                                          type: integer
+                                          exclusiveMinimum: 0
+                                      required:
+                                        - caip
+                                        - chainId
+                                required:
+                                  - type
+                                  - symbol
+                                  - logoURI
+                                  - name
+                                  - address
+                                  - decimals
+                                  - position
+                                  - chainId
+                                  - chains
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - farcaster
+                                  address: {}
+                                  fid:
+                                    type: integer
+                                  fname:
+                                    type: string
+                                  username:
+                                    type: string
+                                  displayName:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  pfpUrl:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  url:
+                                    type: string
+                                    format: uri
+                                required:
+                                  - type
+                                  - address
+                                  - fid
+                                  - fname
+                                  - username
+                                  - displayName
+                                  - pfpUrl
+                                  - position
+                                  - url
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - webpage
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  title:
+                                    type: string
+                                  description:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  favicon:
+                                    type:
+                                      - string
+                                      - 'null'
+                                    format: uri
+                                  opengraph:
+                                    type:
+                                      - object
+                                      - 'null'
+                                    properties:
                                       title:
                                         type: string
                                       description:
                                         type:
                                           - string
                                           - 'null'
-                                      favicon:
-                                        type:
-                                          - string
-                                          - 'null'
+                                      image:
+                                        type: string
                                         format: uri
-                                      opengraph:
-                                        type:
-                                          - object
-                                          - 'null'
-                                        properties:
-                                          title:
-                                            type: string
-                                          description:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          image:
-                                            anyOf:
-                                              - type: string
-                                                format: uri
-                                              - type: string
-                                                pattern: ^\/[^\s]+$
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - title
-                                          - description
-                                          - image
-                                          - url
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - type
-                                      - url
-                                      - position
                                       - title
                                       - description
-                                      - favicon
-                                      - opengraph
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - file
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
-                                    required:
-                                      - type
+                                      - image
                                       - url
-                                      - position
-                                      - mediaType
-                                  - type: object
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - title
+                                  - description
+                                  - favicon
+                                  - opengraph
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - file
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - image
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
                                     required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                                  - type: object
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - image
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - video
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
                                     required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                              - type: 'null'
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - video
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - {}
                               - type: 'null'
                         viewerReactions:
                           type: object
@@ -4968,281 +4932,277 @@ paths:
                                   type: array
                                   items:
                                     anyOf:
-                                      - anyOf:
-                                          - type: object
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - ens
+                                          avatarUrl:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          name:
+                                            type: string
+                                          address: {}
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - ens
-                                              avatarUrl:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              name:
-                                                type: string
-                                              address: {}
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              url:
-                                                type: string
-                                                format: uri
-                                            required:
-                                              - type
-                                              - avatarUrl
-                                              - name
-                                              - address
-                                              - position
-                                              - url
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - erc20
-                                              symbol:
-                                                type: string
-                                              logoURI:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              name:
-                                                type: string
-                                              address: {}
-                                              decimals:
+                                              start:
                                                 type: integer
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              chainId:
-                                                type:
-                                                  - integer
-                                                  - 'null'
-                                                exclusiveMinimum: 0
-                                              chains:
-                                                type: array
-                                                items:
-                                                  type: object
-                                                  properties:
-                                                    caip:
-                                                      type: string
-                                                    chainId:
-                                                      type: integer
-                                                      exclusiveMinimum: 0
-                                                  required:
-                                                    - caip
-                                                    - chainId
-                                            required:
-                                              - type
-                                              - symbol
-                                              - logoURI
-                                              - name
-                                              - address
-                                              - decimals
-                                              - position
-                                              - chainId
-                                              - chains
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - farcaster
-                                              address: {}
-                                              fid:
+                                              end:
                                                 type: integer
-                                              fname:
-                                                type: string
-                                              username:
-                                                type: string
-                                              displayName:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              pfpUrl:
-                                                type:
-                                                  - string
-                                                  - 'null'
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              url:
-                                                type: string
-                                                format: uri
                                             required:
-                                              - type
-                                              - address
-                                              - fid
-                                              - fname
-                                              - username
-                                              - displayName
-                                              - pfpUrl
-                                              - position
-                                              - url
-                                          - type: object
+                                              - start
+                                              - end
+                                          url:
+                                            type: string
+                                            format: uri
+                                        required:
+                                          - type
+                                          - avatarUrl
+                                          - name
+                                          - address
+                                          - position
+                                          - url
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - erc20
+                                          symbol:
+                                            type: string
+                                          logoURI:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          name:
+                                            type: string
+                                          address: {}
+                                          decimals:
+                                            type: integer
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - webpage
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          chainId:
+                                            type:
+                                              - integer
+                                              - 'null'
+                                            exclusiveMinimum: 0
+                                          chains:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                caip:
+                                                  type: string
+                                                chainId:
+                                                  type: integer
+                                                  exclusiveMinimum: 0
+                                              required:
+                                                - caip
+                                                - chainId
+                                        required:
+                                          - type
+                                          - symbol
+                                          - logoURI
+                                          - name
+                                          - address
+                                          - decimals
+                                          - position
+                                          - chainId
+                                          - chains
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - farcaster
+                                          address: {}
+                                          fid:
+                                            type: integer
+                                          fname:
+                                            type: string
+                                          username:
+                                            type: string
+                                          displayName:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          pfpUrl:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          url:
+                                            type: string
+                                            format: uri
+                                        required:
+                                          - type
+                                          - address
+                                          - fid
+                                          - fname
+                                          - username
+                                          - displayName
+                                          - pfpUrl
+                                          - position
+                                          - url
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - webpage
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          title:
+                                            type: string
+                                          description:
+                                            type:
+                                              - string
+                                              - 'null'
+                                          favicon:
+                                            type:
+                                              - string
+                                              - 'null'
+                                            format: uri
+                                          opengraph:
+                                            type:
+                                              - object
+                                              - 'null'
+                                            properties:
                                               title:
                                                 type: string
                                               description:
                                                 type:
                                                   - string
                                                   - 'null'
-                                              favicon:
-                                                type:
-                                                  - string
-                                                  - 'null'
+                                              image:
+                                                type: string
                                                 format: uri
-                                              opengraph:
-                                                type:
-                                                  - object
-                                                  - 'null'
-                                                properties:
-                                                  title:
-                                                    type: string
-                                                  description:
-                                                    type:
-                                                      - string
-                                                      - 'null'
-                                                  image:
-                                                    anyOf:
-                                                      - type: string
-                                                        format: uri
-                                                      - type: string
-                                                        pattern: ^\/[^\s]+$
-                                                  url:
-                                                    type: string
-                                                    format: uri
-                                                required:
-                                                  - title
-                                                  - description
-                                                  - image
-                                                  - url
+                                              url:
+                                                type: string
+                                                format: uri
                                             required:
-                                              - type
-                                              - url
-                                              - position
                                               - title
                                               - description
-                                              - favicon
-                                              - opengraph
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - file
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
-                                            required:
-                                              - type
+                                              - image
                                               - url
-                                              - position
-                                              - mediaType
-                                          - type: object
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - title
+                                          - description
+                                          - favicon
+                                          - opengraph
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - file
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - image
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
                                             required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
-                                          - type: object
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - image
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
                                             properties:
-                                              type:
-                                                type: string
-                                                enum:
-                                                  - video
-                                              url:
-                                                type: string
-                                                format: uri
-                                              position:
-                                                type: object
-                                                properties:
-                                                  start:
-                                                    type: integer
-                                                  end:
-                                                    type: integer
-                                                required:
-                                                  - start
-                                                  - end
-                                              mediaType:
-                                                type: string
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
                                             required:
-                                              - type
-                                              - url
-                                              - position
-                                              - mediaType
-                                      - type: 'null'
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - type: object
+                                        properties:
+                                          type:
+                                            type: string
+                                            enum:
+                                              - video
+                                          url:
+                                            type: string
+                                            format: uri
+                                          position:
+                                            type: object
+                                            properties:
+                                              start:
+                                                type: integer
+                                              end:
+                                                type: integer
+                                            required:
+                                              - start
+                                              - end
+                                          mediaType:
+                                            type: string
+                                        required:
+                                          - type
+                                          - url
+                                          - position
+                                          - mediaType
+                                      - {}
                                       - type: 'null'
                               required:
                                 - app
@@ -5445,281 +5405,277 @@ paths:
                                     type: array
                                     items:
                                       anyOf:
-                                        - anyOf:
-                                            - type: object
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - ens
+                                            avatarUrl:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            name:
+                                              type: string
+                                            address: {}
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - ens
-                                                avatarUrl:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                name:
-                                                  type: string
-                                                address: {}
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                              required:
-                                                - type
-                                                - avatarUrl
-                                                - name
-                                                - address
-                                                - position
-                                                - url
-                                            - type: object
-                                              properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - erc20
-                                                symbol:
-                                                  type: string
-                                                logoURI:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                name:
-                                                  type: string
-                                                address: {}
-                                                decimals:
+                                                start:
                                                   type: integer
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                chainId:
-                                                  type:
-                                                    - integer
-                                                    - 'null'
-                                                  exclusiveMinimum: 0
-                                                chains:
-                                                  type: array
-                                                  items:
-                                                    type: object
-                                                    properties:
-                                                      caip:
-                                                        type: string
-                                                      chainId:
-                                                        type: integer
-                                                        exclusiveMinimum: 0
-                                                    required:
-                                                      - caip
-                                                      - chainId
-                                              required:
-                                                - type
-                                                - symbol
-                                                - logoURI
-                                                - name
-                                                - address
-                                                - decimals
-                                                - position
-                                                - chainId
-                                                - chains
-                                            - type: object
-                                              properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - farcaster
-                                                address: {}
-                                                fid:
+                                                end:
                                                   type: integer
-                                                fname:
-                                                  type: string
-                                                username:
-                                                  type: string
-                                                displayName:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                pfpUrl:
-                                                  type:
-                                                    - string
-                                                    - 'null'
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                url:
-                                                  type: string
-                                                  format: uri
                                               required:
-                                                - type
-                                                - address
-                                                - fid
-                                                - fname
-                                                - username
-                                                - displayName
-                                                - pfpUrl
-                                                - position
-                                                - url
-                                            - type: object
+                                                - start
+                                                - end
+                                            url:
+                                              type: string
+                                              format: uri
+                                          required:
+                                            - type
+                                            - avatarUrl
+                                            - name
+                                            - address
+                                            - position
+                                            - url
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - erc20
+                                            symbol:
+                                              type: string
+                                            logoURI:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            name:
+                                              type: string
+                                            address: {}
+                                            decimals:
+                                              type: integer
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - webpage
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            chainId:
+                                              type:
+                                                - integer
+                                                - 'null'
+                                              exclusiveMinimum: 0
+                                            chains:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  caip:
+                                                    type: string
+                                                  chainId:
+                                                    type: integer
+                                                    exclusiveMinimum: 0
+                                                required:
+                                                  - caip
+                                                  - chainId
+                                          required:
+                                            - type
+                                            - symbol
+                                            - logoURI
+                                            - name
+                                            - address
+                                            - decimals
+                                            - position
+                                            - chainId
+                                            - chains
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - farcaster
+                                            address: {}
+                                            fid:
+                                              type: integer
+                                            fname:
+                                              type: string
+                                            username:
+                                              type: string
+                                            displayName:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            pfpUrl:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            position:
+                                              type: object
+                                              properties:
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            url:
+                                              type: string
+                                              format: uri
+                                          required:
+                                            - type
+                                            - address
+                                            - fid
+                                            - fname
+                                            - username
+                                            - displayName
+                                            - pfpUrl
+                                            - position
+                                            - url
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - webpage
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
+                                              properties:
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            title:
+                                              type: string
+                                            description:
+                                              type:
+                                                - string
+                                                - 'null'
+                                            favicon:
+                                              type:
+                                                - string
+                                                - 'null'
+                                              format: uri
+                                            opengraph:
+                                              type:
+                                                - object
+                                                - 'null'
+                                              properties:
                                                 title:
                                                   type: string
                                                 description:
                                                   type:
                                                     - string
                                                     - 'null'
-                                                favicon:
-                                                  type:
-                                                    - string
-                                                    - 'null'
+                                                image:
+                                                  type: string
                                                   format: uri
-                                                opengraph:
-                                                  type:
-                                                    - object
-                                                    - 'null'
-                                                  properties:
-                                                    title:
-                                                      type: string
-                                                    description:
-                                                      type:
-                                                        - string
-                                                        - 'null'
-                                                    image:
-                                                      anyOf:
-                                                        - type: string
-                                                          format: uri
-                                                        - type: string
-                                                          pattern: ^\/[^\s]+$
-                                                    url:
-                                                      type: string
-                                                      format: uri
-                                                  required:
-                                                    - title
-                                                    - description
-                                                    - image
-                                                    - url
+                                                url:
+                                                  type: string
+                                                  format: uri
                                               required:
-                                                - type
-                                                - url
-                                                - position
                                                 - title
                                                 - description
-                                                - favicon
-                                                - opengraph
-                                            - type: object
-                                              properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - file
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                mediaType:
-                                                  type: string
-                                              required:
-                                                - type
+                                                - image
                                                 - url
-                                                - position
-                                                - mediaType
-                                            - type: object
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - title
+                                            - description
+                                            - favicon
+                                            - opengraph
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - file
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - image
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                mediaType:
-                                                  type: string
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
                                               required:
-                                                - type
-                                                - url
-                                                - position
-                                                - mediaType
-                                            - type: object
+                                                - start
+                                                - end
+                                            mediaType:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - mediaType
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - image
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
                                               properties:
-                                                type:
-                                                  type: string
-                                                  enum:
-                                                    - video
-                                                url:
-                                                  type: string
-                                                  format: uri
-                                                position:
-                                                  type: object
-                                                  properties:
-                                                    start:
-                                                      type: integer
-                                                    end:
-                                                      type: integer
-                                                  required:
-                                                    - start
-                                                    - end
-                                                mediaType:
-                                                  type: string
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
                                               required:
-                                                - type
-                                                - url
-                                                - position
-                                                - mediaType
-                                        - type: 'null'
+                                                - start
+                                                - end
+                                            mediaType:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - mediaType
+                                        - type: object
+                                          properties:
+                                            type:
+                                              type: string
+                                              enum:
+                                                - video
+                                            url:
+                                              type: string
+                                              format: uri
+                                            position:
+                                              type: object
+                                              properties:
+                                                start:
+                                                  type: integer
+                                                end:
+                                                  type: integer
+                                              required:
+                                                - start
+                                                - end
+                                            mediaType:
+                                              type: string
+                                          required:
+                                            - type
+                                            - url
+                                            - position
+                                            - mediaType
+                                        - {}
                                         - type: 'null'
                                   viewerReactions:
                                     type: object
@@ -5880,281 +5836,277 @@ paths:
                                             type: array
                                             items:
                                               anyOf:
-                                                - anyOf:
-                                                    - type: object
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - ens
+                                                    avatarUrl:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    name:
+                                                      type: string
+                                                    address: {}
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - ens
-                                                        avatarUrl:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        name:
-                                                          type: string
-                                                        address: {}
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                      required:
-                                                        - type
-                                                        - avatarUrl
-                                                        - name
-                                                        - address
-                                                        - position
-                                                        - url
-                                                    - type: object
-                                                      properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - erc20
-                                                        symbol:
-                                                          type: string
-                                                        logoURI:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        name:
-                                                          type: string
-                                                        address: {}
-                                                        decimals:
+                                                        start:
                                                           type: integer
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        chainId:
-                                                          type:
-                                                            - integer
-                                                            - 'null'
-                                                          exclusiveMinimum: 0
-                                                        chains:
-                                                          type: array
-                                                          items:
-                                                            type: object
-                                                            properties:
-                                                              caip:
-                                                                type: string
-                                                              chainId:
-                                                                type: integer
-                                                                exclusiveMinimum: 0
-                                                            required:
-                                                              - caip
-                                                              - chainId
-                                                      required:
-                                                        - type
-                                                        - symbol
-                                                        - logoURI
-                                                        - name
-                                                        - address
-                                                        - decimals
-                                                        - position
-                                                        - chainId
-                                                        - chains
-                                                    - type: object
-                                                      properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - farcaster
-                                                        address: {}
-                                                        fid:
+                                                        end:
                                                           type: integer
-                                                        fname:
-                                                          type: string
-                                                        username:
-                                                          type: string
-                                                        displayName:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        pfpUrl:
-                                                          type:
-                                                            - string
-                                                            - 'null'
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        url:
-                                                          type: string
-                                                          format: uri
                                                       required:
-                                                        - type
-                                                        - address
-                                                        - fid
-                                                        - fname
-                                                        - username
-                                                        - displayName
-                                                        - pfpUrl
-                                                        - position
-                                                        - url
-                                                    - type: object
+                                                        - start
+                                                        - end
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                  required:
+                                                    - type
+                                                    - avatarUrl
+                                                    - name
+                                                    - address
+                                                    - position
+                                                    - url
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - erc20
+                                                    symbol:
+                                                      type: string
+                                                    logoURI:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    name:
+                                                      type: string
+                                                    address: {}
+                                                    decimals:
+                                                      type: integer
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - webpage
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    chainId:
+                                                      type:
+                                                        - integer
+                                                        - 'null'
+                                                      exclusiveMinimum: 0
+                                                    chains:
+                                                      type: array
+                                                      items:
+                                                        type: object
+                                                        properties:
+                                                          caip:
+                                                            type: string
+                                                          chainId:
+                                                            type: integer
+                                                            exclusiveMinimum: 0
+                                                        required:
+                                                          - caip
+                                                          - chainId
+                                                  required:
+                                                    - type
+                                                    - symbol
+                                                    - logoURI
+                                                    - name
+                                                    - address
+                                                    - decimals
+                                                    - position
+                                                    - chainId
+                                                    - chains
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - farcaster
+                                                    address: {}
+                                                    fid:
+                                                      type: integer
+                                                    fname:
+                                                      type: string
+                                                    username:
+                                                      type: string
+                                                    displayName:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    pfpUrl:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    position:
+                                                      type: object
+                                                      properties:
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                  required:
+                                                    - type
+                                                    - address
+                                                    - fid
+                                                    - fname
+                                                    - username
+                                                    - displayName
+                                                    - pfpUrl
+                                                    - position
+                                                    - url
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - webpage
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
+                                                      properties:
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    title:
+                                                      type: string
+                                                    description:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                    favicon:
+                                                      type:
+                                                        - string
+                                                        - 'null'
+                                                      format: uri
+                                                    opengraph:
+                                                      type:
+                                                        - object
+                                                        - 'null'
+                                                      properties:
                                                         title:
                                                           type: string
                                                         description:
                                                           type:
                                                             - string
                                                             - 'null'
-                                                        favicon:
-                                                          type:
-                                                            - string
-                                                            - 'null'
+                                                        image:
+                                                          type: string
                                                           format: uri
-                                                        opengraph:
-                                                          type:
-                                                            - object
-                                                            - 'null'
-                                                          properties:
-                                                            title:
-                                                              type: string
-                                                            description:
-                                                              type:
-                                                                - string
-                                                                - 'null'
-                                                            image:
-                                                              anyOf:
-                                                                - type: string
-                                                                  format: uri
-                                                                - type: string
-                                                                  pattern: ^\/[^\s]+$
-                                                            url:
-                                                              type: string
-                                                              format: uri
-                                                          required:
-                                                            - title
-                                                            - description
-                                                            - image
-                                                            - url
+                                                        url:
+                                                          type: string
+                                                          format: uri
                                                       required:
-                                                        - type
-                                                        - url
-                                                        - position
                                                         - title
                                                         - description
-                                                        - favicon
-                                                        - opengraph
-                                                    - type: object
-                                                      properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - file
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        mediaType:
-                                                          type: string
-                                                      required:
-                                                        - type
+                                                        - image
                                                         - url
-                                                        - position
-                                                        - mediaType
-                                                    - type: object
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - title
+                                                    - description
+                                                    - favicon
+                                                    - opengraph
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - file
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - image
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        mediaType:
-                                                          type: string
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
                                                       required:
-                                                        - type
-                                                        - url
-                                                        - position
-                                                        - mediaType
-                                                    - type: object
+                                                        - start
+                                                        - end
+                                                    mediaType:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - mediaType
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - image
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
                                                       properties:
-                                                        type:
-                                                          type: string
-                                                          enum:
-                                                            - video
-                                                        url:
-                                                          type: string
-                                                          format: uri
-                                                        position:
-                                                          type: object
-                                                          properties:
-                                                            start:
-                                                              type: integer
-                                                            end:
-                                                              type: integer
-                                                          required:
-                                                            - start
-                                                            - end
-                                                        mediaType:
-                                                          type: string
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
                                                       required:
-                                                        - type
-                                                        - url
-                                                        - position
-                                                        - mediaType
-                                                - type: 'null'
+                                                        - start
+                                                        - end
+                                                    mediaType:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - mediaType
+                                                - type: object
+                                                  properties:
+                                                    type:
+                                                      type: string
+                                                      enum:
+                                                        - video
+                                                    url:
+                                                      type: string
+                                                      format: uri
+                                                    position:
+                                                      type: object
+                                                      properties:
+                                                        start:
+                                                          type: integer
+                                                        end:
+                                                          type: integer
+                                                      required:
+                                                        - start
+                                                        - end
+                                                    mediaType:
+                                                      type: string
+                                                  required:
+                                                    - type
+                                                    - url
+                                                    - position
+                                                    - mediaType
+                                                - {}
                                                 - type: 'null'
                                         required:
                                           - app
@@ -6834,281 +6786,277 @@ paths:
                           type: array
                           items:
                             anyOf:
-                              - anyOf:
-                                  - type: object
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - ens
+                                  avatarUrl:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  name:
+                                    type: string
+                                  address: {}
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - ens
-                                      avatarUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
-                                    required:
-                                      - type
-                                      - avatarUrl
-                                      - name
-                                      - address
-                                      - position
-                                      - url
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - erc20
-                                      symbol:
-                                        type: string
-                                      logoURI:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      name:
-                                        type: string
-                                      address: {}
-                                      decimals:
+                                      start:
                                         type: integer
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      chainId:
-                                        type:
-                                          - integer
-                                          - 'null'
-                                        exclusiveMinimum: 0
-                                      chains:
-                                        type: array
-                                        items:
-                                          type: object
-                                          properties:
-                                            caip:
-                                              type: string
-                                            chainId:
-                                              type: integer
-                                              exclusiveMinimum: 0
-                                          required:
-                                            - caip
-                                            - chainId
-                                    required:
-                                      - type
-                                      - symbol
-                                      - logoURI
-                                      - name
-                                      - address
-                                      - decimals
-                                      - position
-                                      - chainId
-                                      - chains
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - farcaster
-                                      address: {}
-                                      fid:
+                                      end:
                                         type: integer
-                                      fname:
-                                        type: string
-                                      username:
-                                        type: string
-                                      displayName:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      pfpUrl:
-                                        type:
-                                          - string
-                                          - 'null'
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      url:
-                                        type: string
-                                        format: uri
                                     required:
-                                      - type
-                                      - address
-                                      - fid
-                                      - fname
-                                      - username
-                                      - displayName
-                                      - pfpUrl
-                                      - position
-                                      - url
-                                  - type: object
+                                      - start
+                                      - end
+                                  url:
+                                    type: string
+                                    format: uri
+                                required:
+                                  - type
+                                  - avatarUrl
+                                  - name
+                                  - address
+                                  - position
+                                  - url
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - erc20
+                                  symbol:
+                                    type: string
+                                  logoURI:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  name:
+                                    type: string
+                                  address: {}
+                                  decimals:
+                                    type: integer
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - webpage
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  chainId:
+                                    type:
+                                      - integer
+                                      - 'null'
+                                    exclusiveMinimum: 0
+                                  chains:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        caip:
+                                          type: string
+                                        chainId:
+                                          type: integer
+                                          exclusiveMinimum: 0
+                                      required:
+                                        - caip
+                                        - chainId
+                                required:
+                                  - type
+                                  - symbol
+                                  - logoURI
+                                  - name
+                                  - address
+                                  - decimals
+                                  - position
+                                  - chainId
+                                  - chains
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - farcaster
+                                  address: {}
+                                  fid:
+                                    type: integer
+                                  fname:
+                                    type: string
+                                  username:
+                                    type: string
+                                  displayName:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  pfpUrl:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  url:
+                                    type: string
+                                    format: uri
+                                required:
+                                  - type
+                                  - address
+                                  - fid
+                                  - fname
+                                  - username
+                                  - displayName
+                                  - pfpUrl
+                                  - position
+                                  - url
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - webpage
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  title:
+                                    type: string
+                                  description:
+                                    type:
+                                      - string
+                                      - 'null'
+                                  favicon:
+                                    type:
+                                      - string
+                                      - 'null'
+                                    format: uri
+                                  opengraph:
+                                    type:
+                                      - object
+                                      - 'null'
+                                    properties:
                                       title:
                                         type: string
                                       description:
                                         type:
                                           - string
                                           - 'null'
-                                      favicon:
-                                        type:
-                                          - string
-                                          - 'null'
+                                      image:
+                                        type: string
                                         format: uri
-                                      opengraph:
-                                        type:
-                                          - object
-                                          - 'null'
-                                        properties:
-                                          title:
-                                            type: string
-                                          description:
-                                            type:
-                                              - string
-                                              - 'null'
-                                          image:
-                                            anyOf:
-                                              - type: string
-                                                format: uri
-                                              - type: string
-                                                pattern: ^\/[^\s]+$
-                                          url:
-                                            type: string
-                                            format: uri
-                                        required:
-                                          - title
-                                          - description
-                                          - image
-                                          - url
+                                      url:
+                                        type: string
+                                        format: uri
                                     required:
-                                      - type
-                                      - url
-                                      - position
                                       - title
                                       - description
-                                      - favicon
-                                      - opengraph
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - file
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
-                                    required:
-                                      - type
+                                      - image
                                       - url
-                                      - position
-                                      - mediaType
-                                  - type: object
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - title
+                                  - description
+                                  - favicon
+                                  - opengraph
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - file
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - image
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
                                     required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                                  - type: object
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - image
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
                                     properties:
-                                      type:
-                                        type: string
-                                        enum:
-                                          - video
-                                      url:
-                                        type: string
-                                        format: uri
-                                      position:
-                                        type: object
-                                        properties:
-                                          start:
-                                            type: integer
-                                          end:
-                                            type: integer
-                                        required:
-                                          - start
-                                          - end
-                                      mediaType:
-                                        type: string
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
                                     required:
-                                      - type
-                                      - url
-                                      - position
-                                      - mediaType
-                              - type: 'null'
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    enum:
+                                      - video
+                                  url:
+                                    type: string
+                                    format: uri
+                                  position:
+                                    type: object
+                                    properties:
+                                      start:
+                                        type: integer
+                                      end:
+                                        type: integer
+                                    required:
+                                      - start
+                                      - end
+                                  mediaType:
+                                    type: string
+                                required:
+                                  - type
+                                  - url
+                                  - position
+                                  - mediaType
+                              - {}
                               - type: 'null'
                       required:
                         - app
@@ -7369,281 +7317,277 @@ paths:
                     type: array
                     items:
                       anyOf:
-                        - anyOf:
-                            - type: object
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - ens
+                            avatarUrl:
+                              type:
+                                - string
+                                - 'null'
+                            name:
+                              type: string
+                            address: {}
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - ens
-                                avatarUrl:
-                                  type:
-                                    - string
-                                    - 'null'
-                                name:
-                                  type: string
-                                address: {}
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                url:
-                                  type: string
-                                  format: uri
-                              required:
-                                - type
-                                - avatarUrl
-                                - name
-                                - address
-                                - position
-                                - url
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - erc20
-                                symbol:
-                                  type: string
-                                logoURI:
-                                  type:
-                                    - string
-                                    - 'null'
-                                name:
-                                  type: string
-                                address: {}
-                                decimals:
+                                start:
                                   type: integer
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                chainId:
-                                  type:
-                                    - integer
-                                    - 'null'
-                                  exclusiveMinimum: 0
-                                chains:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      caip:
-                                        type: string
-                                      chainId:
-                                        type: integer
-                                        exclusiveMinimum: 0
-                                    required:
-                                      - caip
-                                      - chainId
-                              required:
-                                - type
-                                - symbol
-                                - logoURI
-                                - name
-                                - address
-                                - decimals
-                                - position
-                                - chainId
-                                - chains
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - farcaster
-                                address: {}
-                                fid:
+                                end:
                                   type: integer
-                                fname:
-                                  type: string
-                                username:
-                                  type: string
-                                displayName:
-                                  type:
-                                    - string
-                                    - 'null'
-                                pfpUrl:
-                                  type:
-                                    - string
-                                    - 'null'
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                url:
-                                  type: string
-                                  format: uri
                               required:
-                                - type
-                                - address
-                                - fid
-                                - fname
-                                - username
-                                - displayName
-                                - pfpUrl
-                                - position
-                                - url
-                            - type: object
+                                - start
+                                - end
+                            url:
+                              type: string
+                              format: uri
+                          required:
+                            - type
+                            - avatarUrl
+                            - name
+                            - address
+                            - position
+                            - url
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - erc20
+                            symbol:
+                              type: string
+                            logoURI:
+                              type:
+                                - string
+                                - 'null'
+                            name:
+                              type: string
+                            address: {}
+                            decimals:
+                              type: integer
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - webpage
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            chainId:
+                              type:
+                                - integer
+                                - 'null'
+                              exclusiveMinimum: 0
+                            chains:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  caip:
+                                    type: string
+                                  chainId:
+                                    type: integer
+                                    exclusiveMinimum: 0
+                                required:
+                                  - caip
+                                  - chainId
+                          required:
+                            - type
+                            - symbol
+                            - logoURI
+                            - name
+                            - address
+                            - decimals
+                            - position
+                            - chainId
+                            - chains
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - farcaster
+                            address: {}
+                            fid:
+                              type: integer
+                            fname:
+                              type: string
+                            username:
+                              type: string
+                            displayName:
+                              type:
+                                - string
+                                - 'null'
+                            pfpUrl:
+                              type:
+                                - string
+                                - 'null'
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            url:
+                              type: string
+                              format: uri
+                          required:
+                            - type
+                            - address
+                            - fid
+                            - fname
+                            - username
+                            - displayName
+                            - pfpUrl
+                            - position
+                            - url
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - webpage
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            title:
+                              type: string
+                            description:
+                              type:
+                                - string
+                                - 'null'
+                            favicon:
+                              type:
+                                - string
+                                - 'null'
+                              format: uri
+                            opengraph:
+                              type:
+                                - object
+                                - 'null'
+                              properties:
                                 title:
                                   type: string
                                 description:
                                   type:
                                     - string
                                     - 'null'
-                                favicon:
-                                  type:
-                                    - string
-                                    - 'null'
+                                image:
+                                  type: string
                                   format: uri
-                                opengraph:
-                                  type:
-                                    - object
-                                    - 'null'
-                                  properties:
-                                    title:
-                                      type: string
-                                    description:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    image:
-                                      anyOf:
-                                        - type: string
-                                          format: uri
-                                        - type: string
-                                          pattern: ^\/[^\s]+$
-                                    url:
-                                      type: string
-                                      format: uri
-                                  required:
-                                    - title
-                                    - description
-                                    - image
-                                    - url
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - type
-                                - url
-                                - position
                                 - title
                                 - description
-                                - favicon
-                                - opengraph
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - file
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
-                              required:
-                                - type
+                                - image
                                 - url
-                                - position
-                                - mediaType
-                            - type: object
+                          required:
+                            - type
+                            - url
+                            - position
+                            - title
+                            - description
+                            - favicon
+                            - opengraph
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - file
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - image
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
                               required:
-                                - type
-                                - url
-                                - position
-                                - mediaType
-                            - type: object
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - image
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - video
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
                               required:
-                                - type
-                                - url
-                                - position
-                                - mediaType
-                        - type: 'null'
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - video
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - {}
                         - type: 'null'
                 required:
                   - app
@@ -7878,281 +7822,277 @@ paths:
                     type: array
                     items:
                       anyOf:
-                        - anyOf:
-                            - type: object
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - ens
+                            avatarUrl:
+                              type:
+                                - string
+                                - 'null'
+                            name:
+                              type: string
+                            address: {}
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - ens
-                                avatarUrl:
-                                  type:
-                                    - string
-                                    - 'null'
-                                name:
-                                  type: string
-                                address: {}
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                url:
-                                  type: string
-                                  format: uri
-                              required:
-                                - type
-                                - avatarUrl
-                                - name
-                                - address
-                                - position
-                                - url
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - erc20
-                                symbol:
-                                  type: string
-                                logoURI:
-                                  type:
-                                    - string
-                                    - 'null'
-                                name:
-                                  type: string
-                                address: {}
-                                decimals:
+                                start:
                                   type: integer
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                chainId:
-                                  type:
-                                    - integer
-                                    - 'null'
-                                  exclusiveMinimum: 0
-                                chains:
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      caip:
-                                        type: string
-                                      chainId:
-                                        type: integer
-                                        exclusiveMinimum: 0
-                                    required:
-                                      - caip
-                                      - chainId
-                              required:
-                                - type
-                                - symbol
-                                - logoURI
-                                - name
-                                - address
-                                - decimals
-                                - position
-                                - chainId
-                                - chains
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - farcaster
-                                address: {}
-                                fid:
+                                end:
                                   type: integer
-                                fname:
-                                  type: string
-                                username:
-                                  type: string
-                                displayName:
-                                  type:
-                                    - string
-                                    - 'null'
-                                pfpUrl:
-                                  type:
-                                    - string
-                                    - 'null'
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                url:
-                                  type: string
-                                  format: uri
                               required:
-                                - type
-                                - address
-                                - fid
-                                - fname
-                                - username
-                                - displayName
-                                - pfpUrl
-                                - position
-                                - url
-                            - type: object
+                                - start
+                                - end
+                            url:
+                              type: string
+                              format: uri
+                          required:
+                            - type
+                            - avatarUrl
+                            - name
+                            - address
+                            - position
+                            - url
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - erc20
+                            symbol:
+                              type: string
+                            logoURI:
+                              type:
+                                - string
+                                - 'null'
+                            name:
+                              type: string
+                            address: {}
+                            decimals:
+                              type: integer
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - webpage
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            chainId:
+                              type:
+                                - integer
+                                - 'null'
+                              exclusiveMinimum: 0
+                            chains:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  caip:
+                                    type: string
+                                  chainId:
+                                    type: integer
+                                    exclusiveMinimum: 0
+                                required:
+                                  - caip
+                                  - chainId
+                          required:
+                            - type
+                            - symbol
+                            - logoURI
+                            - name
+                            - address
+                            - decimals
+                            - position
+                            - chainId
+                            - chains
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - farcaster
+                            address: {}
+                            fid:
+                              type: integer
+                            fname:
+                              type: string
+                            username:
+                              type: string
+                            displayName:
+                              type:
+                                - string
+                                - 'null'
+                            pfpUrl:
+                              type:
+                                - string
+                                - 'null'
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            url:
+                              type: string
+                              format: uri
+                          required:
+                            - type
+                            - address
+                            - fid
+                            - fname
+                            - username
+                            - displayName
+                            - pfpUrl
+                            - position
+                            - url
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - webpage
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            title:
+                              type: string
+                            description:
+                              type:
+                                - string
+                                - 'null'
+                            favicon:
+                              type:
+                                - string
+                                - 'null'
+                              format: uri
+                            opengraph:
+                              type:
+                                - object
+                                - 'null'
+                              properties:
                                 title:
                                   type: string
                                 description:
                                   type:
                                     - string
                                     - 'null'
-                                favicon:
-                                  type:
-                                    - string
-                                    - 'null'
+                                image:
+                                  type: string
                                   format: uri
-                                opengraph:
-                                  type:
-                                    - object
-                                    - 'null'
-                                  properties:
-                                    title:
-                                      type: string
-                                    description:
-                                      type:
-                                        - string
-                                        - 'null'
-                                    image:
-                                      anyOf:
-                                        - type: string
-                                          format: uri
-                                        - type: string
-                                          pattern: ^\/[^\s]+$
-                                    url:
-                                      type: string
-                                      format: uri
-                                  required:
-                                    - title
-                                    - description
-                                    - image
-                                    - url
+                                url:
+                                  type: string
+                                  format: uri
                               required:
-                                - type
-                                - url
-                                - position
                                 - title
                                 - description
-                                - favicon
-                                - opengraph
-                            - type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - file
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
-                              required:
-                                - type
+                                - image
                                 - url
-                                - position
-                                - mediaType
-                            - type: object
+                          required:
+                            - type
+                            - url
+                            - position
+                            - title
+                            - description
+                            - favicon
+                            - opengraph
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - file
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - image
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
                               required:
-                                - type
-                                - url
-                                - position
-                                - mediaType
-                            - type: object
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - image
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
                               properties:
-                                type:
-                                  type: string
-                                  enum:
-                                    - video
-                                url:
-                                  type: string
-                                  format: uri
-                                position:
-                                  type: object
-                                  properties:
-                                    start:
-                                      type: integer
-                                    end:
-                                      type: integer
-                                  required:
-                                    - start
-                                    - end
-                                mediaType:
-                                  type: string
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
                               required:
-                                - type
-                                - url
-                                - position
-                                - mediaType
-                        - type: 'null'
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - type: object
+                          properties:
+                            type:
+                              type: string
+                              enum:
+                                - video
+                            url:
+                              type: string
+                              format: uri
+                            position:
+                              type: object
+                              properties:
+                                start:
+                                  type: integer
+                                end:
+                                  type: integer
+                              required:
+                                - start
+                                - end
+                            mediaType:
+                              type: string
+                          required:
+                            - type
+                            - url
+                            - position
+                            - mediaType
+                        - {}
                         - type: 'null'
                 required:
                   - app

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -3007,6 +3007,12 @@
     <priority>0.4</priority>
   </url>
   <url>
+    <loc>https://docs.ethcomments.xyz/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaInputType</loc>
+    <lastmod>2025-09-16T14:10:54.777Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/indexer/type-aliases/IndexerAPICommentReferencesSchemaType</loc>
     <lastmod>2025-09-10T11:13:46.000Z</lastmod>
     <changefreq>weekly</changefreq>

--- a/packages/sdk/src/indexer/test/schemas.ts
+++ b/packages/sdk/src/indexer/test/schemas.ts
@@ -1,0 +1,124 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { IndexerAPICommentReferencesSchema } from "../schemas.js";
+
+const position = {
+  start: 0,
+  end: 100,
+};
+
+describe("IndexerAPICommentReferencesSchema", () => {
+  it("should parse an array of references", () => {
+    const commentReferences = [
+      {
+        position,
+        type: "video",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        mediaType: "video/mp4",
+      },
+      {
+        position,
+        type: "image",
+        url: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+        mediaType: "image/png",
+      },
+      {
+        position,
+        type: "webpage",
+        url: "https://www.google.com",
+        title: "Google",
+        description: "Google is a search engine",
+        favicon: "https://www.google.com/favicon.ico",
+        opengraph: {
+          title: "Google",
+          description: "Google is a search engine",
+          image:
+            "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+          url: "https://www.google.com",
+        },
+      },
+      {
+        position,
+        type: "file",
+        url: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+        mediaType: "image/png",
+      },
+    ];
+
+    const parsed =
+      IndexerAPICommentReferencesSchema.safeParse(commentReferences);
+
+    if (!parsed.success) {
+      console.error(JSON.stringify(parsed.error, null, 2));
+    }
+
+    assert.ok(parsed.success);
+    assert.deepStrictEqual(parsed.data, commentReferences);
+  });
+
+  it("should avoid any invalid reference", () => {
+    const commentReferences = [
+      {
+        position,
+        type: "video",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        mediaType: "video/mp4",
+      },
+      {
+        position,
+        type: "image",
+        url: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+        mediaType: "image/png",
+      },
+      {
+        position,
+        type: "webpage",
+        url: "https://www.google.com",
+        title: "Google",
+        description: "Google is a search engine",
+        favicon: "https://www.google.com/favicon.ico",
+        opengraph: {
+          title: "Google",
+          description: "Google is a search engine",
+          image: "/not-a-url",
+          url: "https://www.google.com",
+        },
+      },
+      {
+        position,
+        type: "file",
+        url: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+        mediaType: "image/png",
+      },
+    ];
+
+    const parsed =
+      IndexerAPICommentReferencesSchema.safeParse(commentReferences);
+
+    if (!parsed.success) {
+      console.error(JSON.stringify(parsed.error, null, 2));
+    }
+
+    assert.ok(parsed.success);
+    assert.deepStrictEqual(parsed.data, [
+      {
+        position,
+        type: "video",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        mediaType: "video/mp4",
+      },
+      {
+        position,
+        type: "image",
+        url: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+        mediaType: "image/png",
+      },
+      {
+        position,
+        type: "file",
+        url: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png",
+        mediaType: "image/png",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
1. for opengraph image field, although the spec says it should be an absolute url, we should still resolve pathname into absolute url before inserting into database, as any website cut corners.
2. validate the schema before inserting into database.
3. not fail the whole query if any reference fail to validate, should instead just ignore it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Open Graph image URLs are now validated and normalized to absolute URLs, reducing broken previews.

- Refactor
  - Resolvers now return runtime-validated reference objects; invalid entries are dropped.

- Documentation
  - API docs updated: image fields are URI-only; attachment/reference arrays allow null or empty items; new type alias documented.

- Tests
  - Added tests confirming parsing of valid references and removal of invalid webpage references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->