### PR TITLE
fix(indexer): `content` with 0 ref should be considered success

### DIFF
--- a/apps/indexer/src/lib/resolve-comment-references.ts
+++ b/apps/indexer/src/lib/resolve-comment-references.ts
@@ -185,10 +185,10 @@ export async function resolveCommentReferences(
 
   let status: CommentSelectType["referencesResolutionStatus"] = "partial";
 
-  if (failed === count) {
-    status = "failed";
-  } else if (resolved === count) {
+  if (resolved === count) {
     status = "success";
+  } else if (failed === count) {
+    status = "failed";
   }
 
   return {


### PR DESCRIPTION
when `count` is `0` meaning there is no ref in the `content`, in this case we don't want to revisit the ref resolution, hence should mark it as `success` instead of `failed`