### PR TITLE
fix(embed,demo): enlarge media preview and take full available space for video

### DIFF
--- a/packages/shared/src/components/CommentMediaReference.tsx
+++ b/packages/shared/src/components/CommentMediaReference.tsx
@@ -38,7 +38,7 @@ function CommentMediaReferenceWrapper({
   children: React.ReactNode;
 }) {
   return (
-    <div className="w-[100px] h-[100px] flex flex-col items-center justify-center gap-2 p-2 border rounded-md bg-muted/30 overflow-hidden">
+    <div className="w-[200px] h-[200px] flex flex-col items-center justify-center gap-2 p-2 border rounded-md bg-muted/30 overflow-hidden">
       {children}
     </div>
   );

--- a/packages/shared/src/components/CommentMediaVideo.tsx
+++ b/packages/shared/src/components/CommentMediaVideo.tsx
@@ -45,7 +45,7 @@ export function CommentMediaVideo({
       ref={videoRef}
       src={url}
       controls
-      className="max-w-full max-h-full rounded-md"
+      className="w-full h-full rounded-md"
       style={{ objectFit }}
     />
   );
@@ -53,7 +53,12 @@ export function CommentMediaVideo({
   return (
     <div className="w-full h-full flex items-center justify-center">
       {typeof file === "string" ? (
-        <a href={file} target="_blank" rel="noopener noreferrer">
+        <a
+          href={file}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="w-full h-full"
+        >
           {video}
         </a>
       ) : (


### PR DESCRIPTION
The preview was way too small for videos, and it was unusable when the controls shows up:

<img width="1978" height="1438" alt="image" src="https://github.com/user-attachments/assets/a576e337-cc9d-4c66-a10b-20d857b3ad6e" />

in this PR:
1. enlarges the preview box to 200px 
2. make video default to take full available space, to make room for the controls

this is how it looks like
<img width="969" height="945" alt="image" src="https://github.com/user-attachments/assets/9afa97fc-aad6-4195-a907-c262995f069b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Enlarged comment media preview tiles from 100px to 200px for improved visibility of attached content.
  - Videos now fill the entire preview tile for a more consistent, edge-to-edge display.
  - Clickable area for video previews expanded to the full tile, making tapping/clicking easier.
  - Purely visual/layout updates; no changes to behavior or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->