### PR TITLE
docs(changeset): fix(sdk): temporarily added a schema fix to avoid cr…

### DIFF
--- a/.changeset/tricky-beds-marry.md
+++ b/.changeset/tricky-beds-marry.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+fix(sdk): temporarily added a schema fix to avoid crashing on opengraph image schema error


### PR DESCRIPTION
…ashing on opengraph image schema error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a changeset entry documenting a patch for the SDK that temporarily mitigates crashes related to OpenGraph image schema errors.
- Chores
  - Prepared release metadata to publish the patch.
  - No runtime behavior or public API changes are included in this PR.
  - End-users should not see any functional differences until the patch is released, but the change positions the package for a stability improvement release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->