### PR TITLE
feat(indexer): make pinata retry configurable

### DIFF
--- a/apps/indexer/.env.example
+++ b/apps/indexer/.env.example
@@ -25,6 +25,14 @@ PINATA_JWT=
 # (REQUIRED) Pinata Gateway Domain (do not include protocol https://)
 PINATA_GATEWAY=
 
+# (Optional) Number of times to retry getting ipfs resource from pinata gateway server
+# (Pinata gateway sometimes can be slow pinning ipfs resource based on its cid)
+IPFS_RESOLUTION_RETRY_COUNT=5
+
+# (Optional) Initial timeout for reach retry of ipfs resource on pinata 
+# Subsequential retry will use exponential back off based on initial timeout
+IPFS_RESOLUTION_RETRY_TIMEOUT=500
+
 # (Optional) Enable moderation. Moderation is enabled by default.
 # If enabled, comments must be approved by indexer admin.
 #

--- a/apps/indexer/src/env.ts
+++ b/apps/indexer/src/env.ts
@@ -99,6 +99,13 @@ const EnvSchema = z
         },
       ),
 
+    IPFS_RESOLUTION_RETRY_COUNT: z.coerce.number().int().positive().default(5),
+    IPFS_RESOLUTION_RETRY_TIMEOUT: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(500),
+
     // this one is more of an internal flag so we can compile the indexer for docs
     SKIP_DRIZZLE_SCHEMA_DETECTION: z
       .enum(["0", "1"])

--- a/apps/indexer/src/services/ipfs-resolver.ts
+++ b/apps/indexer/src/services/ipfs-resolver.ts
@@ -20,4 +20,6 @@ export const ipfsResolverService = createIPFSResolver({
   cacheMap,
   pinataSDK,
   urlResolver: urlResolverService,
+  retryCount: env.IPFS_RESOLUTION_RETRY_COUNT,
+  retryTimeout: env.IPFS_RESOLUTION_RETRY_TIMEOUT,
 });

--- a/apps/indexer/tests/resolvers/ipfs-resolver.test.ts
+++ b/apps/indexer/tests/resolvers/ipfs-resolver.test.ts
@@ -87,7 +87,12 @@ describe("IPFS Resolver", () => {
         },
       },
     } as unknown as PinataSDK;
-    const ipfsResolver = createIPFSResolver({ urlResolver, pinataSDK });
+    const ipfsResolver = createIPFSResolver({
+      urlResolver,
+      pinataSDK,
+      retryCount: 3,
+      retryTimeout: 300,
+    });
     const ipfsUrl = "ipfs://QmTestHash";
     const result = await ipfsResolver.load(ipfsUrl);
 
@@ -133,7 +138,12 @@ describe("IPFS Resolver", () => {
         },
       },
     } as unknown as PinataSDK;
-    const ipfsResolver = createIPFSResolver({ urlResolver, pinataSDK });
+    const ipfsResolver = createIPFSResolver({
+      urlResolver,
+      pinataSDK,
+      retryCount: 3,
+      retryTimeout: 300,
+    });
     const ipfsUrl = "ipfs://QmTestHash/path/to/file.png";
     const result = await ipfsResolver.load(ipfsUrl);
 
@@ -188,6 +198,8 @@ describe("IPFS Resolver", () => {
     const fallbackResolver = createIPFSResolver({
       urlResolver: urlResolver,
       pinataSDK: pinataSDK,
+      retryCount: 3,
+      retryTimeout: 300,
     });
 
     const ipfsUrl = "ipfs://QmFallbackHash";
@@ -247,6 +259,8 @@ describe("IPFS Resolver", () => {
     const ipfsResolver = createIPFSResolver({
       urlResolver: urlResolver,
       pinataSDK: pinataSDK,
+      retryCount: 3,
+      retryTimeout: 300,
     });
 
     const ipfsUrl = "ipfs://QmTestHash/path/to/file.png";


### PR DESCRIPTION
make pinata retry configurable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable IPFS resolution retry behavior with exponential backoff via environment variables:
    - IPFS_RESOLUTION_RETRY_COUNT (default: 5)
    - IPFS_RESOLUTION_RETRY_TIMEOUT (ms, default: 500)
  - Improves reliability when fetching IPFS resources through the gateway.

- Documentation
  - Updated the indexer .env example with the new variables and explanatory comments.

- Tests
  - Expanded test coverage to include retry count and timeout scenarios for IPFS resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->