### PR TITLE
fix(indexer): worker start up issue

### DIFF
--- a/apps/indexer/bin/shared.ts
+++ b/apps/indexer/bin/shared.ts
@@ -7,7 +7,7 @@ const workerCommand = new Command()
     "-i, --indexer-url <url>",
     "The URL of the indexer",
     (value) => z.string().url().parse(value),
-    "https://localhost:42069",
+    "http://localhost:42069",
   );
 
 type WorkerCommandOptions = {

--- a/apps/indexer/schema.offchain.ts
+++ b/apps/indexer/schema.offchain.ts
@@ -28,7 +28,7 @@ import type {
   EventOutboxAggregateType,
 } from "./src/events/types.ts";
 import type { WebhookAuthConfig } from "./src/webhooks/schemas.ts";
-import { IndexerAPICommentReferencesSchemaType } from "@ecp.eth/sdk/indexer";
+import { type IndexerAPICommentReferencesSchemaType } from "@ecp.eth/sdk/indexer";
 
 export const offchainSchema = pgSchema(ECP_INDEXER_SCHEMA_NAME);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default indexer URL to http://localhost:42069 (previously https://localhost:42069). This affects default local connections when no URL is specified; the tool will now connect over HTTP by default.
  * Internal cleanup: switched a schema import to type-only usage. No runtime behavior, API, or user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->