### PR TITLE
fix(sdk): createCommentData deadline was in wrong unit

### DIFF
--- a/.changeset/late-radios-tie.md
+++ b/.changeset/late-radios-tie.md
@@ -1,0 +1,5 @@
+---
+"@ecp.eth/sdk": patch
+---
+
+fix(sdk): createCommentData was in wrong unit

--- a/docs/pages/sdk-reference/comments/functions/addApproval.mdx
+++ b/docs/pages/sdk-reference/comments/functions/addApproval.mdx
@@ -10,7 +10,7 @@
 function addApproval(params): Promise<AddApprovalResult>;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:97](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L97)
+Defined in: [packages/sdk/src/comments/approval.ts:98](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L98)
 
 Approves an app signer directly as author
 

--- a/docs/pages/sdk-reference/comments/functions/createCommentData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createCommentData.mdx
@@ -38,7 +38,7 @@ function createCommentData(__namedParameters):
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:560](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L560)
+Defined in: [packages/sdk/src/comments/comment.ts:563](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L563)
 
 Create the data structure of a comment
 

--- a/docs/pages/sdk-reference/comments/functions/createCommentTypedData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createCommentTypedData.mdx
@@ -94,7 +94,7 @@ function createCommentTypedData(params): {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:535](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L535)
+Defined in: [packages/sdk/src/comments/comment.ts:538](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L538)
 
 Create the EIP-712 typed data structure for adding comment
 

--- a/docs/pages/sdk-reference/comments/functions/createDeleteCommentTypedData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createDeleteCommentTypedData.mdx
@@ -43,7 +43,7 @@ function createDeleteCommentTypedData(params): {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:634](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L634)
+Defined in: [packages/sdk/src/comments/comment.ts:637](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L637)
 
 Create the EIP-712 typed data structure for deleting comment
 

--- a/docs/pages/sdk-reference/comments/functions/createEditCommentData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createEditCommentData.mdx
@@ -20,7 +20,7 @@ function createEditCommentData(params): {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:744](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L744)
+Defined in: [packages/sdk/src/comments/comment.ts:746](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L746)
 
 Create the data structure of a comment for editing
 

--- a/docs/pages/sdk-reference/comments/functions/createEditCommentTypedData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createEditCommentTypedData.mdx
@@ -70,7 +70,7 @@ function createEditCommentTypedData(params): {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:800](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L800)
+Defined in: [packages/sdk/src/comments/comment.ts:801](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L801)
 
 Create the EIP-712 typed data structure for editing comment
 

--- a/docs/pages/sdk-reference/comments/functions/createRemoveApprovalTypedData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createRemoveApprovalTypedData.mdx
@@ -43,7 +43,7 @@ function createRemoveApprovalTypedData(params): {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:566](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L566)
+Defined in: [packages/sdk/src/comments/approval.ts:563](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L563)
 
 Create the EIP-712 typed data structure for removing approval
 

--- a/docs/pages/sdk-reference/comments/functions/createReportCommentTypedData.mdx
+++ b/docs/pages/sdk-reference/comments/functions/createReportCommentTypedData.mdx
@@ -38,7 +38,7 @@ function createReportCommentTypedData(params): {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:990](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L990)
+Defined in: [packages/sdk/src/comments/comment.ts:991](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L991)
 
 Create the EIP-712 typed data structure for reporting a comment
 

--- a/docs/pages/sdk-reference/comments/functions/getComment.mdx
+++ b/docs/pages/sdk-reference/comments/functions/getComment.mdx
@@ -10,7 +10,7 @@
 function getComment(params): Promise<GetCommentResult>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:220](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L220)
+Defined in: [packages/sdk/src/comments/comment.ts:223](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L223)
 
 Get a comment by ID
 

--- a/docs/pages/sdk-reference/comments/functions/getCommentId.mdx
+++ b/docs/pages/sdk-reference/comments/functions/getCommentId.mdx
@@ -10,7 +10,7 @@
 function getCommentId(params): Promise<`0x${string}`>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:263](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L263)
+Defined in: [packages/sdk/src/comments/comment.ts:266](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L266)
 
 Get the ID for a comment before it is posted
 

--- a/docs/pages/sdk-reference/comments/functions/getDeleteCommentHash.mdx
+++ b/docs/pages/sdk-reference/comments/functions/getDeleteCommentHash.mdx
@@ -10,7 +10,7 @@
 function getDeleteCommentHash(params): Promise<`0x${string}`>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:457](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L457)
+Defined in: [packages/sdk/src/comments/comment.ts:460](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L460)
 
 Get the hash for deleting a comment
 

--- a/docs/pages/sdk-reference/comments/functions/getEditCommentHash.mdx
+++ b/docs/pages/sdk-reference/comments/functions/getEditCommentHash.mdx
@@ -10,7 +10,7 @@
 function getEditCommentHash(params): Promise<`0x${string}`>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:689](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L689)
+Defined in: [packages/sdk/src/comments/comment.ts:691](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L691)
 
 Get the hash for editing a comment
 

--- a/docs/pages/sdk-reference/comments/functions/getNonce.mdx
+++ b/docs/pages/sdk-reference/comments/functions/getNonce.mdx
@@ -10,7 +10,7 @@
 function getNonce(params): Promise<bigint>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:502](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L502)
+Defined in: [packages/sdk/src/comments/comment.ts:505](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L505)
 
 Get the nonce for the author and app signer
 

--- a/docs/pages/sdk-reference/comments/functions/isApproved.mdx
+++ b/docs/pages/sdk-reference/comments/functions/isApproved.mdx
@@ -10,7 +10,7 @@
 function isApproved(params): Promise<boolean>;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:48](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L48)
+Defined in: [packages/sdk/src/comments/approval.ts:49](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L49)
 
 Checks if an app signer is approved for an author
 

--- a/docs/pages/sdk-reference/comments/type-aliases/AddApprovalParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/AddApprovalParams.mdx
@@ -15,7 +15,7 @@ type AddApprovalParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:61](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L61)
+Defined in: [packages/sdk/src/comments/approval.ts:62](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L62)
 
 ## Properties
 
@@ -25,7 +25,7 @@ Defined in: [packages/sdk/src/comments/approval.ts:61](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:65](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L65)
+Defined in: [packages/sdk/src/comments/approval.ts:66](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L66)
 
 The address of the app signer being approved
 
@@ -37,7 +37,7 @@ The address of the app signer being approved
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:76](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L76)
+Defined in: [packages/sdk/src/comments/approval.ts:77](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L77)
 
 The address of the comments contract
 
@@ -55,7 +55,7 @@ COMMENT_MANAGER_ADDRESS
 optional expiry: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:70](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L70)
+Defined in: [packages/sdk/src/comments/approval.ts:71](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L71)
 
 Timestamp when the approval expires
 
@@ -73,4 +73,4 @@ Timestamp when the approval expires
 writeContract: ContractWriteFunctions["addApproval"];
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:77](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L77)
+Defined in: [packages/sdk/src/comments/approval.ts:78](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L78)

--- a/docs/pages/sdk-reference/comments/type-aliases/AddApprovalResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/AddApprovalResult.mdx
@@ -12,7 +12,7 @@ type AddApprovalResult = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:80](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L80)
+Defined in: [packages/sdk/src/comments/approval.ts:81](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L81)
 
 ## Properties
 
@@ -22,4 +22,4 @@ Defined in: [packages/sdk/src/comments/approval.ts:80](https://github.com/ecp-et
 txHash: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:81](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L81)
+Defined in: [packages/sdk/src/comments/approval.ts:82](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L82)

--- a/docs/pages/sdk-reference/comments/type-aliases/BaseEditCommentDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/BaseEditCommentDataParams.mdx
@@ -16,7 +16,7 @@ type BaseEditCommentDataParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:705](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L705)
+Defined in: [packages/sdk/src/comments/comment.ts:707](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L707)
 
 ## Properties
 
@@ -26,7 +26,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:705](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:713](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L713)
+Defined in: [packages/sdk/src/comments/comment.ts:715](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L715)
 
 The app
 
@@ -38,7 +38,7 @@ The app
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:709](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L709)
+Defined in: [packages/sdk/src/comments/comment.ts:711](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L711)
 
 The ID of the comment to edit
 
@@ -50,7 +50,7 @@ The ID of the comment to edit
 content: string;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:717](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L717)
+Defined in: [packages/sdk/src/comments/comment.ts:719](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L719)
 
 The content of the comment (either updated or original)
 
@@ -62,7 +62,7 @@ The content of the comment (either updated or original)
 optional deadline: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:727](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L727)
+Defined in: [packages/sdk/src/comments/comment.ts:729](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L729)
 
 The deadline of the comment
 
@@ -80,6 +80,6 @@ The deadline of the comment
 nonce: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:721](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L721)
+Defined in: [packages/sdk/src/comments/comment.ts:723](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L723)
 
 The nonce for the signature

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateCommentTypedDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateCommentTypedDataParams.mdx
@@ -14,7 +14,7 @@ type CreateCommentTypedDataParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:515](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L515)
+Defined in: [packages/sdk/src/comments/comment.ts:518](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L518)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:515](https://github.com/ecp-et
 chainId: number;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:517](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L517)
+Defined in: [packages/sdk/src/comments/comment.ts:520](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L520)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:517](https://github.com/ecp-et
 commentData: CommentInputData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:516](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L516)
+Defined in: [packages/sdk/src/comments/comment.ts:519](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L519)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:516](https://github.com/ecp-et
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:522](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L522)
+Defined in: [packages/sdk/src/comments/comment.ts:525](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L525)
 
 The address of the comments contract
 

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateDeleteCommentTypedDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateDeleteCommentTypedDataParams.mdx
@@ -17,7 +17,7 @@ type CreateDeleteCommentTypedDataParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:593](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L593)
+Defined in: [packages/sdk/src/comments/comment.ts:596](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L596)
 
 ## Properties
 
@@ -27,7 +27,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:593](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:603](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L603)
+Defined in: [packages/sdk/src/comments/comment.ts:606](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L606)
 
 The app signer
 
@@ -39,7 +39,7 @@ The app signer
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:599](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L599)
+Defined in: [packages/sdk/src/comments/comment.ts:602](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L602)
 
 The author of the comment
 
@@ -51,7 +51,7 @@ The author of the comment
 chainId: number;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:595](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L595)
+Defined in: [packages/sdk/src/comments/comment.ts:598](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L598)
 
 ***
 
@@ -61,7 +61,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:595](https://github.com/ecp-et
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:594](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L594)
+Defined in: [packages/sdk/src/comments/comment.ts:597](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L597)
 
 ***
 
@@ -71,7 +71,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:594](https://github.com/ecp-et
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:614](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L614)
+Defined in: [packages/sdk/src/comments/comment.ts:617](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L617)
 
 The address of the comments contract
 
@@ -89,7 +89,7 @@ COMMENT_MANAGER_ADDRESS
 optional deadline: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:609](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L609)
+Defined in: [packages/sdk/src/comments/comment.ts:612](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L612)
 
 The deadline of the comment
 

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateEditCommentTypedDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateEditCommentTypedDataParams.mdx
@@ -15,7 +15,7 @@ type CreateEditCommentTypedDataParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:766](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L766)
+Defined in: [packages/sdk/src/comments/comment.ts:767](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L767)
 
 ## Properties
 
@@ -25,7 +25,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:766](https://github.com/ecp-et
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:770](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L770)
+Defined in: [packages/sdk/src/comments/comment.ts:771](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L771)
 
 The author of the comment
 
@@ -37,7 +37,7 @@ The author of the comment
 chainId: number;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:780](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L780)
+Defined in: [packages/sdk/src/comments/comment.ts:781](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L781)
 
 The chain ID
 
@@ -49,7 +49,7 @@ The chain ID
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:785](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L785)
+Defined in: [packages/sdk/src/comments/comment.ts:786](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L786)
 
 The address of the comments contract
 
@@ -67,7 +67,7 @@ COMMENT_MANAGER_ADDRESS
 edit: EditCommentData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:776](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L776)
+Defined in: [packages/sdk/src/comments/comment.ts:777](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L777)
 
 The edit data
 

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateRemoveApprovalTypedDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateRemoveApprovalTypedDataParams.mdx
@@ -17,7 +17,7 @@ type CreateRemoveApprovalTypedDataParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:523](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L523)
+Defined in: [packages/sdk/src/comments/approval.ts:520](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L520)
 
 ## Properties
 
@@ -27,7 +27,7 @@ Defined in: [packages/sdk/src/comments/approval.ts:523](https://github.com/ecp-e
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:531](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L531)
+Defined in: [packages/sdk/src/comments/approval.ts:528](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L528)
 
 The address of the app signer
 
@@ -39,7 +39,7 @@ The address of the app signer
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:527](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L527)
+Defined in: [packages/sdk/src/comments/approval.ts:524](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L524)
 
 The address of the author
 
@@ -51,7 +51,7 @@ The address of the author
 chainId: number;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:535](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L535)
+Defined in: [packages/sdk/src/comments/approval.ts:532](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L532)
 
 The chain ID
 
@@ -63,7 +63,7 @@ The chain ID
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:547](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L547)
+Defined in: [packages/sdk/src/comments/approval.ts:544](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L544)
 
 The address of the comments contract
 
@@ -75,7 +75,7 @@ The address of the comments contract
 optional deadline: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:543](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L543)
+Defined in: [packages/sdk/src/comments/approval.ts:540](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L540)
 
 Timestamp after which the signature becomes invalid
 
@@ -87,6 +87,6 @@ Timestamp after which the signature becomes invalid
 nonce: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:539](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L539)
+Defined in: [packages/sdk/src/comments/approval.ts:536](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L536)
 
 The current nonce for the author and app signer

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateRemoveApprovalTypedDataResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateRemoveApprovalTypedDataResult.mdx
@@ -10,4 +10,4 @@
 type CreateRemoveApprovalTypedDataResult = RemoveApprovalTypedDataSchemaType;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:550](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L550)
+Defined in: [packages/sdk/src/comments/approval.ts:547](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L547)

--- a/docs/pages/sdk-reference/comments/type-aliases/CreateReportCommentTypedDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/CreateReportCommentTypedDataParams.mdx
@@ -16,7 +16,7 @@ type CreateReportCommentTypedDataParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:970](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L970)
+Defined in: [packages/sdk/src/comments/comment.ts:971](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L971)
 
 ## Properties
 
@@ -26,7 +26,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:970](https://github.com/ecp-et
 chainId: number;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:974](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L974)
+Defined in: [packages/sdk/src/comments/comment.ts:975](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L975)
 
 ***
 
@@ -36,7 +36,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:974](https://github.com/ecp-et
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:971](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L971)
+Defined in: [packages/sdk/src/comments/comment.ts:972](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L972)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:971](https://github.com/ecp-et
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:975](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L975)
+Defined in: [packages/sdk/src/comments/comment.ts:976](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L976)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:975](https://github.com/ecp-et
 optional message: string;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:973](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L973)
+Defined in: [packages/sdk/src/comments/comment.ts:974](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L974)
 
 ***
 
@@ -66,4 +66,4 @@ Defined in: [packages/sdk/src/comments/comment.ts:973](https://github.com/ecp-et
 reportee: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:972](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L972)
+Defined in: [packages/sdk/src/comments/comment.ts:973](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L973)

--- a/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentParams.mdx
@@ -14,7 +14,7 @@ type DeleteCommentParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:277](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L277)
+Defined in: [packages/sdk/src/comments/comment.ts:280](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L280)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:277](https://github.com/ecp-et
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:281](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L281)
+Defined in: [packages/sdk/src/comments/comment.ts:284](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L284)
 
 The ID of the comment to delete
 
@@ -36,7 +36,7 @@ The ID of the comment to delete
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:286](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L286)
+Defined in: [packages/sdk/src/comments/comment.ts:289](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L289)
 
 The address of the comments contract
 
@@ -54,4 +54,4 @@ COMMENT_MANAGER_ADDRESS
 writeContract: ContractWriteFunctions["deleteComment"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:287](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L287)
+Defined in: [packages/sdk/src/comments/comment.ts:290](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L290)

--- a/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentResult.mdx
@@ -10,4 +10,4 @@
 type DeleteCommentResult = WaitableWriteContractHelperResult<CommentManagerABIType, "CommentDeleted">;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:290](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L290)
+Defined in: [packages/sdk/src/comments/comment.ts:293](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L293)

--- a/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentWithSigParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentWithSigParams.mdx
@@ -18,7 +18,7 @@ type DeleteCommentWithSigParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:327](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L327)
+Defined in: [packages/sdk/src/comments/comment.ts:330](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L330)
 
 ## Properties
 
@@ -28,7 +28,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:327](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:335](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L335)
+Defined in: [packages/sdk/src/comments/comment.ts:338](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L338)
 
 The app signer
 
@@ -40,7 +40,7 @@ The app signer
 appSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:348](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L348)
+Defined in: [packages/sdk/src/comments/comment.ts:351](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L351)
 
 The app signature
 
@@ -52,7 +52,7 @@ The app signature
 optional authorSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:352](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L352)
+Defined in: [packages/sdk/src/comments/comment.ts:355](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L355)
 
 The author signature. Necessary if the author hasn't approved the signer to delete comments on their behalf.
 
@@ -64,7 +64,7 @@ The author signature. Necessary if the author hasn't approved the signer to dele
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:331](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L331)
+Defined in: [packages/sdk/src/comments/comment.ts:334](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L334)
 
 The ID of the comment to delete
 
@@ -76,7 +76,7 @@ The ID of the comment to delete
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:344](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L344)
+Defined in: [packages/sdk/src/comments/comment.ts:347](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L347)
 
 The address of the comments contract
 
@@ -94,7 +94,7 @@ COMMENT_MANAGER_ADDRESS
 deadline: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:339](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L339)
+Defined in: [packages/sdk/src/comments/comment.ts:342](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L342)
 
 The deadline for the signature
 
@@ -106,6 +106,6 @@ The deadline for the signature
 writeContract: ContractWriteFunctions["deleteCommentWithSig"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:356](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L356)
+Defined in: [packages/sdk/src/comments/comment.ts:359](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L359)
 
 The write contract function

--- a/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentWithSigResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/DeleteCommentWithSigResult.mdx
@@ -10,4 +10,4 @@
 type DeleteCommentWithSigResult = WaitableWriteContractHelperResult<CommentManagerABIType, "CommentDeleted">;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:359](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L359)
+Defined in: [packages/sdk/src/comments/comment.ts:362](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L362)

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentDataParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentDataParams.mdx
@@ -10,4 +10,4 @@
 type EditCommentDataParams = EditCommentDataParamsWithMetadataEntries;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:738](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L738)
+Defined in: [packages/sdk/src/comments/comment.ts:740](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L740)

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentDataParamsWithMetadataEntries.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentDataParamsWithMetadataEntries.mdx
@@ -12,7 +12,7 @@ type EditCommentDataParamsWithMetadataEntries = BaseEditCommentDataParams & {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:730](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L730)
+Defined in: [packages/sdk/src/comments/comment.ts:732](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L732)
 
 ## Type declaration
 

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentParams.mdx
@@ -16,7 +16,7 @@ type EditCommentParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:823](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L823)
+Defined in: [packages/sdk/src/comments/comment.ts:824](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L824)
 
 ## Properties
 
@@ -26,7 +26,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:823](https://github.com/ecp-et
 appSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:842](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L842)
+Defined in: [packages/sdk/src/comments/comment.ts:843](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L843)
 
 The author signature.
 
@@ -38,7 +38,7 @@ The author signature.
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:838](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L838)
+Defined in: [packages/sdk/src/comments/comment.ts:839](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L839)
 
 The address of the comments contract
 
@@ -56,7 +56,7 @@ COMMENT_MANAGER_ADDRESS
 edit: EditCommentData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:829](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L829)
+Defined in: [packages/sdk/src/comments/comment.ts:830](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L830)
 
 The edit data
 
@@ -70,7 +70,7 @@ You can obtain this by using the `createEditCommentData()` function
 optional fee: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:833](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L833)
+Defined in: [packages/sdk/src/comments/comment.ts:834](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L834)
 
 The fee for the edit operation
 
@@ -82,6 +82,6 @@ The fee for the edit operation
 writeContract: ContractWriteFunctions["editComment"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:846](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L846)
+Defined in: [packages/sdk/src/comments/comment.ts:847](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L847)
 
 The write contract function

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentResult.mdx
@@ -10,4 +10,4 @@
 type EditCommentResult = WaitableWriteContractHelperResult<CommentManagerABIType, "CommentEdited">;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:856](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L856)
+Defined in: [packages/sdk/src/comments/comment.ts:857](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L857)

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentWithSigParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentWithSigParams.mdx
@@ -17,7 +17,7 @@ type EditCommentWithSigParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:890](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L890)
+Defined in: [packages/sdk/src/comments/comment.ts:891](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L891)
 
 ## Properties
 
@@ -27,7 +27,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:890](https://github.com/ecp-et
 appSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:909](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L909)
+Defined in: [packages/sdk/src/comments/comment.ts:910](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L910)
 
 The app signature
 
@@ -39,7 +39,7 @@ The app signature
 optional authorSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:913](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L913)
+Defined in: [packages/sdk/src/comments/comment.ts:914](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L914)
 
 The author signature. Necessary if the author hasn't approved the signer to edit comments on their behalf.
 
@@ -51,7 +51,7 @@ The author signature. Necessary if the author hasn't approved the signer to edit
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:905](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L905)
+Defined in: [packages/sdk/src/comments/comment.ts:906](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L906)
 
 The address of the comments contract
 
@@ -69,7 +69,7 @@ COMMENT_MANAGER_ADDRESS
 edit: EditCommentData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:896](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L896)
+Defined in: [packages/sdk/src/comments/comment.ts:897](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L897)
 
 The edit data
 
@@ -83,7 +83,7 @@ You can obtain this by using the `createEditCommentData()` function
 optional fee: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:900](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L900)
+Defined in: [packages/sdk/src/comments/comment.ts:901](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L901)
 
 The fee for the edit operation
 
@@ -95,6 +95,6 @@ The fee for the edit operation
 writeContract: ContractWriteFunctions["editCommentWithSig"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:917](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L917)
+Defined in: [packages/sdk/src/comments/comment.ts:918](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L918)
 
 The write contract function

--- a/docs/pages/sdk-reference/comments/type-aliases/EditCommentWithSigResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/EditCommentWithSigResult.mdx
@@ -10,4 +10,4 @@
 type EditCommentWithSigResult = WaitableWriteContractHelperResult<CommentManagerABIType, "CommentEdited">;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:928](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L928)
+Defined in: [packages/sdk/src/comments/comment.ts:929](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L929)

--- a/docs/pages/sdk-reference/comments/type-aliases/GetCommentIdParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/GetCommentIdParams.mdx
@@ -14,7 +14,7 @@ type GetCommentIdParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:239](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L239)
+Defined in: [packages/sdk/src/comments/comment.ts:242](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L242)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:239](https://github.com/ecp-et
 commentData: CreateCommentDataParams;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:243](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L243)
+Defined in: [packages/sdk/src/comments/comment.ts:246](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L246)
 
 The comment data to get ID for
 
@@ -36,7 +36,7 @@ The comment data to get ID for
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:248](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L248)
+Defined in: [packages/sdk/src/comments/comment.ts:251](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L251)
 
 The address of the comments contract
 
@@ -54,4 +54,4 @@ COMMENT_MANAGER_ADDRESS
 readContract: ContractReadFunctions["getCommentId"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:249](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L249)
+Defined in: [packages/sdk/src/comments/comment.ts:252](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L252)

--- a/docs/pages/sdk-reference/comments/type-aliases/GetCommentParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/GetCommentParams.mdx
@@ -14,7 +14,7 @@ type GetCommentParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:192](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L192)
+Defined in: [packages/sdk/src/comments/comment.ts:195](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L195)
 
 ## Properties
 
@@ -24,7 +24,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:192](https://github.com/ecp-et
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:196](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L196)
+Defined in: [packages/sdk/src/comments/comment.ts:199](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L199)
 
 The ID of the comment to get
 
@@ -36,7 +36,7 @@ The ID of the comment to get
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:201](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L201)
+Defined in: [packages/sdk/src/comments/comment.ts:204](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L204)
 
 The address of the comments contract
 
@@ -54,4 +54,4 @@ COMMENT_MANAGER_ADDRESS
 readContract: ContractReadFunctions["getComment"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:202](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L202)
+Defined in: [packages/sdk/src/comments/comment.ts:205](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L205)

--- a/docs/pages/sdk-reference/comments/type-aliases/GetCommentResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/GetCommentResult.mdx
@@ -12,7 +12,7 @@ type GetCommentResult = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:205](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L205)
+Defined in: [packages/sdk/src/comments/comment.ts:208](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L208)
 
 ## Properties
 
@@ -22,4 +22,4 @@ Defined in: [packages/sdk/src/comments/comment.ts:205](https://github.com/ecp-et
 comment: CommentData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:206](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L206)
+Defined in: [packages/sdk/src/comments/comment.ts:209](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L209)

--- a/docs/pages/sdk-reference/comments/type-aliases/GetDeleteCommentHashParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/GetDeleteCommentHashParams.mdx
@@ -17,7 +17,7 @@ type GetDeleteCommentHashParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:416](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L416)
+Defined in: [packages/sdk/src/comments/comment.ts:419](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L419)
 
 ## Properties
 
@@ -27,7 +27,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:416](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:428](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L428)
+Defined in: [packages/sdk/src/comments/comment.ts:431](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L431)
 
 The app signer
 
@@ -39,7 +39,7 @@ The app signer
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:424](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L424)
+Defined in: [packages/sdk/src/comments/comment.ts:427](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L427)
 
 The author of the comment
 
@@ -51,7 +51,7 @@ The author of the comment
 commentId: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:420](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L420)
+Defined in: [packages/sdk/src/comments/comment.ts:423](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L423)
 
 The ID of the comment to delete
 
@@ -63,7 +63,7 @@ The ID of the comment to delete
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:439](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L439)
+Defined in: [packages/sdk/src/comments/comment.ts:442](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L442)
 
 The address of the comments contract
 
@@ -81,7 +81,7 @@ COMMENT_MANAGER_ADDRESS
 deadline: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:434](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L434)
+Defined in: [packages/sdk/src/comments/comment.ts:437](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L437)
 
 The deadline for the signature
 
@@ -99,4 +99,4 @@ The deadline for the signature
 readContract: ContractReadFunctions["getDeleteCommentHash"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:440](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L440)
+Defined in: [packages/sdk/src/comments/comment.ts:443](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L443)

--- a/docs/pages/sdk-reference/comments/type-aliases/GetEditCommentHashParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/GetEditCommentHashParams.mdx
@@ -15,7 +15,7 @@ type GetEditCommentHashParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:662](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L662)
+Defined in: [packages/sdk/src/comments/comment.ts:664](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L664)
 
 ## Properties
 
@@ -25,7 +25,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:662](https://github.com/ecp-et
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:666](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L666)
+Defined in: [packages/sdk/src/comments/comment.ts:668](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L668)
 
 The author of the comment
 
@@ -37,7 +37,7 @@ The author of the comment
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:675](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L675)
+Defined in: [packages/sdk/src/comments/comment.ts:677](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L677)
 
 The address of the comments contract
 
@@ -55,7 +55,7 @@ COMMENT_MANAGER_ADDRESS
 edit: EditCommentData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:670](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L670)
+Defined in: [packages/sdk/src/comments/comment.ts:672](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L672)
 
 The edit data
 
@@ -67,4 +67,4 @@ The edit data
 readContract: ContractReadFunctions["getEditCommentHash"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:676](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L676)
+Defined in: [packages/sdk/src/comments/comment.ts:678](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L678)

--- a/docs/pages/sdk-reference/comments/type-aliases/GetNonceParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/GetNonceParams.mdx
@@ -15,7 +15,7 @@ type GetNonceParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:473](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L473)
+Defined in: [packages/sdk/src/comments/comment.ts:476](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L476)
 
 ## Properties
 
@@ -25,7 +25,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:473](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:481](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L481)
+Defined in: [packages/sdk/src/comments/comment.ts:484](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L484)
 
 The app signer
 
@@ -37,7 +37,7 @@ The app signer
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:477](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L477)
+Defined in: [packages/sdk/src/comments/comment.ts:480](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L480)
 
 The author of the comment
 
@@ -49,7 +49,7 @@ The author of the comment
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:486](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L486)
+Defined in: [packages/sdk/src/comments/comment.ts:489](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L489)
 
 The address of the comments contract
 
@@ -67,4 +67,4 @@ COMMENT_MANAGER_ADDRESS
 readContract: ContractReadFunctions["getNonce"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:487](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L487)
+Defined in: [packages/sdk/src/comments/comment.ts:490](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L490)

--- a/docs/pages/sdk-reference/comments/type-aliases/IsApprovedParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/IsApprovedParams.mdx
@@ -15,7 +15,7 @@ type IsApprovedParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:19](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L19)
+Defined in: [packages/sdk/src/comments/approval.ts:20](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L20)
 
 ## Properties
 
@@ -25,7 +25,7 @@ Defined in: [packages/sdk/src/comments/approval.ts:19](https://github.com/ecp-et
 app: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:27](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L27)
+Defined in: [packages/sdk/src/comments/approval.ts:28](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L28)
 
 The app signer address
 
@@ -37,7 +37,7 @@ The app signer address
 author: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:23](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L23)
+Defined in: [packages/sdk/src/comments/approval.ts:24](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L24)
 
 The author address
 
@@ -49,7 +49,7 @@ The author address
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:32](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L32)
+Defined in: [packages/sdk/src/comments/approval.ts:33](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L33)
 
 The address of the comments contract
 
@@ -67,4 +67,4 @@ COMMENT_MANAGER_ADDRESS
 readContract: ContractReadFunctions["getIsApproved"];
 ```
 
-Defined in: [packages/sdk/src/comments/approval.ts:33](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L33)
+Defined in: [packages/sdk/src/comments/approval.ts:34](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/approval.ts#L34)

--- a/docs/pages/sdk-reference/comments/type-aliases/PostCommentParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/PostCommentParams.mdx
@@ -16,7 +16,7 @@ type PostCommentParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:49](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L49)
+Defined in: [packages/sdk/src/comments/comment.ts:52](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L52)
 
 ## Properties
 
@@ -26,7 +26,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:49](https://github.com/ecp-eth
 appSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:59](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L59)
+Defined in: [packages/sdk/src/comments/comment.ts:62](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L62)
 
 The app signature
 
@@ -38,7 +38,7 @@ The app signature
 comment: CommentInputData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:55](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L55)
+Defined in: [packages/sdk/src/comments/comment.ts:58](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L58)
 
 The comment data
 
@@ -52,7 +52,7 @@ You can obtain this by using the `createCommentData()` function
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:68](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L68)
+Defined in: [packages/sdk/src/comments/comment.ts:71](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L71)
 
 The address of the comments contract
 
@@ -70,7 +70,7 @@ COMMENT_MANAGER_ADDRESS
 optional fee: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:63](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L63)
+Defined in: [packages/sdk/src/comments/comment.ts:66](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L66)
 
 The fee for the comment
 
@@ -82,6 +82,6 @@ The fee for the comment
 writeContract: ContractWriteFunctions["postComment"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:72](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L72)
+Defined in: [packages/sdk/src/comments/comment.ts:75](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L75)
 
 The write contract function

--- a/docs/pages/sdk-reference/comments/type-aliases/PostCommentResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/PostCommentResult.mdx
@@ -10,4 +10,4 @@
 type PostCommentResult = WaitableWriteContractHelperResult<CommentManagerABIType, "CommentAdded">;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:75](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L75)
+Defined in: [packages/sdk/src/comments/comment.ts:78](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L78)

--- a/docs/pages/sdk-reference/comments/type-aliases/PostCommentWithSigParams.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/PostCommentWithSigParams.mdx
@@ -17,7 +17,7 @@ type PostCommentWithSigParams = {
 };
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:117](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L117)
+Defined in: [packages/sdk/src/comments/comment.ts:120](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L120)
 
 ## Properties
 
@@ -27,7 +27,7 @@ Defined in: [packages/sdk/src/comments/comment.ts:117](https://github.com/ecp-et
 appSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:127](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L127)
+Defined in: [packages/sdk/src/comments/comment.ts:130](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L130)
 
 The app signature
 
@@ -39,7 +39,7 @@ The app signature
 optional authorSignature: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:131](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L131)
+Defined in: [packages/sdk/src/comments/comment.ts:134](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L134)
 
 The author signature. Necessary if the author hasn't approved the signer to post comments on their behalf.
 
@@ -51,7 +51,7 @@ The author signature. Necessary if the author hasn't approved the signer to post
 comment: CommentInputData;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:123](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L123)
+Defined in: [packages/sdk/src/comments/comment.ts:126](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L126)
 
 The comment data
 
@@ -65,7 +65,7 @@ You can obtain this by using the `createCommentData()` function
 optional commentsAddress: Hex;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:140](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L140)
+Defined in: [packages/sdk/src/comments/comment.ts:143](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L143)
 
 The address of the comments contract
 
@@ -83,7 +83,7 @@ COMMENT_MANAGER_ADDRESS
 optional fee: bigint;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:135](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L135)
+Defined in: [packages/sdk/src/comments/comment.ts:138](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L138)
 
 The fee for the comment
 
@@ -95,6 +95,6 @@ The fee for the comment
 writeContract: ContractWriteFunctions["postCommentWithSig"];
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:144](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L144)
+Defined in: [packages/sdk/src/comments/comment.ts:147](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L147)
 
 The write contract function

--- a/docs/pages/sdk-reference/comments/type-aliases/PostCommentWithSigResult.mdx
+++ b/docs/pages/sdk-reference/comments/type-aliases/PostCommentWithSigResult.mdx
@@ -10,4 +10,4 @@
 type PostCommentWithSigResult = WaitableWriteContractHelperResult<CommentManagerABIType, "CommentAdded">;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:147](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L147)
+Defined in: [packages/sdk/src/comments/comment.ts:150](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L150)

--- a/docs/pages/sdk-reference/comments/variables/deleteComment.mdx
+++ b/docs/pages/sdk-reference/comments/variables/deleteComment.mdx
@@ -1530,7 +1530,7 @@ const deleteComment: (...args) => Promise<WaitableWriteContractHelperResult<read
 }], "CommentDeleted">>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:305](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L305)
+Defined in: [packages/sdk/src/comments/comment.ts:308](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L308)
 
 Delete a comment as an author
 

--- a/docs/pages/sdk-reference/comments/variables/deleteCommentWithSig.mdx
+++ b/docs/pages/sdk-reference/comments/variables/deleteCommentWithSig.mdx
@@ -1530,7 +1530,7 @@ const deleteCommentWithSig: (...args) => Promise<WaitableWriteContractHelperResu
 }], "CommentDeleted">>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:378](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L378)
+Defined in: [packages/sdk/src/comments/comment.ts:381](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L381)
 
 Delete a comment with app signature verification
 

--- a/docs/pages/sdk-reference/comments/variables/editComment.mdx
+++ b/docs/pages/sdk-reference/comments/variables/editComment.mdx
@@ -1530,7 +1530,7 @@ const editComment: (...args) => Promise<WaitableWriteContractHelperResult<readon
 }], "CommentEdited">>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:866](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L866)
+Defined in: [packages/sdk/src/comments/comment.ts:867](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L867)
 
 Edit a comment as an author
 

--- a/docs/pages/sdk-reference/comments/variables/editCommentWithSig.mdx
+++ b/docs/pages/sdk-reference/comments/variables/editCommentWithSig.mdx
@@ -1530,7 +1530,7 @@ const editCommentWithSig: (...args) => Promise<WaitableWriteContractHelperResult
 }], "CommentEdited">>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:938](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L938)
+Defined in: [packages/sdk/src/comments/comment.ts:939](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L939)
 
 Edit a comment
 

--- a/docs/pages/sdk-reference/comments/variables/postComment.mdx
+++ b/docs/pages/sdk-reference/comments/variables/postComment.mdx
@@ -1530,7 +1530,7 @@ const postComment: (...args) => Promise<WaitableWriteContractHelperResult<readon
 }], "CommentAdded">>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:93](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L93)
+Defined in: [packages/sdk/src/comments/comment.ts:96](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L96)
 
 Posts a comment as an author
 

--- a/docs/pages/sdk-reference/comments/variables/postCommentWithSig.mdx
+++ b/docs/pages/sdk-reference/comments/variables/postCommentWithSig.mdx
@@ -1530,7 +1530,7 @@ const postCommentWithSig: (...args) => Promise<WaitableWriteContractHelperResult
 }], "CommentAdded">>;
 ```
 
-Defined in: [packages/sdk/src/comments/comment.ts:165](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L165)
+Defined in: [packages/sdk/src/comments/comment.ts:168](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/comments/comment.ts#L168)
 
 Posts a comment with author signature verification
 

--- a/docs/pages/sdk-reference/core/functions/getOneDayFromNowInSeconds.mdx
+++ b/docs/pages/sdk-reference/core/functions/getOneDayFromNowInSeconds.mdx
@@ -1,0 +1,21 @@
+[**@ecp.eth/sdk**](../../index.mdx)
+
+***
+
+[@ecp.eth/sdk](/sdk-reference/index.mdx) / [core](/sdk-reference/core/index.mdx) / getOneDayFromNowInSeconds
+
+# Function: getOneDayFromNowInSeconds()
+
+```ts
+function getOneDayFromNowInSeconds(): bigint;
+```
+
+Defined in: [packages/sdk/src/core/utils.ts:225](https://github.com/ecp-eth/comments-monorepo/blob/main/packages/sdk/src/core/utils.ts#L225)
+
+Get the number of seconds to one day from now
+
+## Returns
+
+`bigint`
+
+one day from now in seconds in bigint

--- a/docs/pages/sdk-reference/core/index.mdx
+++ b/docs/pages/sdk-reference/core/index.mdx
@@ -29,5 +29,6 @@ Core functionality for the Ethereum Comments Protocol
 | Function | Description |
 | ------ | ------ |
 | [createWaitableWriteContractHelper](/sdk-reference/core/functions/createWaitableWriteContractHelper.mdx) | This function wraps the write function to add a `wait()` method in the returned object. The `wait()` method waits the transaction receipt and returns the event arguments specified by the write function, within the transaction. |
+| [getOneDayFromNowInSeconds](/sdk-reference/core/functions/getOneDayFromNowInSeconds.mdx) | Get the number of seconds to one day from now |
 | [isZeroHex](/sdk-reference/core/functions/isZeroHex.mdx) | Check if a hex string is zero |
 | [runAsync](/sdk-reference/core/functions/runAsync.mdx) | Run an async function with retries and backoff. |

--- a/docs/public/sitemap.xml
+++ b/docs/public/sitemap.xml
@@ -2449,6 +2449,12 @@
     <priority>0.4</priority>
   </url>
   <url>
+    <loc>https://docs.ethcomments.xyz/sdk-reference/core/functions/getOneDayFromNowInSeconds</loc>
+    <lastmod>2025-10-07T21:30:43.378Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
     <loc>https://docs.ethcomments.xyz/sdk-reference/core/functions/isZeroHex</loc>
     <lastmod>2025-05-29T13:53:34.000Z</lastmod>
     <changefreq>weekly</changefreq>

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -27,7 +27,7 @@
     "debug:gas": "rivet forge script script/debug.s.sol:DebugGasUsage",
     "node": "rivet anvil --block-time 2",
     "dev": "node dev.js",
-    "deploy:test": "rivet forge script script/deploy.s.sol:DeployScript --sig \"run(string)\" \"test\" --rpc-url http://localhost:8545 --broadcast --force --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+    "deploy:test": "rivet forge script script/deploy.s.sol:DeployScript --sig \"run(string)\" \"test\" --rpc-url http://localhost:8546 --broadcast --force --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     "deploy:dev": "rivet forge script script/deploy.s.sol:DeployScript --sig \"run(string)\" \"dev\" --rpc-url http://localhost:8545 --broadcast --force --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
     "deploy:dev:simulation": "SIM=true rivet forge script script/deploy.s.sol --sig \"run(string)\" \"dev\" --rpc-url http://localhost:8545 --force",
     "deploy:dev:fork": "rivet forge script script/deploy.s.sol:DeployScript --sig \"run(string)\" \"dev\" --rpc-url http://localhost:8545 --broadcast --force --sender $CUSTOM_ANVIL_DEPLOYER_ADDRESS",

--- a/packages/sdk/scripts/constants.ts
+++ b/packages/sdk/scripts/constants.ts
@@ -15,3 +15,8 @@ export const COMMENTS_ADDRESS =
  */
 export const NOOP_HOOK_ADDRESS =
   "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512" as const;
+
+/**
+ * The port of the Anvil node for running SDK tests
+ */
+export const ANVIL_PORT_FOR_TESTS = 8546;

--- a/packages/sdk/scripts/test-helpers.ts
+++ b/packages/sdk/scripts/test-helpers.ts
@@ -5,7 +5,7 @@ import type { Hex } from "viem";
 
 const cwd = path.resolve(import.meta.dirname, "../../protocol");
 
-export function deployContracts(): {
+export function deployContractsForTests(): {
   commentsAddress: Hex;
   channelManagerAddress: Hex;
   noopHookAddress: Hex;

--- a/packages/sdk/scripts/vitest-global-setup.ts
+++ b/packages/sdk/scripts/vitest-global-setup.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import path from "node:path";
+import { ANVIL_PORT_FOR_TESTS } from "./constants";
 
 let nodeProcess: ChildProcess;
 
@@ -12,7 +13,17 @@ export async function setup() {
   console.log("📡 Starting Anvil node...");
   nodeProcess = spawn(
     "pnpm",
-    ["rivet", "anvil", "--host", "0.0.0.0", "--block-time", "0.5"],
+    [
+      "rivet",
+      "anvil",
+      "--host",
+      "0.0.0.0",
+      "--block-time",
+      "0.5",
+      // let's use a different port for sdk testing so we don't conflict with the main anvil node
+      "--port",
+      ANVIL_PORT_FOR_TESTS.toString(),
+    ],
     {
       cwd,
       env: process.env,
@@ -32,7 +43,7 @@ export async function setup() {
 
       nodeProcess.stdout?.on("data", (data) => {
         const output = data.toString();
-        if (output.includes("Listening on 0.0.0.0:8545")) {
+        if (output.includes(`Listening on 0.0.0.0:${ANVIL_PORT_FOR_TESTS}`)) {
           console.log("✅ Anvil node started");
           resolve(true);
         }
@@ -86,7 +97,7 @@ async function verifyAnvilConnection() {
 
   while (retries < maxRetries) {
     try {
-      const response = await fetch("http://localhost:8545", {
+      const response = await fetch(`http://localhost:${ANVIL_PORT_FOR_TESTS}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/packages/sdk/src/channel-manager/test/channel.spec.ts
+++ b/packages/sdk/src/channel-manager/test/channel.spec.ts
@@ -29,7 +29,8 @@ import type { Hex } from "../../core/schemas.js";
 import type { CommentData, MetadataEntry } from "../../comments/types.js";
 import { AuthorAuthMethod } from "../../comments/types.js";
 import { NATIVE_ASSET_ADDRESS } from "../../constants.js";
-import { deployContracts } from "../../../scripts/test-helpers.js";
+import { deployContractsForTests } from "../../../scripts/test-helpers.js";
+import { ANVIL_PORT_FOR_TESTS } from "../../../scripts/constants.js";
 
 describe("channel", () => {
   let channelManagerAddress: Hex;
@@ -41,7 +42,7 @@ describe("channel", () => {
       channelManagerAddress,
       flatFeeHookAddress,
       legacyTakeChannelFeeHookAddress,
-    } = deployContracts());
+    } = deployContractsForTests());
   });
 
   // Test account setup
@@ -56,14 +57,14 @@ describe("channel", () => {
   // Create wallet client
   const client = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account,
     pollingInterval: 500,
   }).extend(publicActions);
 
   const client2 = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account: account2,
     pollingInterval: 500,
   }).extend(publicActions);

--- a/packages/sdk/src/channel-manager/test/hook.spec.ts
+++ b/packages/sdk/src/channel-manager/test/hook.spec.ts
@@ -16,15 +16,16 @@ import {
 } from "../hook.js";
 import { createChannel } from "../channel.js";
 import { ChannelManagerABI } from "../../abis.js";
-import { deployContracts } from "../../../scripts/test-helpers.js";
+import { deployContractsForTests } from "../../../scripts/test-helpers.js";
 import type { Hex } from "../../core/schemas.js";
+import { ANVIL_PORT_FOR_TESTS } from "../../../scripts/constants.js";
 
 describe("hook", () => {
   let channelManagerAddress: Hex;
   let noopHookAddress: Hex;
 
   beforeAll(() => {
-    ({ channelManagerAddress, noopHookAddress } = deployContracts());
+    ({ channelManagerAddress, noopHookAddress } = deployContractsForTests());
   });
 
   // Test account setup
@@ -39,14 +40,14 @@ describe("hook", () => {
   // Create wallet client
   const client = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account,
     pollingInterval: 500,
   }).extend(publicActions);
 
   const client2 = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account: account2,
     pollingInterval: 500,
   }).extend(publicActions);

--- a/packages/sdk/src/comments/approval.ts
+++ b/packages/sdk/src/comments/approval.ts
@@ -15,6 +15,7 @@ import {
   type RemoveApprovalTypedDataSchemaType,
   type AddApprovalTypedDataSchemaType,
 } from "./schemas.js";
+import { getOneDayFromNowInSeconds } from "../core/utils.js";
 
 export type IsApprovedParams = {
   /**
@@ -101,8 +102,7 @@ export async function addApproval(
 
   const { app, expiry, commentsAddress, writeContract } = validatedParams;
 
-  const computedExpiry =
-    expiry ?? BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365); // 1 year from now
+  const computedExpiry = expiry ?? getOneDayFromNowInSeconds() * 365n; // 1 year from now
 
   const txHash = await writeContract({
     address: commentsAddress,
@@ -364,11 +364,11 @@ export async function getAddApprovalHash(
   let computedExpiry = expiry;
 
   if (!computedDeadline) {
-    computedDeadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24); // 1 day from now
+    computedDeadline = getOneDayFromNowInSeconds();
   }
 
   if (!computedExpiry) {
-    computedExpiry = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365); // 1 year from now
+    computedExpiry = getOneDayFromNowInSeconds() * 365n; // 1 year from now
   }
 
   const hash = await params.readContract({
@@ -495,11 +495,8 @@ export function createApprovalTypedData(
   const { author, app, chainId, nonce, deadline, commentsAddress } =
     validatedParams;
 
-  const computedDeadline =
-    deadline ?? BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24); // 1 day from now
-  const computedExpiry = BigInt(
-    Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365,
-  ); // 1 year from now
+  const computedDeadline = deadline ?? getOneDayFromNowInSeconds();
+  const computedExpiry = getOneDayFromNowInSeconds() * 365n; // 1 year from now
 
   return AddApprovalTypedDataSchema.parse({
     domain: {
@@ -575,7 +572,7 @@ export function createRemoveApprovalTypedData(
   let computedDeadline = deadline;
 
   if (!computedDeadline) {
-    computedDeadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24); // 1 day from now
+    computedDeadline = getOneDayFromNowInSeconds();
   }
 
   return RemoveApprovalTypedDataSchema.parse({

--- a/packages/sdk/src/comments/comment.ts
+++ b/packages/sdk/src/comments/comment.ts
@@ -43,7 +43,10 @@ import type {
   WaitableWriteContractHelperResult,
   WriteContractHelperResult,
 } from "../core/types.js";
-import { createWaitableWriteContractHelper } from "../core/utils.js";
+import {
+  createWaitableWriteContractHelper,
+  getOneDayFromNowInSeconds,
+} from "../core/utils.js";
 import type { MetadataEntry } from "./types.js";
 
 export type PostCommentParams = {
@@ -585,7 +588,7 @@ export function createCommentData({
     author,
     app,
     channelId,
-    deadline: deadline ?? BigInt(Date.now() + 24 * 60 * 60 * 1000),
+    deadline: deadline ?? getOneDayFromNowInSeconds(),
     ...parentIdOrTargetUri,
   };
 }
@@ -653,8 +656,7 @@ export function createDeleteCommentTypedData(
       commentId,
       author,
       app,
-      deadline:
-        deadline ?? BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24), // 1 day from now
+      deadline: deadline ?? getOneDayFromNowInSeconds(),
     },
   });
 }
@@ -758,8 +760,7 @@ export function createEditCommentData(
     metadata,
     app: params.app,
     nonce: params.nonce,
-    deadline:
-      params.deadline ?? BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24),
+    deadline: params.deadline ?? getOneDayFromNowInSeconds(),
   };
 }
 

--- a/packages/sdk/src/comments/test/approval.spec.ts
+++ b/packages/sdk/src/comments/test/approval.spec.ts
@@ -24,13 +24,14 @@ import type {
   AddApprovalTypedDataSchemaType,
   RemoveApprovalTypedDataSchemaType,
 } from "../schemas.js";
-import { deployContracts } from "../../../scripts/test-helpers.js";
+import { deployContractsForTests } from "../../../scripts/test-helpers.js";
+import { ANVIL_PORT_FOR_TESTS } from "../../../scripts/constants.js";
 
 describe("approval", () => {
   let commentsAddress: Hex;
 
   beforeAll(() => {
-    ({ commentsAddress } = deployContracts());
+    ({ commentsAddress } = deployContractsForTests());
   });
 
   // Test account setup
@@ -45,14 +46,14 @@ describe("approval", () => {
   // Create wallet client
   const client = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account,
     pollingInterval: 500,
   }).extend(publicActions);
 
   const appClient = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account: app,
     pollingInterval: 500,
   }).extend(publicActions);

--- a/packages/sdk/src/comments/test/comment.spec.ts
+++ b/packages/sdk/src/comments/test/comment.spec.ts
@@ -41,13 +41,14 @@ import {
   MetadataTypeValues,
 } from "../metadata.js";
 import type { MetadataEntry } from "../types.js";
-import { deployContracts } from "../../../scripts/test-helpers.js";
+import { deployContractsForTests } from "../../../scripts/test-helpers.js";
+import { ANVIL_PORT_FOR_TESTS } from "../../../scripts/constants.js";
 
 describe("comment", () => {
   let commentsAddress: Hex;
 
   beforeAll(() => {
-    ({ commentsAddress } = deployContracts());
+    ({ commentsAddress } = deployContractsForTests());
   });
 
   // Test account setup
@@ -66,21 +67,21 @@ describe("comment", () => {
   // Create wallet client
   const client = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account,
     pollingInterval: 500,
   }).extend(publicActions);
 
   const appClient = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account: appAccount,
     pollingInterval: 500,
   }).extend(publicActions);
 
   const thirdPartyClient = createWalletClient({
     chain: anvil,
-    transport: http("http://localhost:8545"),
+    transport: http(`http://localhost:${ANVIL_PORT_FOR_TESTS}`),
     account: thirdPartyAccount,
     pollingInterval: 500,
   }).extend(publicActions);
@@ -220,7 +221,8 @@ describe("comment", () => {
           comment: createCommentData({
             app: appAccount.address,
             author: account.address,
-            content: "Test comment content",
+            content:
+              "Test comment content different from the one in the signature",
             metadata: [],
             targetUri: "https://example.com",
           }),
@@ -311,7 +313,7 @@ describe("comment", () => {
       const commentData = createCommentData({
         author: account.address,
         app: appAccount.address,
-        content: "Test comment content",
+        content: "Test comment content for deleteComment",
         metadata: [],
         targetUri: "https://example.com",
       });
@@ -497,7 +499,7 @@ describe("comment", () => {
       const commentData = createCommentData({
         author: account.address,
         app: appAccount.address,
-        content: "Test comment content",
+        content: "Test editComment",
         metadata: [],
         targetUri: "https://example.com",
       });
@@ -605,7 +607,7 @@ describe("comment", () => {
       const commentData = createCommentData({
         author: account.address,
         app: appAccount.address,
-        content: "Test comment content",
+        content: "Test editCommentWithSig",
         metadata: [],
         targetUri: "https://example.com",
       });

--- a/packages/sdk/src/core/utils.ts
+++ b/packages/sdk/src/core/utils.ts
@@ -217,3 +217,11 @@ export function runAsync<T>(
 
   return execute();
 }
+
+/**
+ * Get the number of seconds to one day from now
+ * @returns one day from now in seconds in bigint
+ */
+export function getOneDayFromNowInSeconds(): bigint {
+  return BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24);
+}


### PR DESCRIPTION
1. createCommentData had very large incorrect deadline value (was using milliseconds) this PR fixes and use seconds instead
2. because of switch to seconds, the tests need to be updated to make sure new comments created are different to avoid conflict
3. updated anvil port for testing to avoid conflicting with on going anvil instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Release
  - Patch update to the SDK.

- Bug Fixes
  - Fixed incorrect units for default comment deadlines/expiries.

- Refactor
  - Standardized default deadline/expiry calculations via a shared helper for consistent behavior across comments and approvals.

- Tests / Tooling
  - Tests updated to use a configurable local test node port; test helper renamed and local test port changed to 8546.

- Documentation
  - New reference for the shared helper and multiple docs updated to reflect source changes.

- Chores
  - Added changeset entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->